### PR TITLE
fix(ci/auth/github): write out gh hosts.yml config

### DIFF
--- a/shell/ci/auth/github.sh
+++ b/shell/ci/auth/github.sh
@@ -13,5 +13,14 @@ if [[ -z $GITHUB_TOKEN ]]; then
   GITHUB_TOKEN=$("$SHELL_DIR/gobin.sh" "github.com/getoutreach/ci/cmd/ghaccesstoken@$(get_tool_version "getoutreach/ci")" --skip-update token)
 fi
 
+# Configure the gh CLI, and tools that depend on it
+mkdir -p "$HOME/.config/gh"
+cat >"$HOME/.config/gh/hosts.yml" <<EOF
+github.com:
+  user: devbase
+  oauth_token: $GITHUB_TOKEN
+EOF
+
+# Configure the legacy path
 mkdir -p "$HOME/.outreach"
 echo "$GITHUB_TOKEN" >"$HOME/.outreach/github.token"

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -33,7 +33,7 @@ if [[ -z $GOBIN_PATH ]]; then
 
   tmp_dir=$(mktemp -d)
   # retry w/ 5s interval, 5 times
-  retry 5 5 curl --location --output "$tmp_dir/gobin.tar.gz" --silent \
+  retry 5 5 curl --fail --location --output "$tmp_dir/gobin.tar.gz" --silent \
     "https://github.com/getoutreach/gobin/releases/download/v$GOBIN_VERSION/gobin_${GOBIN_VERSION}_${GOOS}_${GOARCH}.tar.gz"
   # shellcheck disable=SC2181 # Why: Reads better this way
   if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR stubs `~/.config/gh/hosts.yml` to enable tools that depend on the github CLI to authenticate in CI.


<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-1186]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1186]: https://outreach-io.atlassian.net/browse/DTSS-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ