### PR TITLE
fix: remove merging of configuration

### DIFF
--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -88,17 +88,9 @@ DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/deploy-to-dev.sh" show | yq -r
     echo -e "$configData" | sed "s:/run/secrets/outreach.io:$configDir:g" |
       sed "s:/run/volumes/outreach.io:$volumeDir:g" >"$tmpFile"
 
-    # If the file already exists, then merge it with the new one.
-    # NOTE: We probably want to make this smarter and log when merging. I don't think
-    # that is feasible to do in bash, though....
-    if [[ -e $saveFile ]] && [[ ${saveFile##*.} =~ ^(yaml|yml)$ ]]; then
-      info_sub "$configFile (merged)"
-      yq --yaml-output -s '.[0] * .[1]' "$tmpFile" "$saveFile" >"$mergedFile"
-      mv "$mergedFile" "$saveFile"
-    else
-      info_sub "$configFile"
-      mv "$tmpFile" "$saveFile"
-    fi
+    info_sub "$configFile"
+    mv "$tmpFile" "$saveFile"
+
 
     rm "$tmpFile" "$mergedFile" >/dev/null 2>&1 || true
   done


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 

This PR moves the merging of configuration functionality in local development. Instead, users should be modifying the `<appName>.config.jsonnet` file instead, which is more deterministic and compatible with the Tilt world we'll be going to soon. Users should use `make devserver` to ensure their changes are always reflected locally.

[**CONTEXT**](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1628786338329700)

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: XX-XX

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
