### PR TITLE
docs(LICENSE): add Apache-2.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-pache License
+Apache License
 ==============
 
 _Version 2.0, January 2004_  


### PR DESCRIPTION
**What this PR does**: This PR adds an Apache-2.0 license so this repository can be open-sourced. While this repo is somewhat specific to Outreach, it's required to run any bootstrap tests/etc. For now, let's OSS this and as bootstrap matures we can split things out as needed.