### PR TITLE
feat(test): shuffle and race tests

### DIFF
--- a/shell/test.sh
+++ b/shell/test.sh
@@ -36,6 +36,13 @@ if [[ -n $GO_TEST_TIMEOUT ]]; then
   TEST_FLAGS=${TEST_FLAGS:--timeout "$GO_TEST_TIMEOUT"}
 fi
 
+# Catches test dependencies by shuffling tests if the installed Go version supports it
+currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
+requiredver="1.17.0"
+if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$requiredver" ]]; then
+  TEST_FLAGS="$TEST_FLAGS -shuffle=on"
+fi
+
 if [[ -n $WITH_COVERAGE || -n $CI ]]; then
   COVER_FLAGS=${COVER_FLAGS:- -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out -cover}
 fi

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -44,7 +44,7 @@ if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$
 fi
 
 # Although we highly encourage all projects to run test with a check for race coditions, projects should
-# only dispable this option temporarily
+# only disable this option temporarily
 if [[ $RACE != "disabled" ]]; then
   TEST_FLAGS="$TEST_FLAGS -race"
 fi

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -43,6 +43,12 @@ if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$
   TEST_FLAGS="$TEST_FLAGS -shuffle=on"
 fi
 
+# Although we highly encourage all projects to run test with a check for race coditions, projects should
+# only dispable this option temporarily
+if [[ $RACE != "disabled" ]]; then
+  TEST_FLAGS="$TEST_FLAGS -race"
+fi
+
 if [[ -n $WITH_COVERAGE || -n $CI ]]; then
   COVER_FLAGS=${COVER_FLAGS:- -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out -cover}
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR introduces both shuffle tests (if the go version supports it) and race condition check.


<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-1369]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

Bootstrap was not the culprit of the initial issue, but to ensure that no project becomes a victim of race condition errors, we decided to add the check to all tests.

To avoid breaking a lot of projects with the new `-race` flag, this PR allows disabling the check by adding `RACE: disabled` environment variable to the `test` job in `.circle-ci/config.yml`.

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1369]: https://outreach-io.atlassian.net/browse/DTSS-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ