### PR TITLE
fix: Use apps deploy and not deploy-app

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -173,7 +173,7 @@ func provisionNew(ctx context.Context, deps []string, target string) error {
 		}
 
 		log.Info().Msgf("Deploying dependency '%s'", d)
-		cmd := exec.CommandContext(ctx, "devenv", "--skip-update", "deploy-app", d)
+		cmd := exec.CommandContext(ctx, "devenv", "--skip-update", "apps", "deploy", d)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		cmd.Stdin = os.Stdin
@@ -273,7 +273,7 @@ func main() { //nolint:funlen,gocyclo
 	}
 
 	log.Info().Msg("Deploying current application into cluster")
-	cmd := exec.CommandContext(ctx, "devenv", "--skip-update", "deploy-app", ".")
+	cmd := exec.CommandContext(ctx, "devenv", "--skip-update", "apps", "deploy", ".")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
`devenv deploy-app` is deprecated and need to use `devenv apps run`


<!--- Block(jiraPrefix) --->
## Jira ID
https://outreach-io.atlassian.net/browse/DTSS-1594
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
