### PR TITLE
feat(OLM-952): support validation flag to enable protoc-gen-validate

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -64,6 +64,7 @@ docker exec "$CONTAINER_ID" sh -c "groupadd -f --gid $gid localuser && useradd -
 info_sub "go"
 docker exec --user localuser "$CONTAINER_ID" entrypoint.sh -f './*.proto' -l go \
   $(for import in $(get_list "go-protoc-imports"); do echo "-i /mod/$(get_import_basename "$import")"; done) \
+  $(if has_feature "validation"; then echo "--with-validator --validator-source-relative"; fi) \
   --go-source-relative -o ./
 
 if has_grpc_client "node"; then


### PR DESCRIPTION

<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
Allows generating `<file>.pb.validate.go` files with https://github.com/envoyproxy/protoc-gen-validate, this is useful for the settings service which operates on protobuf definitions. As the service is largely generic on the inside, having a means to define constraints (validation rules) on the messages themselves is tremendously useful in enabling a broad set of validation cases for settings groups.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [OLM-952]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:


[OLM-952]: https://outreach-io.atlassian.net/browse/OLM-952