### PR TITLE
feat: add the ability to run devenv pre-release version for circleCI e2e test

### DIFF
--- a/orbs/shared/commands/setup_devenv.yaml
+++ b/orbs/shared/commands/setup_devenv.yaml
@@ -12,9 +12,13 @@ parameters:
     description: Arguments for provision, optional
     type: string
     default: ""
+  devenv_pre_release:
+    description: Provision the devenv using pre-release version
+    type: boolean
+    default: false
 steps:
   - run:
       name: Setting up devenv
       command: |-
-        PROVISION="<< parameters.provision >>" E2E="<< parameters.e2e >>" PROVISION_ARGS="<< parameters.provision_args >>" \
+        PROVISION="<< parameters.provision >>" E2E="<< parameters.e2e >>" PROVISION_ARGS="<< parameters.provision_args >>" DEVENV_PRE_RELEASE="<< parameters.devenv_pre_release >>" \
           ./scripts/shell-wrapper.sh ci/testing/setup-devenv.sh

--- a/orbs/shared/commands/setup_devenv.yaml
+++ b/orbs/shared/commands/setup_devenv.yaml
@@ -12,13 +12,9 @@ parameters:
     description: Arguments for provision, optional
     type: string
     default: ""
-  devenv_pre_release:
-    description: Provision the devenv using pre-release version
-    type: boolean
-    default: false
 steps:
   - run:
       name: Setting up devenv
       command: |-
-        PROVISION="<< parameters.provision >>" E2E="<< parameters.e2e >>" PROVISION_ARGS="<< parameters.provision_args >>" DEVENV_PRE_RELEASE="<< parameters.devenv_pre_release >>" \
+        PROVISION="<< parameters.provision >>" E2E="<< parameters.e2e >>" PROVISION_ARGS="<< parameters.provision_args >>" \
           ./scripts/shell-wrapper.sh ci/testing/setup-devenv.sh

--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -4,10 +4,15 @@ parameters:
     description: Vault Instance to use
     type: string
     default: ""
+  devenv_pre_release:
+    description: Provision the devenv using pre-release version
+    type: boolean
+    default: false
 executor:
   name: testbed-machine
 environment:
   VAULT_ADDR: << parameters.vault_address >>
+  DEVENV_PRE_RELEASE: << parameters.devenv_pre_release >>
 resource_class: large
 steps:
   - setup_environment:

--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -5,7 +5,7 @@ parameters:
     type: string
     default: ""
   devenv_pre_release:
-    description: Provision the devenv using pre-release version
+    description: Use devenv release candidate to provision the test cluster.
     type: boolean
     default: false
 executor:

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -11,7 +11,6 @@ source "$DIR/../../lib/logging.sh"
 PROVISION="${PROVISION:-"false"}"
 PROVISION_ARGS="${PROVISION_ARGS:-""}"
 E2E="${E2E:-"false"}"
-DEVENV_PRE_RELEASE="${DEVENV_PRE_RELEASE:-"false"}"
 
 if [[ $PROVISION == "true" ]] && [[ $E2E == "true" ]]; then
   info "e2e was set, ignoring provision"

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -53,10 +53,8 @@ if [[ -n $CI ]]; then
     # download the pre-release/latest version
     REPO=getoutreach/devenv
     if [[ $DEVENV_PRE_RELEASE == "true" ]]; then
-      echo "Using devenv pre-release version"
       TAG=$(gh release -R "$REPO" list | grep Pre-release | head -n1 | awk '{ print $1 }')
     else
-      echo "Using devenv latest version"
       TAG=$(gh release -R "$REPO" list | grep Latest | awk '{ print $1 }')
     fi
     gh release -R "$REPO" download "$TAG" --pattern "devenv_*_$(go env GOOS)_$(go env GOARCH).tar.gz"

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -53,8 +53,10 @@ if [[ -n $CI ]]; then
     # download the pre-release/latest version
     REPO=getoutreach/devenv
     if [[ $DEVENV_PRE_RELEASE == "true" ]]; then
+      echo "Runing pre-release"
       TAG=$(gh release -R "$REPO" list | grep Pre-release | head -n1 | awk '{ print $1 }')
     else
+      echo "Runing latest"
       TAG=$(gh release -R "$REPO" list | grep Latest | awk '{ print $1 }')
     fi
     gh release -R "$REPO" download "$TAG" --pattern "devenv_*_$(go env GOOS)_$(go env GOARCH).tar.gz"

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -56,6 +56,7 @@ if [[ -n $CI ]]; then
       echo "Using devenv pre-release version"
       TAG=$(gh release -R "$REPO" list | grep Pre-release | head -n1 | awk '{ print $1 }')
     else
+      echo "Using devenv latest version"
       TAG=$(gh release -R "$REPO" list | grep Latest | awk '{ print $1 }')
     fi
     gh release -R "$REPO" download "$TAG" --pattern "devenv_*_$(go env GOOS)_$(go env GOARCH).tar.gz"

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -11,6 +11,7 @@ source "$DIR/../../lib/logging.sh"
 PROVISION="${PROVISION:-"false"}"
 PROVISION_ARGS="${PROVISION_ARGS:-""}"
 E2E="${E2E:-"false"}"
+DEVENV_PRE_RELEASE="${DEVENV_PRE_RELEASE:-"false"}"
 
 if [[ $PROVISION == "true" ]] && [[ $E2E == "true" ]]; then
   info "e2e was set, ignoring provision"
@@ -48,7 +49,17 @@ if [[ -n $CI ]]; then
     tempDir=$(mktemp -d)
     cp "$DIR/../../../.tool-versions" "$tempDir/" # Use the versions from devbase
     pushd "$tempDir" >/dev/null || exit 1
-    gh release -R getoutreach/devenv download --pattern "devenv_*_$(go env GOOS)_$(go env GOARCH).tar.gz"
+
+    # download the pre-release/latest version
+    REPO=getoutreach/devenv
+    if [[ $DEVENV_PRE_RELEASE == "true" ]]; then
+      echo "Using devenv pre-release version"
+      TAG=$(gh release -R "$REPO" list | grep Pre-release | head -n1 | awk '{ print $1 }')
+    else
+      TAG=$(gh release -R "$REPO" list | grep Latest | awk '{ print $1 }')
+    fi
+    gh release -R "$REPO" download "$TAG" --pattern "devenv_*_$(go env GOOS)_$(go env GOARCH).tar.gz"
+
     echo "" # Fixes issues with output being corrupted in CI
     tar xf devenv**.tar.gz
     sudo mv devenv /usr/local/bin/devenv

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -52,12 +52,11 @@ if [[ -n $CI ]]; then
     # download the pre-release/latest version
     REPO=getoutreach/devenv
     if [[ $DEVENV_PRE_RELEASE == "true" ]]; then
-      echo "Runing pre-release"
       TAG=$(gh release -R "$REPO" list | grep Pre-release | head -n1 | awk '{ print $1 }')
     else
-      echo "Runing latest"
       TAG=$(gh release -R "$REPO" list | grep Latest | awk '{ print $1 }')
     fi
+    info "Using devenv version: ($TAG)"
     gh release -R "$REPO" download "$TAG" --pattern "devenv_*_$(go env GOOS)_$(go env GOARCH).tar.gz"
 
     echo "" # Fixes issues with output being corrupted in CI


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it



<!--- Block(jiraPrefix) --->
## Jira ID

https://outreach-io.atlassian.net/browse/DTSS-1592
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
Made associated change in bootstrap to  kick a circle ci build for bulkworkflow -
https://github.com/getoutreach/bootstrap/pull/1150/files

The checks below are to see if it downloaded the pre-release/latest devenv version depending on the environment variable.

With pre-release devenv version - (ignore the fact that e2e test failed) https://app.circleci.com/pipelines/github/getoutreach/bulkworkflow/345/workflows/1b938040-f734-4f97-b239-ed9f5634bd47/jobs/1460

With latest devenv version - 
https://app.circleci.com/pipelines/github/getoutreach/bulkworkflow/346/workflows/631e8595-1456-4ef3-8a20-e8c6946651a3/jobs/1465

<!--- Block(custom) -->
<!--- EndBlock(custom) -->
