### PR TITLE
fix: update get_vault_secrets to only remove trailing newline

### DIFF
--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -61,7 +61,8 @@ get_vault_secrets() {
 
   mapfile -t subKeys < <(jq -r 'keys[]' <<<"$data")
   for subKey in "${subKeys[@]}"; do
-    jq -cr ".[\"$subKey\"]" <<<"$data" | sed 's/\n//' | tr -d '\n' >"$path/$subKey"
+    jq -cr ".[\"$subKey\"]" <<<"$data" >"$path/$subKey"
+    printf %s "$(<"$path/$subKey")" >"$path/$subKey" # this is a hack to remove trailing new lines
   done
 
   return 0


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
This PR changes the `get_vault_secrets` function in devconfig.sh to only remove trailing newlines

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [DT-316]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:


[DT-316]: https://outreach-io.atlassian.net/browse/DT-316