### PR TITLE
fix(e2e): set correct TEST_TAGS

### DIFF
--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -82,5 +82,5 @@ fi
 
 if [[ $E2E == "true" ]]; then
   info "Starting E2E test runner"
-  exec "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/e2e@$(cat "$DIR/../../../.version")")"
+  exec TEST_TAGS=or_test,or_e2e "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/e2e@$(cat "$DIR/../../../.version")")"
 fi

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -82,5 +82,5 @@ fi
 
 if [[ $E2E == "true" ]]; then
   info "Starting E2E test runner"
-   TEST_TAGS=or_test,or_e2e exec "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/e2e@$(cat "$DIR/../../../.version")")"
+  TEST_TAGS=or_test,or_e2e exec "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/e2e@$(cat "$DIR/../../../.version")")"
 fi

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -82,5 +82,5 @@ fi
 
 if [[ $E2E == "true" ]]; then
   info "Starting E2E test runner"
-  exec TEST_TAGS=or_test,or_e2e "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/e2e@$(cat "$DIR/../../../.version")")"
+   TEST_TAGS=or_test,or_e2e exec "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/e2e@$(cat "$DIR/../../../.version")")"
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

It looks like the `TEST_TAGS` got removed from the Makefile when the E2E rework was done. This was always an issue of misdirection anyways, so now we explicitly set it when we call the E2E runner.


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
