### PR TITLE
feat: [DP-2355] Add clerkgen.sh

### DIFF
--- a/shell/clerkgenproto.sh
+++ b/shell/clerkgenproto.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# This is a wrapper around gobin.sh to run clerkgenproto(https://github.com/getoutreach/clerkgen/tree/main/cmd/clerkgenproto)
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+GOBIN="$DIR/gobin.sh"
+
+# shellcheck source=./lib/logging.sh
+source "$DIR/lib/logging.sh"
+# shellcheck source=./lib/bootstrap.sh
+source "$DIR/lib/bootstrap.sh"
+
+# Get GH_TOKEN
+if [[ -n $OUTREACH_GITHUB_TOKEN ]]; then
+	GH_TOKEN="$OUTREACH_GITHUB_TOKEN"
+elif [[ -f "$HOME/.outreach/github.token" ]]; then
+	GH_TOKEN="$(cat "$HOME/.outreach/github.token")"
+else
+	echo "" >/dev/stderr
+    echo "Unable to find Github personal access token. This is required by clerkgen" >/dev/stderr
+    exit 1
+fi
+
+# Verify GH_TOKEN
+resp=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token $GH_TOKEN" https://api.github.com/orgs/getoutreach/repos)
+if [[ $resp -ne 200 ]]; then
+    echo "Unable to run clerkgen. Github personal access is not valid." >/dev/stderr
+	exit 1
+fi
+
+# Verify docker is running
+docker info > /dev/null 2>/dev/stderr
+exit_code=$(echo $?)
+if [[ $exit_code != "0" ]]; then
+    echo "Unable to run clerkgen. Docker is not running. Please start docker." >/dev/stderr
+    exit "$exit_code"
+fi
+
+#Verify AWS creds
+aws sts get-caller-identity > /dev/null 2>/dev/stderr
+exit_code=$(echo $?)
+if [[ $exit_code != "0" ]]; then
+    echo "Unable to run clerkgen. AWS credentials are not valid. Please run 'saml2aws login'." >/dev/stderr
+    exit "$exit_code"
+fi
+
+# Run clerkgen
+"$GOBIN" "github.com/getoutreach/clerkgen/cmd/clerkgenproto@v$(get_application_version "clerkgenproto")" "$@"

--- a/shell/clerkgenproto.sh
+++ b/shell/clerkgenproto.sh
@@ -15,7 +15,7 @@ if [[ -n $OUTREACH_GITHUB_TOKEN ]]; then
 elif [[ -f "$HOME/.outreach/github.token" ]]; then
 	GH_TOKEN="$(cat "$HOME/.outreach/github.token")"
 else
-	echo "" >/dev/stderr
+    echo "" >/dev/stderr
     echo "Unable to find Github personal access token. This is required by clerkgen" >/dev/stderr
     exit 1
 fi
@@ -23,14 +23,16 @@ fi
 # Verify GH_TOKEN
 resp=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token $GH_TOKEN" https://api.github.com/orgs/getoutreach/repos)
 if [[ $resp -ne 200 ]]; then
+    echo "" >/dev/stderr
     echo "Unable to run clerkgen. Github personal access is not valid." >/dev/stderr
-	exit 1
+    exit 1
 fi
 
 # Verify docker is running
 docker info > /dev/null 2>/dev/stderr
 exit_code=$(echo $?)
 if [[ $exit_code != "0" ]]; then
+    echo "" >/dev/stderr
     echo "Unable to run clerkgen. Docker is not running. Please start docker." >/dev/stderr
     exit "$exit_code"
 fi
@@ -39,6 +41,7 @@ fi
 aws sts get-caller-identity > /dev/null 2>/dev/stderr
 exit_code=$(echo $?)
 if [[ $exit_code != "0" ]]; then
+    echo "" >/dev/stderr
     echo "Unable to run clerkgen. AWS credentials are not valid. Please run 'saml2aws login'." >/dev/stderr
     exit "$exit_code"
 fi

--- a/shell/clerkgenproto.sh
+++ b/shell/clerkgenproto.sh
@@ -29,22 +29,18 @@ if [[ $resp -ne 200 ]]; then
 fi
 
 # Verify docker is running
-docker info > /dev/null 2>/dev/stderr
-exit_code=$(echo $?)
-if [[ $exit_code != "0" ]]; then
+if ! docker info > /dev/null 2>/dev/stderr; then
     echo "" >/dev/stderr
     echo "Unable to run clerkgen. Docker is not running. Please start docker." >/dev/stderr
-    exit "$exit_code"
+    exit 1
 fi
 
 #Verify AWS creds
-aws sts get-caller-identity > /dev/null 2>/dev/stderr
-exit_code=$(echo $?)
-if [[ $exit_code != "0" ]]; then
+if ! aws sts get-caller-identity > /dev/null 2>/dev/stderr; then
     echo "" >/dev/stderr
     echo "Unable to run clerkgen. AWS credentials are not valid. Please run 'saml2aws login'." >/dev/stderr
-    exit "$exit_code"
+    exit 1
 fi
 
 # Run clerkgen
-"$GOBIN" "github.com/getoutreach/clerkgen/cmd/clerkgenproto@v$(get_application_version "clerkgenproto")" "$@"
+exec "$GOBIN" "github.com/getoutreach/clerkgen/cmd/clerkgenproto@v$(get_application_version "clerkgenproto")" "$@"

--- a/versions.yaml
+++ b/versions.yaml
@@ -9,3 +9,4 @@ delve: 1.6.0
 gotestsum: 1.7.0
 lintroller: 1.7.0
 codeowners-validator: 0.6.0
+clerkgenproto: 1.12.0


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
This PR add `clerkgen.sh`. This will run from bootstrap as part of `gogenerate`. Command will look like this:
```
//go:generate ../scripts/shell-wrapper.sh clerkgenproto.sh --sn outreach.application.twilio_recording_del_req --sn outreach.tutorial.tutorial_event --od . -l go
```
In the above command, the schema names will be replaced as per the user's configuration. 

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: DP-2355

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Testing**:
1. `chmod +x clerkgenproto.sh` <- Hoping this happens automagically when an user runs `bootstrap`
2. `./clerkgenproto.sh --sn outreach.application.twilio_recording_del_req --sn outreach.tutorial.tutorial_event --od . -l go`

Generated all types as expected. Output:
```
INFO[0000] Starting clerkgen for protobuf
Generating proto clients
Generating go clients
go: finding module for package github.com/getoutreach/clerk/v2/pkg/clerk
go: finding module for package github.com/getoutreach/clerk/v2/pkg/clerk/models
go: finding module for package github.com/getoutreach/clerk/v2/pkg/clerk/models/schema/proto/outreach/system
go: found github.com/getoutreach/clerk/v2/pkg/clerk/models in github.com/getoutreach/clerk/v2 v2.0.0-20210929212026-b669b22b72cb
go: found github.com/getoutreach/clerk/v2/pkg/clerk in github.com/getoutreach/clerk/v2 v2.0.0-20210929212026-b669b22b72cb
go: found github.com/getoutreach/clerk/v2/pkg/clerk/models/schema/proto/outreach/system in github.com/getoutreach/clerk/v2 v2.0.0-20210929212026-b669b22b72cb
INFO[0008] Finished clerkgen for protobuf
```
