### PR TITLE
fix: use AMD64 version of shellcheck on M1

### DIFF
--- a/shell/shellcheck.sh
+++ b/shell/shellcheck.sh
@@ -14,6 +14,13 @@ BIN_DIR="$(get_repo_directory)/bin"
 SHELLCHECK_VERSION="$(get_application_version "shellcheck")"
 GOOS=$(go env GOOS)
 ARCH=$(uname -m)
+
+# No builds for M1 macs at the moment, so just download
+# the amd64 build.
+if [[ $GOOS == "darwin" ]] && [[ $ARCH == "arm64" ]]; then
+  ARCH="x86_64"
+fi
+
 binPath="$BIN_DIR/shellcheck-$SHELLCHECK_VERSION"
 
 # Ensure $BIN_DIR exists, since GOBIN makes it, but


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: There are no arm64 builds of shellcheck at the moment, so we need to use the amd64 version on darwin/arm64. 

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: DT-0

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
