### PR TITLE
fix(sync-package-hjson): update relative path due to the script moving

### DIFF
--- a/shell/ci/testing/sync-package-hjson.js
+++ b/shell/ci/testing/sync-package-hjson.js
@@ -14,11 +14,11 @@ function exec(cmd) {
 
 const relativeNodeClientPath = path.join("api", "clients", "node");
 
-// repoRoot/.bootstrap/shell/circleci -> repoRoot/$relativeNodeClientPath
-const nodeClientPath = path.resolve(__dirname, "../../..", relativeNodeClientPath);
+// repoRoot/.bootstrap/shell/ci/testing -> repoRoot/$relativeNodeClientPath
+const nodeClientPath = path.resolve(__dirname, "../../../..", relativeNodeClientPath);
 
 if (!fs.existsSync(nodeClientPath)) {
-  console.log("No Node.js gRPC client found, exiting");
+  console.log(`No Node.js gRPC client found in "${nodeClientPath}", exiting`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

The Dependabot updater failed silently because the script moved from `shell/circleci` to `shell/ci/testing`.

## Jira ID

N/A

## Notes for your reviewers

Also added some debug info to the log for easier troubleshooting in the future.