### PR TITLE
feat(devspace): Send logs to datadog

### DIFF
--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -66,7 +66,7 @@ This is how you can work with it:
 "
 
 if [[ -z $DEV_CONTAINER_LOGFILE ]] || [[ $DEVENV_DEV_TERMINAL == "true" ]]; then
-  echo "$BANNER"
+  echo -e "$BANNER"
   bash
 else
   make dev | tee -ai "${DEV_CONTAINER_LOGFILE:-/tmp/app.log}"

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -5,7 +5,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
 
-GH_NO_UPDATE_NOTIFIER=disabled gh auth setup-git
+GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 
 if [[ -n $NPM_TOKEN ]]; then
   # We actually don't want it to expand, we want it to be a literal string written to the file

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -5,7 +5,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
 
-gh auth setup-git
+GH_NO_UPDATE_NOTIFIER=disabled gh auth setup-git
 
 if [[ -n $NPM_TOKEN ]]; then
   # We actually don't want it to expand, we want it to be a literal string written to the file
@@ -25,7 +25,7 @@ if [[ -n $GH_TOKEN ]]; then
   # shellcheck disable=SC1091
   . "$HOME/.asdf/asdf.sh"
 
-  # Bundler requires an expanded $GH_TOKENV so we use the variable directly here
+  # Bundler requires an expanded $GH_TOKEN so we use the variable directly here
   # shellcheck disable=SC2016
   # shellcheck disable=SC2086
   bundle config set --global rubygems.pkg.github.com x-access-token:$GH_TOKEN
@@ -47,8 +47,8 @@ COLOR_RESET="\033[0m"
 
 APPNAME="$(get_app_name)"
 
-echo -e "${COLOR_CYAN}
-   ____              ____
+BANNER="${COLOR_CYAN}
+  ____              ____
   |  _ \  _____   __/ ___| _ __   __ _  ___ ___
   | | | |/ _ \ \ / /\___ \| '_ \ / _\` |/ __/ _ \\
   | |_| |  __/\ V /  ___) | |_) | (_| | (_|  __/
@@ -65,4 +65,9 @@ This is how you can work with it:
 - Some ports will be forwarded.
 "
 
-bash
+if [[ -z $DEV_CONTAINER_LOGFILE ]] || [[ $DEVENV_DEV_TERMINAL == "true" ]]; then
+  echo "$BANNER"
+  bash
+else
+  make dev | tee -ai "${DEV_CONTAINER_LOGFILE:-/tmp/app.log}"
+fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

We pass env variables to help startup script decide whether to start the terminal, or start the app.

These variables are passed from devenv https://github.com/getoutreach/devenv/pull/224

When it starts the app and source watchers, it sends the logs into a file - this file is tailed in container entrypoint. https://github.com/getoutreach/bootstrap/pull/1099




<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-1520]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1520]: https://outreach-io.atlassian.net/browse/DTSS-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ