### PR TITLE
feat(devspace): Support debugging non-default binaries (e.g. cdc bins)

### DIFF
--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -13,7 +13,7 @@ export CGO_ENABLED=1
 set -ex
 
 if [[ -n ${DLV_PORT} ]]; then
-  exec "$SCRIPTS_DIR/gobin.sh" github.com/go-delve/delve/cmd/dlv@v"$(get_application_version "delve")" exec "$(get_repo_directory)/bin/$(get_app_name)" --headless --listen=":${DLV_PORT}"
+  exec "$SCRIPTS_DIR/gobin.sh" github.com/go-delve/delve/cmd/dlv@v"$(get_application_version "delve")" exec "$(get_repo_directory)/bin/${DEV_CONTAINER_EXECUTABLE:-$(get_app_name)}" --headless --listen=":${DLV_PORT}"
 else
   exec "$SCRIPTS_DIR/gobin.sh" github.com/go-delve/delve/cmd/dlv@v"$(get_application_version "delve")" debug --build-flags="-tags=or_dev" "$(get_repo_directory)/cmd/$(get_app_name)"
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Enables debugging bins based on environment variable. This is passed through from `devenv`, and bootstrap adds it in `devspace.yaml` config.

Other PRs to make it work e2e:
- https://github.com/getoutreach/bootstrap/pull/1108
- https://github.com/getoutreach/devenv/pull/231

<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-1466]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1466]: https://outreach-io.atlassian.net/browse/DTSS-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ