### PR TITLE
fix(coveralls): handle when there are no E2E tests

### DIFF
--- a/shell/ci/testing/coveralls.sh
+++ b/shell/ci/testing/coveralls.sh
@@ -8,12 +8,13 @@ LIB_DIR="${DIR}/../../lib"
 source "${LIB_DIR}/bootstrap.sh"
 
 flag_name="$1"
+coverage_file=/tmp/coverage.out
 
-if [[ -n $COVERALLS_TOKEN ]]; then
+if [[ -n $COVERALLS_TOKEN && -f "$coverage_file" ]]; then
   extra_args=()
   if [[ -n $flag_name ]]; then
     extra_args+=("-parallel" "-flagname" "$flag_name")
   fi
 
-  "$SHELL_DIR/gobin.sh" "github.com/mattn/goveralls@v$(get_tool_version "goveralls")" -coverprofile=/tmp/coverage.out -service=circle-ci -jobid="$CIRCLE_WORKFLOW_ID" -repotoken="$COVERALLS_TOKEN" "${extra_args[@]}"
+  "$SHELL_DIR/gobin.sh" "github.com/mattn/goveralls@v$(get_tool_version "goveralls")" -coverprofile="$coverage_file" -service=circle-ci -jobid="$CIRCLE_WORKFLOW_ID" -repotoken="$COVERALLS_TOKEN" "${extra_args[@]}"
 fi

--- a/shell/ci/testing/coveralls.sh
+++ b/shell/ci/testing/coveralls.sh
@@ -10,7 +10,7 @@ source "${LIB_DIR}/bootstrap.sh"
 flag_name="$1"
 coverage_file=/tmp/coverage.out
 
-if [[ -n $COVERALLS_TOKEN && -f "$coverage_file" ]]; then
+if [[ -n $COVERALLS_TOKEN && -f $coverage_file ]]; then
   extra_args=()
   if [[ -n $flag_name ]]; then
     extra_args+=("-parallel" "-flagname" "$flag_name")


### PR DESCRIPTION
## What this PR does / why we need it

This should fix the case when a service doesn't have any E2E tests (i.e., it shouldn't try to upload coverage to coveralls).

CC: @davefry-outreach 

## Jira ID

N/A
