### PR TITLE
fix: update goreleaser to support go 1.17 darwin/arm64

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -67,7 +67,7 @@ release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
-	@./.bootstrap/shell/gobin.sh github.com/goreleaser/goreleaser@v0.157.0 release --skip-publish --rm-dist
+	@./.bootstrap/shell/gobin.sh github.com/goreleaser/goreleaser@v0.180.3 release --skip-publish --rm-dist
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: Looks like older versions skip Go 1.17 in their < 1.16 check, so we upgrade to fix that and restore support for Go 1.17 darwin/arm64 builds.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: DTSS-0

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
