### PR TITLE
fix: return proper resource version

### DIFF
--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -54,7 +54,7 @@ has_resource() {
 get_resource_version() {
   local name="$1"
 
-  if [[ "$(yq -r '.resources' <"$(get_service_yaml)")" == "null" ]]; then
+  if [[ "$(yq -r ".resources[\"$name\"]" <"$(get_service_yaml)")" == "null" ]]; then
     echo ""
   else
     yq -r ".resources[\"$name\"]" <"$(get_service_yaml)"


### PR DESCRIPTION
**What this PR does / why we need it**: 
Resource versions query in bootstrap lib currently returns `null` for non-existent resources which leads test script to setup non-existent containers. This PR adds a fix to the mentioned query.