### PR TITLE
feat: Added devspace container start script and make dev for watcher

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -59,6 +59,7 @@ pre-e2e::
 pre-benchmark::
 pre-gogenerate::
 pre-devserver::
+pre-dev::
 pre-debug::
 pre-docker-build::
 pre-fmt::
@@ -142,6 +143,11 @@ gobuild: check-deps
 grpcui:
 	@$(LOG) info "Launching gRPCUI"
 	./scripts/shell-wrapper.sh grpcui.sh localhost:5000
+## dev:       run the service
+.PHONY: dev
+dev:: pre-dev
+	@./scripts/shell-wrapper.sh gobin.sh github.com/cosmtrek/air@v1.27.8 -c $(CURDIR)/.air.toml
+
 ## devserver:       run the service
 .PHONY: devserver
 devserver:: pre-devserver build

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set +e # Continue on errors
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=./lib/bootstrap.sh
+source "$DIR/lib/bootstrap.sh"
+
+gh auth setup-git
+
+# IDEA: Maybe do this in the image build?
+if ! grep -q '. "$HOME/.asdf/asdf.sh"' $HOME/.bashrc; then
+  echo '. "$HOME/.asdf/asdf.sh"' >>$HOME/.bashrc
+fi
+
+COLOR_CYAN="\033[0;36m"
+COLOR_RESET="\033[0m"
+
+APPNAME="$(get_app_name)"
+
+echo -e "${COLOR_CYAN}
+   ____              ____
+  |  _ \  _____   __/ ___| _ __   __ _  ___ ___
+  | | | |/ _ \ \ / /\___ \| '_ \ / _\` |/ __/ _ \\
+  | |_| |  __/\ V /  ___) | |_) | (_| | (_|  __/
+  |____/ \___| \_/  |____/| .__/ \__,_|\___\___|
+                          |_|
+${COLOR_RESET}
+Welcome to your development container!
+
+This is how you can work with it:
+- Run \`${COLOR_CYAN}make${COLOR_RESET}\` to build the application
+- Run \`${COLOR_CYAN}make dev${COLOR_RESET}\` to start the development server with reloading
+- Run \`${COLOR_CYAN}./bin/${APPNAME}${COLOR_RESET}\` to start the server
+- ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
+- Some ports will be forwarded.
+"
+
+bash

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -9,9 +9,11 @@ gh auth setup-git
 
 # IDEA: Maybe do this in the image build?
 # We actually don't want it to expand, we want it to be a literal string written to the file
+# shellcheck disable=SC2016
 # shellcheck disable=SC2086
 if ! grep -q '. "$HOME/.asdf/asdf.sh"' "$HOME/.bashrc"; then
   # We actually don't want it to expand, we want it to be a literal string written to the file
+  # shellcheck disable=SC2016
   # shellcheck disable=SC2086
   echo '. "$HOME/.asdf/asdf.sh"' >>"$HOME/.bashrc"
 fi

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -8,8 +8,12 @@ source "$DIR/lib/bootstrap.sh"
 gh auth setup-git
 
 # IDEA: Maybe do this in the image build?
-if ! grep -q '. "$HOME/.asdf/asdf.sh"' $HOME/.bashrc; then
-  echo '. "$HOME/.asdf/asdf.sh"' >>$HOME/.bashrc
+# We actually don't want it to expand, we want it to be a literal string written to the file
+# shellcheck disable=SC2086
+if ! grep -q '. "$HOME/.asdf/asdf.sh"' "$HOME/.bashrc"; then
+  # We actually don't want it to expand, we want it to be a literal string written to the file
+  # shellcheck disable=SC2086
+  echo '. "$HOME/.asdf/asdf.sh"' >>"$HOME/.bashrc"
 fi
 
 COLOR_CYAN="\033[0;36m"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
* Add [air](https://github.com/cosmtrek/air) as file watcher
* Add `devspace_start.sh` as entry point in devspace container. When this runs, it adds the `asdf` sourcing to `~/.bashrc`, sets up `gh` as git creds provider (`gh` is automatically authenticated as we set `GH_TOKEN` env variable for devspace container). This way, when you run `devspace dev` you can immediately do `make` or `make dev` and it will run, pull modules, ...


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

`.air.toml` requires app specific binary name, so it's generated by bootstrap

<!--- Block(custom) -->
<!--- EndBlock(custom) -->
