### PR TITLE
fix: update devenv to v1.15.6

### DIFF
--- a/shell/circleci/setup-e2e.sh
+++ b/shell/circleci/setup-e2e.sh
@@ -26,7 +26,7 @@ EOF
 
 info "Setting up devenv container"
 docker run --net=host -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME:$HOME" -v "$(pwd):/host_mnt" \
-  --name devenv --entrypoint bash -d gcr.io/outreach-docker/devenv:1.4.0 -c "exec sleep infinity"
+  --name devenv --entrypoint bash -d gcr.io/outreach-docker/devenv:v1.15.6 -c "exec sleep infinity"
 
 # Create CircleCI user and give it the needed perms
 docker exec devenv addgroup -g "$(id -g)" circleci


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
When running e2e tests the older version of devenv image has go 1.16.2, updating to the latest devenv moves this to go 1.17.1 and can now compile and run features in go 1.17.1

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
I was iterating on telefork until I was able to get the e2e to pass. Below is the version where it passed.
https://app.circleci.com/pipelines/github/getoutreach/telefork/321/workflows/26027e09-3e8a-4183-a680-7dbeeb155d9e/jobs/1419
