### PR TITLE
fix: add build tags to lintroller run

### DIFF
--- a/shell/validate.sh
+++ b/shell/validate.sh
@@ -63,7 +63,7 @@ info_sub "golangci-lint"
 if [[ "$OSS" == "false" ]]; then
   info_sub "lintroller"
   # The sed is used to strip the pwd from lintroller output, which is currently prefixed with it.
-  "$GOBIN" "github.com/getoutreach/lintroller/cmd/lintroller@v$(get_application_version "lintroller")" \
+  GOFLAGS=-tags=or_e2e,or_test,or_int "$GOBIN" "github.com/getoutreach/lintroller/cmd/lintroller@v$(get_application_version "lintroller")" \
     -config scripts/golangci.yml ./... 2>&1 | sed "s#^$(pwd)/##"
 fi
 


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
* This includes files protected by the build tags `or_e2e`, `or_test`, and `or_int` when running `lintroller`.

<!-- Feel free to omit if outside contributor, e.g. N/A -->
**JIRA ID**: XX-XX

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
