### PR TITLE
fix(Makefile): set default value for OSS

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -41,7 +41,7 @@ ACCOUNTS_URL        ?= https://accounts.$(OUTREACH_DOMAIN)
 BASE_TEST_ENV       ?= GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) SKIP_VALIDATE=${SKIP_VALIDATE} OSS=$(OSS)
 E2E_NAMESPACE       ?= $(APP)--bento1a
 E2E_SERVICE_ACCOUNT ?= $(APP)-e2e-client-svc
-OSS                 ?= $(OSS)
+OSS                 ?= false
 
 .PHONY: default
 default: build


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This fixes an issue where `OSS` would recursively call itself. With the usage of `?=` the value in `Makefile` will only be applied if not already set, so the attempt to default `OSS` that was being done before is not needed.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: [DTSS-0]

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
