### PR TITLE
fix(clerkgenproto): [DP-2355] Don't run clerkgen in CircleCI

### DIFF
--- a/shell/clerkgenproto.sh
+++ b/shell/clerkgenproto.sh
@@ -9,6 +9,11 @@ source "$DIR/lib/logging.sh"
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
 
+# Don't run clerkgen in CircleCI
+if [[ -n $CIRCLECI ]]; then
+  exit 0
+fi
+
 # Get GH_TOKEN
 if [[ -n $OUTREACH_GITHUB_TOKEN ]]; then
 	GH_TOKEN="$OUTREACH_GITHUB_TOKEN"


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
Fixes the `clerkgenproto.sh`. I figured this out in my bootstrap work when I was integrating this with bootstrap. My CircleCI build failed. Sorry I missed this earlier.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: DP-2355

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
