### PR TITLE
fix: confluence publish with chore commits

### DIFF
--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -75,5 +75,5 @@ while read -r file; do
   else
     info_sub "no space directive found, skipping ${file}"
   fi
-releaseCommits=($(git log --pretty=format:'%H' -n 2 --grep='^chore' --invert-grep))
-done < <(git diff --name-only ${releaseCommits[@]} -- '*.md')
+  readarray -t releaseCommits < <(git log --pretty=format:'%H' -n 2 --grep='^chore' --invert-grep)
+done < <(git diff --name-only "${releaseCommits[@]}" -- '*.md')

--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -75,5 +75,5 @@ while read -r file; do
   else
     info_sub "no space directive found, skipping ${file}"
   fi
-  previousTag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)" || git rev-list --max-parents=0 HEAD)
+  previousTag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)" || printf '' | git hash-object -t tree --stdin)
 done < <(git diff --name-only HEAD.."$previousTag" -- '*.md')

--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -75,4 +75,5 @@ while read -r file; do
   else
     info_sub "no space directive found, skipping ${file}"
   fi
-done < <(git diff --name-only HEAD HEAD~1 -- '*.md')
+releaseCommits=($(git log --pretty=format:'%H' -n 2 --grep='^chore' --invert-grep))
+done < <(git diff --name-only ${releaseCommits[@]} -- '*.md')

--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -75,5 +75,5 @@ while read -r file; do
   else
     info_sub "no space directive found, skipping ${file}"
   fi
-  readarray -t releaseCommits < <(git log --pretty=format:'%H' -n 2 --grep='^chore' --invert-grep)
-done < <(git diff --name-only "${releaseCommits[@]}" -- '*.md')
+  previousTag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)" || git rev-list --max-parents=0 HEAD)
+done < <(git diff --name-only HEAD.."$previousTag" -- '*.md')


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
This PR ignores any chore commits when looking for changed markdown files. 



<!--- Block(jiraPrefix) --->
## Jira ID

[[DTSS-1567]]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

Current state: when confluence-publish runs, the actual commit could have one or more chore (bot) commits infront of it. I have found cases where the commit has  a sementic-release-bot in front of it, and a sementic-release-bot and dependabot commit in front. 

This change tries to be a little smarter about which commits we compare by looking at only the non-bot commits.

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1567]: https://outreach-io.atlassian.net/browse/DTSS-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ