### PR TITLE
fix: downgrade goreleaser version

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -41,7 +41,7 @@ release:
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
-	@./.bootstrap/shell/gobin.sh github.com/goreleaser/goreleaser@v0.160.0 release --skip-publish --rm-dist
+	@./.bootstrap/shell/gobin.sh github.com/goreleaser/goreleaser@v0.157.0 release --skip-publish --rm-dist
 	@# Delete the tag once we're done.
 	@git tag -d "$(APP_VERSION)" >&2
 


### PR DESCRIPTION
**What this PR does / why we need it**: 
Current [CI pipelines](https://app.circleci.com/pipelines/github/getoutreach/orexservice/472/workflows/b6ce4fc9-d8b4-4578-b874-840e5ae12501/jobs/2164) are failing in `release-dryrun` step when a minor release is triggered.

Turns out `goreleaser` bumped up one of its [dependencies](https://github.com/goreleaser/goreleaser/commit/be93544e5ccb82735da3cc133d75d96801e9b1ea#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R18) in [v0.158.0](https://github.com/goreleaser/goreleaser/releases/tag/v0.158.0). From version [v1.0.0](https://github.com/goreleaser/fileglob/pull/17), such dependency started to use the pkg `io/fs`. This pkg is part of the standard library in Go 1.6.

