### PR TITLE
feat(fmt): run eslint --fix on the Node.js API client

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -48,11 +48,15 @@ if has_feature "grpc"; then
   if has_grpc_client "node"; then
     CLIENTS_DIR="$(pwd)/api/clients"
 
-    info_sub "Prettier (Node.js)"
-
     nodeSourceDir="$CLIENTS_DIR/node"
 
     run_node_command "$nodeSourceDir" yarn install
+
+    info_sub "ESLint (Node.js)"
+
+    run_node_command "$nodeSourceDir" yarn lint-fix
+
+    info_sub "Prettier (Node.js)"
 
     # When files are modified this returns 1.
     run_node_command "$nodeSourceDir" yarn pretty-fix


### PR DESCRIPTION
**What this PR does / why we need it**: This fixes a formatting bug where `eslint` may have formatting changes (such as import order) but `make fmt` doesn't apply them, which means that rebootstrapping reverts the changes.

See, for example, https://github.com/getoutreach/authz/pull/465

**JIRA ID**: DTSS-00

**Notes for your reviewer**:
