### PR TITLE
fix(fmt): don't format shell files in .bootstrap

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -37,7 +37,7 @@ info_sub "clang-format"
 find . -path "$(get_repo_directory)/api/clients" -prune -o -name '*.proto' -exec "$SCRIPTS_DIR/clang-format.sh" -style=file -i {} \;
 
 info_sub "shfmt"
-find . -path ./vendor -prune -o -name node_modules -type d \
+find . -path ./vendor -prune -o -path ./.bootstrap -prune -o -name node_modules -type d \
   -prune -o -type f -name '*.sh' -exec "$SCRIPTS_DIR/shfmt.sh" -w -l {} +
 
 info_sub "Prettier (yaml/json)"


### PR DESCRIPTION
## What this PR does / why we need it

I noticed that during `make fmt`, `shfmt` was formatting files in devbase, which is a waste of computing power since that folder gets regenerated every time the devbase version changes.

## Jira ID

N/A

## Notes for your reviewer

That being said, `validate.sh` should run on this repo in CI so that shfmt wouldn't rewrite the files to begin with.