### PR TITLE
revert(test): shuffle and race tests

### DIFF
--- a/shell/test.sh
+++ b/shell/test.sh
@@ -36,19 +36,6 @@ if [[ -n $GO_TEST_TIMEOUT ]]; then
   TEST_FLAGS=${TEST_FLAGS:--timeout "$GO_TEST_TIMEOUT"}
 fi
 
-# Catches test dependencies by shuffling tests if the installed Go version supports it
-currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
-requiredver="1.17.0"
-if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$requiredver" ]]; then
-  TEST_FLAGS="$TEST_FLAGS -shuffle=on"
-fi
-
-# Although we highly encourage all projects to run test with a check for race coditions, projects should
-# only disable this option temporarily
-if [[ $RACE != "disabled" ]]; then
-  TEST_FLAGS="$TEST_FLAGS -race"
-fi
-
 if [[ -n $WITH_COVERAGE || -n $CI ]]; then
   COVER_FLAGS=${COVER_FLAGS:- -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out -cover}
 fi


### PR DESCRIPTION
This reverts commit 779f817413fd39ae8c75e4f8d0abab8572b2a851.

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR reverts the changes from https://github.com/getoutreach/devbase/pull/184. The original PR introduced a breaking change which should be merged in for the June 15th release.


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
