### PR TITLE
feat(coveralls): add support for parallel coveralls uploads

### DIFF
--- a/shell/ci/testing/coveralls-finish.sh
+++ b/shell/ci/testing/coveralls-finish.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Finish uploading code coverage to coveralls.io
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SHELL_DIR="$DIR/../.."
+LIB_DIR="${DIR}/../../lib"
+
+# shellcheck source=../../lib/bootstrap.sh
+source "${LIB_DIR}/bootstrap.sh"
+
+if [[ -n $COVERALLS_TOKEN ]]; then
+  curl "https://coveralls.io/webhook?repo_token=$COVERALLS_TOKEN" -d "payload[build_num]=$CIRCLE_WORKFLOW_ID&payload[status]=done"
+fi

--- a/shell/ci/testing/coveralls-finish.sh
+++ b/shell/ci/testing/coveralls-finish.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Finish uploading code coverage to coveralls.io
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SHELL_DIR="$DIR/../.."
 LIB_DIR="${DIR}/../../lib"
 
 # shellcheck source=../../lib/bootstrap.sh

--- a/shell/ci/testing/coveralls.sh
+++ b/shell/ci/testing/coveralls.sh
@@ -7,6 +7,13 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/bootstrap.sh
 source "${LIB_DIR}/bootstrap.sh"
 
+flag_name="$1"
+
 if [[ -n $COVERALLS_TOKEN ]]; then
-  "$SHELL_DIR/gobin.sh" "github.com/mattn/goveralls@v$(get_tool_version "goveralls")" -coverprofile=/tmp/coverage.out -service=circle-ci -repotoken="$COVERALLS_TOKEN"
+  extra_args=()
+  if [[ -n $flag_name ]]; then
+    extra_args+=("-parallel" "-flagname" "$flag_name")
+  fi
+
+  "$SHELL_DIR/gobin.sh" "github.com/mattn/goveralls@v$(get_tool_version "goveralls")" -coverprofile=/tmp/coverage.out -service=circle-ci -jobid="$CIRCLE_WORKFLOW_ID" -repotoken="$COVERALLS_TOKEN" "${extra_args[@]}"
 fi


### PR DESCRIPTION
## What this PR does / why we need it

This allows, for example, uploading both unit test and end-to-end test code coverage to coveralls and have it merge appropriately.

## Jira ID

[TAU-1223]

## Notes for your reviewers

Each test job will run goveralls, and then a finisher job will run when all test jobs complete successfully, to tell coveralls that the coverage uploads are done.

I had to adjust goveralls to use the CircleCI workflow ID instead of (by default) the build number, so that the uploaded coverage files are grouped correctly.

[Coveralls + CircleCI + parallelization docs](https://docs.coveralls.io/parallel-build-webhook#circleci-setup)


[TAU-1223]: https://outreach-io.atlassian.net/browse/TAU-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ