### PR TITLE
fix: ruby client app name fix

### DIFF
--- a/shell/ruby/build.sh
+++ b/shell/ruby/build.sh
@@ -9,7 +9,7 @@ LIB_DIR="$SCRIPTS_DIR/lib"
 # shellcheck source=../lib/bootstrap.sh
 source "$LIB_DIR/bootstrap.sh"
 
-appName="bootstraptestservice"
+appName="$(get_app_name)"
 rubyVersion="2.6"
 subDir="api/clients/ruby"
 versionFile="$(get_repo_directory)/$subDir/lib/${appName}_client/version.rb"

--- a/shell/ruby/publish.sh
+++ b/shell/ruby/publish.sh
@@ -9,7 +9,7 @@ LIB_DIR="$SCRIPTS_DIR/lib"
 # shellcheck source=../lib/bootstrap.sh
 source "$LIB_DIR/bootstrap.sh"
 
-appName="bootstraptestservice"
+appName="$(get_app_name)"
 
 newVersion="$1"
 


### PR DESCRIPTION
It was probably copy/paste issue but appName for ruby client was hardcoded. Following same patter as in other sh files.


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: CMS-637

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
