### PR TITLE
fix(gobin): directly download gobin

### DIFF
--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -38,7 +38,7 @@ if [[ ! -e $GOBIN_PATH ]]; then
   fi
 
   pushd "$tmp_dir" >/dev/null || exit 1
-  tar xvf "$tmp_dir/gobin.tar.gz"
+  tar xf "$tmp_dir/gobin.tar.gz"
   cp gobin "$GOBIN_PATH"
   popd >/dev/null || exit 1
 fi

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -32,6 +32,10 @@ if [[ ! -e $GOBIN_PATH ]]; then
   tmp_dir=$(mktemp -d)
   curl --location --output "$tmp_dir/gobin.tar.gz" --silent \
     "https://github.com/getoutreach/gobin/releases/download/v$GOBIN_VERSION/gobin_${GOBIN_VERSION}_${GOOS}_${GOARCH}.tar.gz"
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Failed to download gobin"
+    exit 1
+  fi
 
   pushd "$tmp_dir" >/dev/null || exit 1
   tar xvf "$tmp_dir/gobin.tar.gz"

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -38,7 +38,10 @@ if [[ ! -e $GOBIN_PATH ]]; then
   fi
 
   pushd "$tmp_dir" >/dev/null || exit 1
-  tar xvf "$tmp_dir/gobin.tar.gz"
+  tar xvf "$tmp_dir/gobin.tar.gz" || (
+    echo "Failed to extract gobin"
+    exit 1
+  )
   cp gobin "$GOBIN_PATH"
   popd >/dev/null || exit 1
 fi

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -3,7 +3,7 @@
 # Run a golang binary using gobin
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-GOBIN_VERSION=1.3.0
+GOBIN_VERSION=1.4.0
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 
@@ -38,10 +38,7 @@ if [[ ! -e $GOBIN_PATH ]]; then
   fi
 
   pushd "$tmp_dir" >/dev/null || exit 1
-  tar xvf "$tmp_dir/gobin.tar.gz" || (
-    echo "Failed to extract gobin"
-    exit 1
-  )
+  tar xvf "$tmp_dir/gobin.tar.gz"
   cp gobin "$GOBIN_PATH"
   popd >/dev/null || exit 1
 fi

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -3,17 +3,18 @@
 # Run a golang binary using gobin
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-GOBINVERSION=v1.3.0
-GOBINBOOTSTRAPVERSION=v0.0.14
-GOBINBOOTSTRAPPATH="$DIR/../../bin/gobin-go-1.15"
+GOBIN_VERSION=1.3.0
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 
-# Allow people who don't have GOPRIVATE set to use this
-export GOPRIVATE='github.com/getoutreach/*'
-
+# shellcheck source=./lib/bootstrap.sh
+source "$SCRIPTS_DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/logging.sh
-source "$DIR/lib/logging.sh"
+source "$SCRIPTS_DIR/lib/logging.sh"
+
+BIN_DIR="$(get_repo_directory)/bin"
+GOBIN_PATH="$BIN_DIR/gobin-$GOBIN_VERSION"
+mkdir -p "$(dirname "$GOBIN_PATH")"
 
 PRINT_PATH=false
 if [[ $1 == "-p" ]]; then
@@ -26,41 +27,19 @@ if [[ -z $1 ]] || [[ $1 =~ ^(--help|-h) ]]; then
   exit 1
 fi
 
-# TODO: When we move to go 1.16, remove this and replace with `go install`
-if [[ ! -e $GOBINBOOTSTRAPPATH ]]; then
-  {
-    mkdir -p "$(dirname "$GOBINBOOTSTRAPPATH")"
-    curl --location --output "$GOBINBOOTSTRAPPATH" --silent "https://github.com/getoutreach/gobin-fork/releases/download/$GOBINBOOTSTRAPVERSION/$GOOS-$GOARCH"
-    chmod +x "$GOBINBOOTSTRAPPATH"
-  } >&2
+# Clone the latest version of gobin
+if [[ ! -e $GOBIN_PATH ]]; then
+  tmp_dir=$(mktemp -d)
+  curl --location --output "$tmp_dir/gobin.tar.gz" --silent \
+    "https://github.com/getoutreach/gobin/releases/download/v$GOBIN_VERSION/gobin_${GOBIN_VERSION}_${GOOS}_${GOARCH}.tar.gz"
+
+  pushd "$tmp_dir" >/dev/null || exit 1
+  tar xvf "$tmp_dir/gobin.tar.gz"
+  cp gobin "$GOBIN_PATH"
+  popd >/dev/null || exit 1
 fi
 
-if [[ $1 == "download-only" ]]; then
-  exit 0
-fi
-
-# Fetch outreach's gobin using the OSS gobin until we can use go install
-# gobin picks up the Go binary from the path and runs it from within
-# the temp directory while building things.  This has the unfortunate
-# side effect that the version of Go used depends on what was used
-# with `asdf global golang <ver>` command.  To make this
-# deterministic, we create a temp directory and fill it in with the
-# current .tool-versions file and then convince gobin to use it.
-# shellcheck disable=SC2155
-gobin_tmpdir="$(mktemp -d -t gobin-XXXXXXXX)"
-trap 'rm -rf "$gobin_tmpdir"' EXIT INT TERM
-cp "$DIR/../../.tool-versions" "$gobin_tmpdir/.tool-versions"
-
-# Change into the temporary directory
-pushd "$gobin_tmpdir" >/dev/null || exit 1
-GOBINPATH=$(/usr/bin/env bash -c "export TMPDIR='$gobin_tmpdir'; unset GOFLAGS; '$GOBINBOOTSTRAPPATH' -p 'github.com/getoutreach/gobin/cmd/gobin@$GOBINVERSION'")
-popd >/dev/null || exit 1
-if [[ -z $GOBINPATH ]]; then
-  echo "Error: Failed to bootstrap gobin" >&2
-  exit 1
-fi
-
-BIN_PATH=$("$GOBINPATH" --skip-update -p "$1")
+BIN_PATH=$("$GOBIN_PATH" --skip-update -p "$1")
 if [[ -z $BIN_PATH ]]; then
   echo "Error: Failed to run $1" >&2
   exit 1

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -8,9 +8,9 @@ GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 
 # shellcheck source=./lib/bootstrap.sh
-source "$SCRIPTS_DIR/lib/bootstrap.sh"
+source "$DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/logging.sh
-source "$SCRIPTS_DIR/lib/logging.sh"
+source "$DIR/lib/logging.sh"
 
 BIN_DIR="$(get_repo_directory)/bin"
 GOBIN_PATH="$BIN_DIR/gobin-$GOBIN_VERSION"


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR does what the title says. Instead of using, the now archived, older gobin to bootstrap this one, we now directly download it. Using the older gobin resulted in 3-4s latency being added on print binary path calls for no apparent reason. Calling gobin directly is faster and removes that component. 

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: DTSS-0

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
