### PR TITLE
feat: Added Telefork API key for CLI telemetry

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -11,7 +11,8 @@ GOOS                ?= $(shell go env GOOS)
 GOARCH              ?= $(shell go env GOARCH)
 PKG                 := $(GO) mod download -x
 HONEYCOMB_API_KEY 	?= $(shell if [[ -f /run/secrets/outreach.io/honeycomb/apiKey ]]; then cat /run/secrets/outreach.io/honeycomb/apiKey; else cat ~/.outreach/$(APP)/honeycomb/apiKey; fi )
-LDFLAGS             ?= $(shell if [[ -z $$DLV_PORT ]]; then printf -- "-w -s"; fi) -X github.com/getoutreach/gobox/pkg/app.Version=$(APP_VERSION) -X github.com/getoutreach/go-outreach/v2/pkg/app.Version=$(APP_VERSION) -X main.HoneycombTracingKey=$(HONEYCOMB_API_KEY)
+TELEFORK_API_KEY 	?= $(shell if [[ -f /run/secrets/outreach.io/telefork/api-keys/default ]]; then cat /run/secrets/outreach.io/telefork/api-keys/default; else cat ~/.outreach/$(APP)/telefork/api-keys/default; fi )
+LDFLAGS             ?= $(shell if [[ -z $$DLV_PORT ]]; then printf -- "-w -s"; fi) -X github.com/getoutreach/gobox/pkg/app.Version=$(APP_VERSION) -X github.com/getoutreach/go-outreach/v2/pkg/app.Version=$(APP_VERSION) -X main.HoneycombTracingKey=$(HONEYCOMB_API_KEY) -X main.TeleforkAPIKey=$(TELEFORK_API_KEY)
 GOFLAGS             :=
 GOPRIVATE           := github.com/$(ORG)/*
 GOPROXY             := https://proxy.golang.org

--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -109,6 +109,9 @@ DEVENV_VERSION="xyz" "$DIR/deploy-to-dev.sh" show | yq -r 'select(.kind == "Vaul
 info_sub "fetching secret 'dev/devenv/honeycomb'"
 get_vault_secrets "dev/devenv/honeycomb" "$configDir"
 
+info_sub "fetching secret 'deploy/telefork/production/api-keys'"
+get_vault_secrets "deploy/telefork/production/api-keys" "$configDir/telefork"
+
 # We add logfmt.yaml directly here because this is only needed for local development.
 # This is not meant to be used in any kubernetes setup
 info "Configuring logfmt"


### PR DESCRIPTION
… today

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

We are going to use Telefork for getting CLI telemetry. For that we need the API key we now store in vault. The API key is public, included in our other clients already.

<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-1629]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1629]: https://outreach-io.atlassian.net/browse/DTSS-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ