### PR TITLE
feat(validate): add validator for GitHub CODEOWNERS file

### DIFF
--- a/shell/codeowners-validator.sh
+++ b/shell/codeowners-validator.sh
@@ -12,17 +12,17 @@ source "$DIR/lib/bootstrap.sh"
 
 CODEOWNERS_CHECKS="syntax,files,duppatterns,owners"
 if [[ -n $OUTREACH_GITHUB_TOKEN ]]; then
-  GH_TOKEN="$OUTREACH_GITHUB_TOKEN"
+	GH_TOKEN="$OUTREACH_GITHUB_TOKEN"
 elif [[ -f "$HOME/.outreach/github.token" ]]; then
-  GH_TOKEN="$(cat "$HOME/.outreach/github.token")"
+	GH_TOKEN="$(cat "$HOME/.outreach/github.token")"
 else
-  warn "No GitHub token found, skipping owner checks"
-  CODEOWNERS_CHECKS="syntax,files,duppatterns"
+	warn "No GitHub token found, skipping owner checks"
+	CODEOWNERS_CHECKS="syntax,files,duppatterns"
 fi
 
 # TODO: use org value instead of hardcoding
 OWNER_CHECKER_REPOSITORY="getoutreach/$(get_app_name)" \
-  REPOSITORY_PATH="$(get_repo_directory)" \
-  CHECKS="$CODEOWNERS_CHECKS" \
-  GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
-  exec "$GOBIN" "github.com/mszostok/codeowners-validator@v$(get_application_version "codeowners-validator")"
+REPOSITORY_PATH="$(get_repo_directory)" \
+CHECKS="$CODEOWNERS_CHECKS" \
+GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
+	exec "$GOBIN" "github.com/mszostok/codeowners-validator@v$(get_application_version "codeowners-validator")"

--- a/shell/codeowners-validator.sh
+++ b/shell/codeowners-validator.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# This is a wrapper around gobin.sh to run codeowners-validator, as it uses
+# environment variables for arguments.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+GOBIN="$DIR/gobin.sh"
+
+# shellcheck source=./lib/logging.sh
+source "$DIR/lib/logging.sh"
+# shellcheck source=./lib/bootstrap.sh
+source "$DIR/lib/bootstrap.sh"
+
+CODEOWNERS_CHECKS="syntax,files,duppatterns,owners"
+if [[ -n $OUTREACH_GITHUB_TOKEN ]]; then
+  GH_TOKEN="$OUTREACH_GITHUB_TOKEN"
+elif [[ -f "$HOME/.outreach/github.token" ]]; then
+  GH_TOKEN="$(cat "$HOME/.outreach/github.token")"
+else
+  warn "No GitHub token found, skipping owner checks"
+  CODEOWNERS_CHECKS="syntax,files,duppatterns"
+fi
+
+# TODO: use org value instead of hardcoding
+OWNER_CHECKER_REPOSITORY="getoutreach/$(get_app_name)" \
+  REPOSITORY_PATH="$(get_repo_directory)" \
+  CHECKS="$CODEOWNERS_CHECKS" \
+  GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
+  exec "$GOBIN" "github.com/mszostok/codeowners-validator@v$(get_application_version "codeowners-validator")"

--- a/shell/validate.sh
+++ b/shell/validate.sh
@@ -35,6 +35,11 @@ if ! git ls-files '*.sh' | xargs -n40 "$SHELLFMTPATH" -s -d; then
   exit 1
 fi
 
+info_sub "codeowners-validator"
+if ! "$DIR"/codeowners-validator.sh; then
+  fatal "GitHub CODEOWNERS file failed to validate"
+fi
+
 # Validators to run when not using a library
 if ! has_feature "library"; then
   info_sub "terraform"

--- a/versions.yaml
+++ b/versions.yaml
@@ -8,3 +8,4 @@ goimports: 0.1.0
 delve: 1.6.0
 gotestsum: 1.7.0
 lintroller: 1.7.0
+codeowners-validator: 0.6.0


### PR DESCRIPTION
**What this PR does / why we need it**: 

This is largely an RFC. For context, there was a minor incident where a CODEOWNERS file was accidentally modified and committed to the default branch with invalid syntax, so none of the code owners were properly notified when PRs were created. As a result, I've added [codeowners-validator](https://github.com/mszostok/codeowners-validator) to the list of linters.

**JIRA ID**: DTSS-00

**Notes for your reviewer**:

I've added rudimentary support for GitHub token checking. Also, there are some hardcoded org name assumptions which need to be addressed, for which I could use some guidance.
