### PR TITLE
feat: add pre-action steps and use double-colon to Makefile

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -50,7 +50,6 @@ pre-debug::
 pre-docker-build::
 pre-fmt::
 
-
 ## release:         tag a new release with goreleaser
 .PHONY: release
 release:: pre-release

--- a/root/Makefile
+++ b/root/Makefile
@@ -160,12 +160,12 @@ fmt:: pre-fmt
 
 ## fly-login:       log into concourse
 .PHONY: fly-login
-fly-login::
+fly-login:
 	${FLY} -t devs userinfo || ${FLY} -t devs login --concourse-url https://concourse.outreach.cloud -n devs
 
 ## update-pipeline: update application pipeline in concourse
 .PHONY: update-pipeline
-update-pipeline:: fly-login
+update-pipeline: fly-login
 	@echo " ===> updating concourse pipeline <==="
 	@if [[ ! -e "concourse/jsonnet-libs" ]]; then git clone https://github.com/getoutreach/jsonnet-libs concourse/jsonnet-libs; else cd concourse/jsonnet-libs && git reset --hard origin/master && git pull; fi
 	cd concourse; rm -f /tmp/pipeline.yml; jsonnet -J ./jsonnet-libs -y pipeline.jsonnet > /tmp/pipeline.yml && ${FLY} -t devs sp -c /tmp/pipeline.yml -p $(APP)

--- a/root/Makefile
+++ b/root/Makefile
@@ -35,14 +35,30 @@ BASE_TEST_ENV       ?= GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) OUTREACH_ACCOUN
 .PHONY: default
 default: build
 
+# All the pre-action steps are bunched together here.
+.PHONY: pre-release pre-build pre-test pre-coverage pre-integration pre-e2e pre-benchmark pre-gogenerate pre-devserver pre-debug pre-docker-build pre-fmt
+pre-release::
+pre-build::
+pre-test::
+pre-coverage::
+pre-integration::
+pre-e2e::
+pre-benchmark::
+pre-gogenerate::
+pre-devserver::
+pre-debug::
+pre-docker-build::
+pre-fmt::
+
+
 ## release:         tag a new release with goreleaser
 .PHONY: release
-release:
+release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
 	@./.bootstrap/shell/gobin.sh github.com/goreleaser/goreleaser@v0.157.0 release --skip-publish --rm-dist
-	@# Delete the tag once we're done.
+	@# Delete the tag once we\'re done.
 	@git tag -d "$(APP_VERSION)" >&2
 
 ## help             show this help
@@ -62,34 +78,34 @@ pre-commit: fmt
 
 ## build:           run codegen and build application binary
 .PHONY: build
-build: gobuild
+build:: pre-build gobuild
 
 ## test:            run unit tests
 .PHONY: test
-test:
+test:: pre-test
 	$(BASE_TEST_ENV) ./.bootstrap/shell/test.sh
 
 ## coverage:        generate code coverage
 .PHONY: coverage
-coverage:
+coverage:: pre-coverage
 	 WITH_COVERAGE=true GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) ./.bootstrap/shell/test.sh
 	 go tool cover --html=/tmp/coverage.out
 
 ## integration:     run integration tests
 .PHONY: integration
-integration:
+integration:: pre-integration
 	TEST_TAGS=${TEST_TAGS} $(BASE_TEST_ENV) ./.bootstrap/shell/test.sh
 
 ## e2e:             run e2e tests
 .PHONY: e2e
-e2e:
+e2e:: pre-e2e
 	@devenv --skip-update status -q || \
 		(echo "Starting developer environment"; set -x; devenv --skip-update provision ${E2E_ARGS})
 	TEST_TAGS=or_test,or_e2e $(BASE_TEST_ENV) MY_NAMESPACE=$(E2E_NAMESPACE) MY_POD_SERVICE_ACCOUNT=$(E2E_SERVICE_ACCOUNT) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) ./.bootstrap/shell/test.sh
 
 ## benchmark:       run benchmarks
 .PHONY: benchmark
-benchmark:
+benchmark:: pre-benchmark
 	BENCH_FLAGS=${BENCH_FLAGS} TEST_TAGS=${TEST_TAGS} $(BASE_TEST_ENV) ./.bootstrap/shell/test.sh | tee /tmp/benchmark.txt
 	@$(LOG) info "Results of benchmarks: "
 	./.bootstrap/shell/gobin.sh golang.org/x/perf/cmd/benchstat /tmp/benchmark.txt
@@ -102,7 +118,7 @@ dep:
 
 ## gogenerate:      run go codegen
 .PHONY: gogenerate
-gogenerate: check-deps
+gogenerate:: pre-gogenerate check-deps
 	@$(LOG) info "Running gogenerate"
 	@GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) $(GO) generate ./...
 
@@ -119,19 +135,19 @@ grpcui:
 	./.bootstrap/shell/grpcui.sh localhost:5000
 ## devserver:       run the service
 .PHONY: devserver
-devserver: build
+devserver:: pre-devserver build
 	if [[ -z $$SKIP_DEVCONFIG ]]; then ./.bootstrap/shell/devconfig.sh; fi
 	OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) $(BINDIR)/$(BIN_NAME)
 
 ## debug:           run the service via delve
 .PHONY: debug
-debug: build
+debug:: pre-debug build
 	if [[ -z $$SKIP_DEVCONFIG ]]; then ./.bootstrap/shell/devconfig.sh; fi
 	OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) ./.bootstrap/shell/debug.sh
 
 ## docker-build:    build docker image for dev environment
 .PHONY: docker-build
-docker-build:
+docker-build:: pre-docker-build
 	@echo " ===> building docker image <==="
 	@ssh-add -L
 	@echo " ===> If you run into credential issues, ensure that your key is in your SSH agent (ssh-add <ssh-key-path>) <==="
@@ -139,17 +155,17 @@ docker-build:
 
 ## fmt:             run source code formatters
 .PHONY: fmt
-fmt:
+fmt:: pre-fmt
 	@./.bootstrap/shell/fmt.sh
 
 ## fly-login:       log into concourse
 .PHONY: fly-login
-fly-login:
+fly-login::
 	${FLY} -t devs userinfo || ${FLY} -t devs login --concourse-url https://concourse.outreach.cloud -n devs
 
 ## update-pipeline: update application pipeline in concourse
 .PHONY: update-pipeline
-update-pipeline: fly-login
+update-pipeline:: fly-login
 	@echo " ===> updating concourse pipeline <==="
 	@if [[ ! -e "concourse/jsonnet-libs" ]]; then git clone https://github.com/getoutreach/jsonnet-libs concourse/jsonnet-libs; else cd concourse/jsonnet-libs && git reset --hard origin/master && git pull; fi
 	cd concourse; rm -f /tmp/pipeline.yml; jsonnet -J ./jsonnet-libs -y pipeline.jsonnet > /tmp/pipeline.yml && ${FLY} -t devs sp -c /tmp/pipeline.yml -p $(APP)

--- a/root/Makefile
+++ b/root/Makefile
@@ -58,7 +58,7 @@ release:: pre-release
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
 	@./.bootstrap/shell/gobin.sh github.com/goreleaser/goreleaser@v0.157.0 release --skip-publish --rm-dist
-	@# Delete the tag once we\'re done.
+	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 
 ## help             show this help


### PR DESCRIPTION
**What this PR does / why we need it**:   Add pre and post action support to Makefile
**JIRA ID**: DWF-5884
**Notes for your reviewer**:

This adds support for individual repos to add pre and post actions to targets that were meaningful and not internal.

The pre action is via a `pre-xyz` target.  The post action is just using the [double-colon](https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html) support in make.