### PR TITLE
feat: add NPM_TOKEN as a docker build secret

### DIFF
--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -24,13 +24,14 @@ source "${LIB_DIR}/buildx.sh"
 # shellcheck source=./lib/ssh-auth.sh
 source "${LIB_DIR}/ssh-auth.sh"
 
+secrets=("--secret" "id=npmtoken,env=NPM_TOKEN")
 args=("--ssh" "default" "--progress=plain" "--file" "deployments/${appName}/Dockerfile" "--build-arg" "VERSION=${VERSION}")
 
 # Build a quick native image on PRs and load it into docker cache
 # for security scanning
 if [[ -z $CIRCLE_TAG ]]; then
   info "Building Docker Image (test)"
-  docker buildx build "${args[@]}" -t "${appName}" --load .
+  docker buildx build "${args[@]}" "${secrets[@]}" -t "${appName}" --load .
 
   info "🔐 Scanning docker image for vulnerabilities"
   source "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}"

--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -40,7 +40,7 @@ fi
 if [[ -n $CIRCLE_TAG ]]; then
   echo "🔨 Building and Pushing Docker Image (production)"
   set -x
-  docker buildx build "${args[@]}" --platform linux/arm64,linux/amd64 \
+  docker buildx build "${args[@]}" "${secrets[@]}" --platform linux/arm64,linux/amd64 \
     -t "${remote_image_name}:${VERSION}" -t "$remote_image_name:latest" --push .
   set +x
 fi


### PR DESCRIPTION

**What this PR does / why we need it**: 
Add the NPM_TOKEN environment variable as a Docker build secret. This
value is available in CircleCI when the `npm-credentials` context is
applied to the build step. It is also available in the development
environment.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: VXP-2691

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
See related PR to add the npm-credentials context in the CircleCI config: https://github.com/getoutreach/bootstrap/pull/613
