### PR TITLE
feat(grpc-js): upgrade our grpc protoc tools to 1.37_2

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -2,7 +2,7 @@
 # This script is a light wrapper around the 'docker-protoc' image (see: https://github.com/namely/docker-protoc),
 # which is capable of compiling proto definitions into various languages.
 # This is not meant to be used in CircleCI (except by bootstrap itself to validate the general process).
-IMAGE="gcr.io/outreach-docker/protoc:latest"
+IMAGE="gcr.io/outreach-docker/protoc:1.37_1"
 uid=$(id -u)
 gid=$(id -g)
 

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -2,7 +2,7 @@
 # This script is a light wrapper around the 'docker-protoc' image (see: https://github.com/namely/docker-protoc),
 # which is capable of compiling proto definitions into various languages.
 # This is not meant to be used in CircleCI (except by bootstrap itself to validate the general process).
-IMAGE="gcr.io/outreach-docker/protoc:1.37_1"
+IMAGE="gcr.io/outreach-docker/protoc:1.37_2"
 uid=$(id -u)
 gid=$(id -g)
 

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -46,7 +46,7 @@ docker exec --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l go 
 
 if has_grpc_client "node"; then
   info_sub "node"
-  docker exec -e "NODE_GRPC_TOOLS_NODE_PROTOC_TS_VERSION=5.3.2" --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l node \
+  docker exec --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l node \
     --with-typescript -o "./clients/node/src/grpc/"
 fi
 

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -46,7 +46,7 @@ docker exec --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l go 
 
 if has_grpc_client "node"; then
   info_sub "node"
-  docker exec --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l node \
+  docker exec -e "NODE_GRPC_TOOLS_NODE_PROTOC_TS_VERSION=5.3.2" --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l node \
     --with-typescript -o "./clients/node/src/grpc/"
 fi
 


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
grpc-node packages have been deprecated since Apr 2021, this PR updates all the js packages to rely on @grpc/grpc-js instead. 
1.37_2 is newer than the 'latest' tag image.
<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: DT-355

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
