### PR TITLE
fix: Fixing relative path in build script

### DIFF
--- a/shell/deploy-to-dev.sh
+++ b/shell/deploy-to-dev.sh
@@ -53,4 +53,4 @@ if [[ $action != "show" ]]; then
   fi
 fi
 
-./build-jsonnet.sh "$action"
+exec "$SCRIPTS_DIR/build-jsonnet.sh" "$action"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Currently trying to deploy to devenv with latest results in the following error: 
```
/Users/mukund.kidambi/outreach/smartstorecdctestproducer/scripts/../.bootstrap/shell/deploy-to-dev.sh: line 56: ./build-jsonnet.sh: No such file or directory  app.name=smartstorecdctestproducer app.type=bootstrap
```
This is due to the use of a relative path in the script path.

<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
