### PR TITLE
fix: enable any host to connect to the local mysql container

### DIFF
--- a/shell/test.sh
+++ b/shell/test.sh
@@ -69,7 +69,7 @@ if [[ -z $CI && $TEST_TAGS == *"or_int"* ]]; then
 
   if has_resource "mysql"; then
     info_sub "creating mysql container"
-    mysqlID=$(docker run -itd --rm -p 3306:3306 -e "MYSQL_DATABASE=$(get_app_name)" -e MYSQL_ROOT_PASSWORD=root "gcr.io/outreach-docker/mysql:$(get_resource_version "mysql")")
+    mysqlID=$(docker run -itd --rm -p 3306:3306 -e "MYSQL_DATABASE=$(get_app_name)" -e "MYSQL_ROOT_HOST=%" -e MYSQL_ROOT_PASSWORD=root "gcr.io/outreach-docker/mysql:$(get_resource_version "mysql")")
     cleanup="$cleanup; docker stop $mysqlID"
     # shellcheck disable=SC2064
     trap "$cleanup" EXIT INT TERM


### PR DESCRIPTION
**What this PR does / why we need it**: it is not possible to connect to the mysql server over cli when the mysql container is started. The change enables it. 

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: CMS-704

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
