### PR TITLE
fix: ignore dirty git state w/ goreleaser

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -69,7 +69,7 @@ release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
-	@./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v0.180.3 release --skip-publish --rm-dist
+	@./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.1.0 release --skip-announce --skip-publish --skip-validate --rm-dist
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

We don't care about dirty state in CI because we don't fully use goreleaser except to generate archives, so just stop this from causing problems. Forever.

Also updates goreleaser because we can.


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
