### PR TITLE
fix(prismaci): copy image scanner from prismaci repo into devbase and reenable it

### DIFF
--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -28,13 +28,14 @@ args=("--ssh" "default" "--progress=plain" "--file" "deployments/${appName}/Dock
 
 # Build a quick native image on PRs and load it into docker cache
 # for security scanning
-if [[ -z $CIRCLE_TAG ]]; then
+# TODO: before final merge: uncomment if/fi
+#if [[ -z $CIRCLE_TAG ]]; then
   info "Building Docker Image (test)"
   docker buildx build "${args[@]}" -t "${appName}" --load .
 
   info "🔐 Scanning docker image for vulnerabilities"
   source "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}"
-fi
+#fi
 
 if [[ -n ${CIRCLE_TAG} ]]; then
   echo "🔨 Building and Pushing Docker Image (production)"

--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -36,7 +36,7 @@ if [[ -z $CIRCLE_TAG ]]; then
   source "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}"
 fi
 
-if [[ -n ${CIRCLE_TAG} ]]; then
+if [[ -n $CIRCLE_TAG ]]; then
   echo "🔨 Building and Pushing Docker Image (production)"
   set -x
   docker buildx build "${args[@]}" --platform linux/arm64,linux/amd64 \

--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -44,6 +44,6 @@ set +x
 # TODO: Re-enable this when buildx supports exporting multiple-manifest docker images
 #if [[ -z $CIRCLE_TAG ]]; then
 #  # Scan the built image
-#  info "Scanning docker image for vulnerabilities"
-#  /usr/local/bin/twist-scan.sh "$appName"
+  info "Scanning docker image for vulnerabilities"
+  /usr/local/bin/twist-scan.sh "$appName"
 #fi

--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -28,14 +28,13 @@ args=("--ssh" "default" "--progress=plain" "--file" "deployments/${appName}/Dock
 
 # Build a quick native image on PRs and load it into docker cache
 # for security scanning
-# TODO: before final merge: uncomment if/fi
-#if [[ -z $CIRCLE_TAG ]]; then
+if [[ -z $CIRCLE_TAG ]]; then
   info "Building Docker Image (test)"
   docker buildx build "${args[@]}" -t "${appName}" --load .
 
   info "🔐 Scanning docker image for vulnerabilities"
   source "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}"
-#fi
+fi
 
 if [[ -n ${CIRCLE_TAG} ]]; then
   echo "🔨 Building and Pushing Docker Image (production)"

--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -24,27 +24,23 @@ source "${LIB_DIR}/buildx.sh"
 # shellcheck source=./lib/ssh-auth.sh
 source "${LIB_DIR}/ssh-auth.sh"
 
-extraArgs=("-t" "$remote_image_name:${VERSION}")
-if [[ -n ${CIRCLE_TAG} ]]; then
-  # Only push on a tag
-  extraArgs+=("--push")
-else
-  echo "Note: Skipping twist-scan due to buildx limitations"
-  # TODO: buildx doesn't currently support this.
-  # Load it into the docker cache so we can run twist-scan
-  #extraArgs+=("--load")
-fi
+args=("--ssh" "default" "--progress=plain" "--file" "deployments/${appName}/Dockerfile" "--build-arg" "VERSION=${VERSION}")
 
-echo "🔨 Building Docker Image"
-set -x
-docker buildx build --ssh default --progress=plain \
-  --platform linux/arm64,linux/amd64 \
-  --file "deployments/${appName}/Dockerfile" \
-  --build-arg "VERSION=${VERSION}" "${extraArgs[@]}" .
-set +x
+# Build a quick native image on PRs and load it into docker cache
+# for security scanning
+# TODO: before final merge: uncomment if/fi
+#if [[ -z $CIRCLE_TAG ]]; then
+  info "Building Docker Image (test)"
+  docker buildx build "${args[@]}" -t "${appName}" --load .
 
-if [[ -z ${CIRCLE_TAG} ]]; then
-  # Scan the built image
-  info "Scanning docker image for vulnerabilities"
+  info "🔐 Scanning docker image for vulnerabilities"
   source "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}"
+#fi
+
+if [[ -n ${CIRCLE_TAG} ]]; then
+  echo "🔨 Building and Pushing Docker Image (production)"
+  set -x
+  docker buildx build "${args[@]}" --platform linux/arm64,linux/amd64 \
+    -t "${remote_image_name}:${VERSION}" --push .
+  set +x
 fi

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -53,7 +53,7 @@ if [[ -z $DOCKER_HOST ]]; then
     # trying the default unix one
     TWISTCLI_DOCKER_HOST=/var/run/docker.sock
 else
-    TWISTCLI_DOCKER_HOST=$(echo "${DOCKER_HOST}" | sed -e 's/tcp/https/')
+    TWISTCLI_DOCKER_HOST=$(sed -e 's/tcp/https/' <<< "${DOCKER_HOST}")
 fi
 
 ${PC_CLOUD_TWISTCLI} images scan --token "${PC_CLOUD_TOKEN}" \

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -49,17 +49,12 @@ curl -L --header "authorization: Bearer ${PC_CLOUD_TOKEN}" \
 chmod a+x ${PC_CLOUD_TWISTCLI}
 
 
-if [[ -z $DOCKER_HOST ]]; then
-    # trying the default unix one
-    TWISTCLI_DOCKER_HOST=/var/run/docker.sock
-else
-    TWISTCLI_DOCKER_HOST=$(sed -e 's/tcp/https/' <<< "${DOCKER_HOST}")
-fi
-
+# Note: we are relying on a default docker host address (which is, per twistcli doc: unix:///var/run/docker.sock)
+# since we are running this script on a bare VM. If this ever changes, pls set --docker-address explicitly.
+# Note: https version of the address will require TLS cert - see twistcli doc for details.
 ${PC_CLOUD_TWISTCLI} images scan --token "${PC_CLOUD_TOKEN}" \
   --ci --details --address "${PC_CONSOLE_URL}" \
   --custom-labels \
-  --docker-address "${TWISTCLI_DOCKER_HOST}" \
   --output-file "${TEST_RESULTS}/image_scan.json" \
   "$@"
   

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -10,12 +10,12 @@ if [ -z "${CIRCLECI}" ]; then
   echo "I can only run in CircleCI"
   exit 1
 fi
-if ! [ -x "$(which curl)" ]; then 
-  echo "We need an executable called curl in the $PATH in order to execute"
+if ! command -v curl >/dev/null 2>&1; then 
+  echo "We need an executable called curl in the \$PATH in order to execute"
   exit 1
 fi
-if ! [ -x "$(which jq)" ]; then 
-  echo "We need an executable called curl in the $PATH in order to execute"
+if ! command -v jq >/dev/null 2>&1; then 
+  echo "We need an executable called curl in the \$PATH in order to execute"
   exit 1
 fi
 if [ -z "${PC_CONSOLE_URL}" ]; then

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -30,10 +30,7 @@ if [ -z "${PC_SECRET_KEY}" ]; then
   echo "Need an environment variable called PC_SECRET_KEY"
   exit 1
 fi
-if [ -z "${DOCKER_CERT_PATH}" ]; then
-  echo "Need a docker certificate path called DOCKER_CERT_PATH, see usage below"
-  exit 1
-fi
+
 ## /Add some safeties for external dependencies when running
 
 PC_CLOUD_TOKEN_JSON=/tmp/token.json
@@ -63,9 +60,6 @@ ${PC_CLOUD_TWISTCLI} images scan --token "${PC_CLOUD_TOKEN}" \
   --ci --details --address "${PC_CONSOLE_URL}" \
   --custom-labels \
   --docker-address "${TWISTCLI_DOCKER_HOST}" \
-  --docker-tlscert "${DOCKER_CERT_PATH}/cert.pem" \
-  --docker-tlscacert "${DOCKER_CERT_PATH}/ca.pem" \
-  --docker-tlskey "${DOCKER_CERT_PATH}/key.pem" \
   --output-file "${TEST_RESULTS}/image_scan.json" \
   "$@"
   

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -18,15 +18,15 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "We need an executable called curl in the \$PATH in order to execute"
   exit 1
 fi
-if [ -z "${PC_CONSOLE_URL}" ]; then
+if [[ -z $PC_CONSOLE_URL ]]; then
   echo "Need an environment variable called PC_CONSOLE_URL"
   exit 1
 fi
-if [ -z "${PC_ACCESS_KEY}" ]; then
+if [[ -z $PC_ACCESS_KEY ]]; then
   echo "Need an environment variable called PC_ACCESS_KEY"
   exit 1
 fi
-if [ -z "${PC_SECRET_KEY}" ]; then
+if [[ -z $PC_SECRET_KEY ]]; then
   echo "Need an environment variable called PC_SECRET_KEY"
   exit 1
 fi

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script scans docker images for vulnerabilities, generates local
 # report and also uploads the report to Prisma Cloud. The script expects

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -49,7 +49,7 @@ curl -L --header "authorization: Bearer ${PC_CLOUD_TOKEN}" \
 chmod a+x ${PC_CLOUD_TWISTCLI}
 
 
-if [ -z "${DOCKER_HOST}" ]; then
+if [[ -z $DOCKER_HOST ]]; then
     # trying the default unix one
     TWISTCLI_DOCKER_HOST=/var/run/docker.sock
 else

--- a/shell/security/prismaci/twist-scan.sh
+++ b/shell/security/prismaci/twist-scan.sh
@@ -6,7 +6,7 @@
 #
 
 ## Add some safeties for external dependencies when running
-if [ -z "${CIRCLECI}" ]; then
+if [[ -z $CIRCLECI ]]; then
   echo "I can only run in CircleCI"
   exit 1
 fi


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
This PR is the first to support [DT-509]: re-enable image scan in bootstrap and move twist-scan shell from prismaci repo into devbase to run in machine-mode on a bare VM itself. The original script was slightly modified to support twistcli download shortly before running the scan (and I removed the curl -k flag that could cause security issues - it should not be needed).

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [DT-509]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
This PR has been tested by faking bootstrap: devenv to point to private branch + temporary removing CIRCLE_TAG block to enable scan on all runs (and not just release/tags).

[DT-509]: https://outreach-io.atlassian.net/browse/DT-509
[DT-509]: https://outreach-io.atlassian.net/browse/DT-509