### PR TITLE
fix: Use fixed bundler version (from flagship Gemfile.lock)

### DIFF
--- a/shell/ci/env/asdf.sh
+++ b/shell/ci/env/asdf.sh
@@ -39,7 +39,7 @@ init_asdf() {
 
   # langauage specifics
   echo -e "npm\nyarn" >"$HOME/.default-npm-packages"
-  echo -e "bundler" >"$HOME/.default-gems"
+  echo -e "bundler 2.2.17" >"$HOME/.default-gems"
   cat >"$HOME/.default-golang-pkgs" <<EOF
 github.com/golang/protobuf/protoc-gen-go@v$(get_tool_version protoc-gen-go)
 github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v$(get_tool_version protoc-gen-doc)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Different bundler versions create different Gemfile.lock versions, messing things up. This solves that problem.


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
