### PR TITLE
feat: add debug script from bootstrap

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -123,6 +123,12 @@ devserver: build
 	if [[ -z $$SKIP_DEVCONFIG ]]; then ./.bootstrap/shell/devconfig.sh; fi
 	OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) $(BINDIR)/$(BIN_NAME)
 
+## debug:           run the service via delve
+.PHONY: debug
+debug: build
+	if [[ -z $$SKIP_DEVCONFIG ]]; then ./.bootstrap/shell/devconfig.sh; fi
+	OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) ./.bootstrap/shell/debug.sh
+
 ## docker-build:    build docker image for dev environment
 .PHONY: docker-build
 docker-build:

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=./lib/bootstrap.sh
+source "$SCRIPTS_DIR/lib/bootstrap.sh"
+
+export GOPROXY=https://proxy.golang.org
+export GOPRIVATE="github.com/getoutreach/*"
+export CGO_ENABLED=1
+
+set -ex
+
+exec "$SCRIPTS_DIR/gobin.sh" github.com/go-delve/delve/cmd/dlv@v"$(get_application_version "delve")" debug --build-flags="-tags=or_dev" "$(get_repo_directory)/cmd/$(get_app_name)"

--- a/versions.yaml
+++ b/versions.yaml
@@ -5,3 +5,4 @@ grpcui: 1.0.0
 golangci-lint: 1.36.0
 jsonnetfmt: 0.16.0
 goimports: 0.1.0
+delve: 1.6.0


### PR DESCRIPTION
**What this PR does / why we need it**:  This adds a debug script that was omitted when we moved the repository scripts to this repo. It also adds a helpful `make debug` command which works similarly to `make devserver`.

**JIRA ID**: DT-00

**Notes for your reviewer**: I did a quick smoke test on an example repository to make sure that delve actually ran. (The old, deleted version did not work with the recent gobin script).
