### PR TITLE
feat(OLM-952): support importing proto files from schema repo

### DIFF
--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -74,3 +74,13 @@ has_grpc_client() {
 
   return 1
 }
+
+get_list() {
+  local name="$1"
+
+  if [[ "$(yq -r ".\"$name\"" <"$(get_service_yaml)")" == "null" ]]; then
+    echo ""
+  else
+    yq -r ".\"$name\"[]" <"$(get_service_yaml)"
+  fi
+}

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -58,7 +58,6 @@ docker exec "$CONTAINER_ID" sh -c "groupadd -f --gid $gid localuser && useradd -
 info_sub "go"
 docker exec --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l go \
   $(for import in $(get_list "go-protoc-imports"); do echo "-i /mod/$(get_import_basename "$import")"; done) \
-  $(if has_feature "validation"; then echo "--with-validator --validator-source-relative"; fi) \
   --go-source-relative -o ./
 
 if has_grpc_client "node"; then

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -33,6 +33,12 @@ get_import_basename() {
   basename $(go list -f '{{ .Path }}' -m "$1" | sed 's|/v[0-9]||') # sed removes the version off the module path if present
 }
 for import in $(get_list "go-protoc-imports"); do
+  currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
+  requiredver="1.16.0"
+  if [ ! "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then
+    echo "Go version must be greater than ${requiredver} to use 'go-protoc-imports' feature"
+    exit 1
+  fi
   go install "$import"
   # check exit for this instead of the install itself, as the install can
   # return non-zero, but still retrieve the dependency. As long as we can


### PR DESCRIPTION


<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 

These changes allow settings service to move forward with leveraging
settings payloads defined in the `schema` repo directly in the settings
service.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [OLM-952]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

Also of note: This only account for generating the pb code within
the repo itself. It won't generate the imported code, that step needs to
be done manually for the service and it's clients

Generation tested manually with and without imports

Example:
```
go-protoc-imports:
  - "github.com/org/repo@latest"
```

[OLM-952]: https://outreach-io.atlassian.net/browse/OLM-952