### PR TITLE
fix: don't fail entire docker image build on scan fail

### DIFF
--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -33,7 +33,7 @@ if [[ -z $CIRCLE_TAG ]]; then
   docker buildx build "${args[@]}" -t "${appName}" --load .
 
   info "🔐 Scanning docker image for vulnerabilities"
-  source "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}"
+  "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}" || echo "Warning: Failed to scan image"
 fi
 
 if [[ -n $CIRCLE_TAG ]]; then


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR makes twist scan fails a non-blocking event.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [DT-0]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**: [**Internal Context**](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1628006855068600)
