### PR TITLE
fix: update buildx

### DIFF
--- a/shell/lib/buildx.sh
+++ b/shell/lib/buildx.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64"
+BUILDX_VERSION="v0.6.1"
+BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-amd64"
 
 echo "👉 Installing Buildx"
 curl --output docker-buildx \


### PR DESCRIPTION
**What this PR does / why we need it**: 
Update buildx so that docker build can accept secrets from environment
variables.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: XX-XX

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
