### PR TITLE
fix(opslevel): Always scan images to ensure opslevel report is sent on releases

### DIFF
--- a/shell/docker-builder.sh
+++ b/shell/docker-builder.sh
@@ -27,15 +27,13 @@ source "${LIB_DIR}/ssh-auth.sh"
 secrets=("--secret" "id=npmtoken,env=NPM_TOKEN")
 args=("--ssh" "default" "--progress=plain" "--file" "deployments/${appName}/Dockerfile" "--build-arg" "VERSION=${VERSION}")
 
-# Build a quick native image on PRs and load it into docker cache
-# for security scanning
-if [[ -z $CIRCLE_TAG ]]; then
-  info "Building Docker Image (test)"
-  docker buildx build "${args[@]}" "${secrets[@]}" -t "${appName}" --load .
+# Build a quick native image and load it into docker cache for security scanning
+# Scan reports for release images are also uploaded to OpsLevel (test image reports only available on PR runs as artifacts).
+info "Building Docker Image (for scanning)"
+docker buildx build "${args[@]}" "${secrets[@]}" -t "${appName}" --load .
 
-  info "🔐 Scanning docker image for vulnerabilities"
-  "${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}" || echo "Warning: Failed to scan image"
-fi
+info "🔐 Scanning docker image for vulnerabilities"
+"${TWIST_SCAN_DIR}/twist-scan.sh" "${appName}" || echo "Warning: Failed to scan image"
 
 if [[ -n $CIRCLE_TAG ]]; then
   echo "🔨 Building and Pushing Docker Image (production)"


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: we need OpsLevel report on released images, yet we only scanned and produced them for PRs.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [DTSS-509]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:


[DTSS-509]: https://outreach-io.atlassian.net/browse/DTSS-509