### PR TITLE
feat: (protoc.sh) update go-protoc-import field to support setting the import path under the module

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -32,22 +32,29 @@ if [[ -z $uid ]] || [[ -z $gid ]]; then
 fi
 
 get_import_basename() {
-  basename "$(go list -f '{{ .Path }}' -m "$1" | sed 's|/v[0-9]||') " # sed removes the version off the module path if present
+  local module=$(echo $1 | jq -r .module)
+  # sed removes the version off the module path if present
+  basename $(go list -f '{{ .Path }}' -m "$module" | sed 's|/v[0-9]||')
+}
+get_import_path() {
+  local module=$(echo $1 | jq -r .module)
+  # sed removes the version off the module path if present
+  module_root=$(go list -f '{{ .Dir }}' -m "$module" | sed 's|/v[0-9]||')
+  echo "${module_root}$(echo $1 | jq -r .path)"
 }
 for import in $(get_list "go-protoc-imports"); do
+  module=$(echo $import | jq -r .module)
   currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
   requiredver="1.16.0"
   if [ ! "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then
     echo "Go version must be greater than ${requiredver} to use 'go-protoc-imports' feature"
     exit 1
   fi
-
-  go install "$import"
+  go install "$module"
   # check exit for this instead of the install itself, as the install can
   # return non-zero, but still retrieve the dependency. As long as we can
   # retrieve the dep with go list, we can import the files for protoc
-  go list -f '{{ .Dir }}' -m "$import"
-
+  go list -f '{{ .Dir }}' -m "$module"
   exit_code=$?
   if [[ $exit_code != "0" ]]; then
     exit $exit_code
@@ -57,7 +64,7 @@ done
 info "Generating GRPC Clients"
 # shellcheck disable=SC2046 # Why: We want it to split
 CONTAINER_ID=$(docker run --rm -v "$(get_repo_directory)/api:/defs" \
-  $(for import in $(get_list "go-protoc-imports"); do echo "-v $(go list -f '{{ .Dir }}' -m "$import"):/mod/$(get_import_basename "$import")"; done) \
+  $(for import in $(get_list "go-protoc-imports"); do echo "-v $(get_import_path "$import"):/mod/$(get_import_basename "$import")"; done) \
   --entrypoint bash -d "$IMAGE" -c 'exec tail -f /dev/null')
 
 trap 'docker stop -t0 $CONTAINER_ID >/dev/null' EXIT

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -32,18 +32,20 @@ if [[ -z $uid ]] || [[ -z $gid ]]; then
 fi
 
 get_import_basename() {
-  local module=$(echo $1 | jq -r .module)
+  # shellcheck disable=SC2155 # Why: splitting declartion is messier
+  local module="$(jq -r .module <<<"$1")"
   # sed removes the version off the module path if present
-  basename $(go list -f '{{ .Path }}' -m "$module" | sed 's|/v[0-9]||')
+  basename "$(go list -f '{{ .Path }}' -m "$module" | sed 's|/v[0-9]||')"
 }
 get_import_path() {
-  local module=$(echo $1 | jq -r .module)
+  # shellcheck disable=SC2155 # Why: splitting declartion is messier
+  local module="$(jq -r .module <<<"$1")"
   # sed removes the version off the module path if present
-  module_root=$(go list -f '{{ .Dir }}' -m "$module" | sed 's|/v[0-9]||')
-  echo "${module_root}$(jq -r .path <<< "$1")"
+  module_root="$(go list -f '{{ .Dir }}' -m "$module" | sed 's|/v[0-9]||')"
+  echo "${module_root}$(jq -r .path <<<"$1")"
 }
 for import in $(get_list "go-protoc-imports"); do
-  module=$(jq -r .module <<< "$import")
+  module=$(jq -r .module <<<"$import")
   currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
   requiredver="1.16.0"
   if [ ! "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -40,10 +40,10 @@ get_import_path() {
   local module=$(echo $1 | jq -r .module)
   # sed removes the version off the module path if present
   module_root=$(go list -f '{{ .Dir }}' -m "$module" | sed 's|/v[0-9]||')
-  echo "${module_root}$(echo $1 | jq -r .path)"
+  echo "${module_root}$(jq -r .path <<< "$1")"
 }
 for import in $(get_list "go-protoc-imports"); do
-  module=$(echo $import | jq -r .module)
+  module=$(jq -r .module <<< "$import")
   currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
   requiredver="1.16.0"
   if [ ! "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
this is important particularly when importing from a bootstrap repo. protobuf expects imports to match their generated files

Example:
settings has `table.proto` which it imports as `import table.proto`
settingsworkflow, uses `go-protoc-imports` to import from settings, but the default path required importing table as `import api/table.proto`, these changes allow us to specify that the protoc include path should be under `/api`. This allows the imports to match and the reflection servers to function properly (among avoid other possible mismatch bugs)

Heres what it looks like in a `service.yaml` file:
```
go-protoc-imports:
  - module: "github.com/getoutreach/settings@latest"
    path: "/api"
```


<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
- this is a breaking change, however this key is currently only used by settings services all owned by the OLI team. We are happy to bring in as a breaking change and fix manually in our 2 repos




<!--- Block(custom) -->
<!--- EndBlock(custom) -->