### PR TITLE
feat: plumb LD_DEV_EMAIL env var to support LD variations based on dev email

### DIFF
--- a/shell/deploy-to-dev.sh
+++ b/shell/deploy-to-dev.sh
@@ -60,5 +60,5 @@ kubecfg \
   -V environment="$environment" \
   -V version="$version" \
   -V bento="$bento" \
-  -V ld_dev_email="$LD_DEV_EMAIL" \
+  -V dev_email="${DEV_EMAIL:-$(git config user.email)}" \
   -V host="bento1a.outreach-dev.com"

--- a/shell/deploy-to-dev.sh
+++ b/shell/deploy-to-dev.sh
@@ -60,4 +60,5 @@ kubecfg \
   -V environment="$environment" \
   -V version="$version" \
   -V bento="$bento" \
+  -V ld_dev_email="$LD_DEV_EMAIL" \
   -V host="bento1a.outreach-dev.com"


### PR DESCRIPTION
**What this PR does / why we need it**:   Plumbs LD_DEV_EMAIL
**JIRA ID**: DT-0
**Notes for your reviewer**:

The flagship client supports an env var LD_DEV_EMAIL.  When this is specified, all Launch Darkly requests include this as a custom flag value.  This allows feature flags to be changed for specific dev env hosts.

This PR adds a similar setup (but using DEV_EMAIL and dev_email so that this can be used in more places than just LD).  Also the `DEV_EMAIL` env var is just an override with the default being `git config user.email`

The plan is to make the following changes (all in separate repos sadly) to support this:

1. Update the bootstrapped fflags.yaml jsonnet to use `std.extVar('dev_email')` so that the env var gets picked up by bootstrapped services automatically.
2. Update flagship for similar support (likely by updating the config map + plumbing through the flagship to the runtime_flags library)
~3. Update `orc setup` to modify the default shellrc to setup this env var based on the employee email in okta~

Basically a series of one-line changes to plumb this through everywhere.  Feel free to suggest an alternate solution.
