### PR TITLE
fix(update-pipeline): use jsonnet from gobin

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -26,7 +26,7 @@ TOOL_DEPS           := ${GO}
 
 # formatters / misc
 CLANG_FORMAT        ?= ./scripts/shell-wrapper.sh clang-format.sh
-JSONNET             ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-/cmd/jsonnet@v0.18.0
+JSONNET             ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 JSONNETFMT          ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.18.0
 LOG                 := ./scripts/shell-wrapper.sh makefile-logger.sh
 FLY                 ?= $(shell ./scripts/shell-wrapper.sh gobin.sh -p github.com/concourse/concourse/fly@cfe7746ae74247743708be6c5b2f40215030a1f1)

--- a/root/Makefile
+++ b/root/Makefile
@@ -26,8 +26,7 @@ TOOL_DEPS           := ${GO}
 
 # formatters / misc
 CLANG_FORMAT        ?= ./scripts/shell-wrapper.sh clang-format.sh
-JSONNET             ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
-JSONNETFMT          ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.18.0
+JSONNET             ?= $(CURDIR)/scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 LOG                 := ./scripts/shell-wrapper.sh makefile-logger.sh
 FLY                 ?= $(shell ./scripts/shell-wrapper.sh gobin.sh -p github.com/concourse/concourse/fly@cfe7746ae74247743708be6c5b2f40215030a1f1)
 

--- a/root/Makefile
+++ b/root/Makefile
@@ -26,7 +26,8 @@ TOOL_DEPS           := ${GO}
 
 # formatters / misc
 CLANG_FORMAT        ?= ./scripts/shell-wrapper.sh clang-format.sh
-JSONNETFMT          ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.16.0
+JSONNET             ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-/cmd/jsonnet@v0.18.0
+JSONNETFMT          ?= ./scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.18.0
 LOG                 := ./scripts/shell-wrapper.sh makefile-logger.sh
 FLY                 ?= $(shell ./scripts/shell-wrapper.sh gobin.sh -p github.com/concourse/concourse/fly@cfe7746ae74247743708be6c5b2f40215030a1f1)
 
@@ -198,7 +199,7 @@ fly-login:
 update-pipeline: fly-login
 	@echo " ===> updating concourse pipeline <==="
 	@if [[ ! -e "concourse/jsonnet-libs" ]]; then git clone https://github.com/getoutreach/jsonnet-libs concourse/jsonnet-libs; else cd concourse/jsonnet-libs && git reset --hard origin/master && git pull; fi
-	cd concourse; rm -f /tmp/pipeline.yml; jsonnet -J ./jsonnet-libs -y pipeline.jsonnet > /tmp/pipeline.yml && ${FLY} -t devs sp -c /tmp/pipeline.yml -p $(APP)
+	cd concourse; rm -f /tmp/pipeline.yml; $(JSONNET) -J ./jsonnet-libs -y pipeline.jsonnet > /tmp/pipeline.yml && ${FLY} -t devs sp -c /tmp/pipeline.yml -p $(APP)
 
 .PHONY: version
 version:


### PR DESCRIPTION
## What this PR does / why we need it

`jsonnet` should be run via gobin to ensure that it's installed/used by whatever version of Go that asdf currently has installed.

Also updated the version of `jsonnetfmt` to be consistent. Although at this point I'm not sure where that's used. `shell/fmt.sh` has its own definition:

https://github.com/getoutreach/devbase/blob/8f1d9c437371059f7f94f4904bc5253a6926c6aa/shell/fmt.sh#L15

I'd be happy to delete that line in `root/Makefile` if it's unused.