### PR TITLE
fix(goreleaser): explictly pass version to goreleaser

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -72,7 +72,7 @@ release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
-	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.1.0 release --skip-announce --skip-publish --skip-validate --rm-dist
+	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.4.1 release --skip-announce --skip-publish --skip-validate --rm-dist
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 

--- a/root/Makefile
+++ b/root/Makefile
@@ -72,7 +72,7 @@ release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 || true
 	@git tag "$(APP_VERSION)" >&2
-	@./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.1.0 release --skip-announce --skip-publish --skip-validate --rm-dist
+	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.1.0 release --skip-announce --skip-publish --skip-validate --rm-dist
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This fixes issues where `goreleaser` would sometimes respect a pre-release tag over the newer version based on git tag ordering. This allows us to set the actual version.


<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

[goreleaser code ref](https://github.com/goreleaser/goreleaser/blob/f01c60026ce6320447736a9e562af85bbf649562/internal/pipe/git/git.go#L228)


<!--- Block(custom) -->
<!--- EndBlock(custom) -->
