### PR TITLE
fix: too many open files for golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for guidelines on de
 
 ### Bootstrap / Stencil
 
-To test a custom build of `devbase` with bootstrap, simply modify `bootstrap.lock` to point to your branch / version. 
+To test a custom build of `devbase` with bootstrap, simply modify `bootstrap.lock` to point to your branch / version.
 
 **Example**: To use `jaredallard/feat/my-cool-feature` instead of `v1.8.0`, you'd update `versions.devbase` to the former. Full example below:
 
@@ -33,4 +33,5 @@ versions:
 
 CI will now use that branch, to use it locally re-run any `make` command. **Note**: This will not automatically update locally when the remote branch is changed, in order to do that you will need to `rm -rf .bootstrap` and re-run a `make` command. If you are testing changes to `make e2e`, you must also run
 `rm -rf ~/.outreach/.cache/gobin/binaries/$(go version | awk '{ print $3 }' | tr -d 'go')/github.com/getoutreach/devbase` before re-running a make command, in addition to `rm -rf .bootstrap`.
+
 <!--- EndBlock(overview) -->

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -26,7 +26,8 @@ fi
 
 # Use individual directories for golangci-lint cache as opposed to a mono-directory.
 # This helps with the "too many open files" error.
-mkdir -p "$HOME/.outreach/.cache/.golangci-lint" > /dev/null 2>&1
-export GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
+mkdir -p "$HOME/.outreach/.cache/.golangci-lint" >/dev/null 2>&1
+GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
+export GOLANGCI_LINT_CACHE
 
 exec "$GOBIN" "github.com/jaredallard/golangci-lint/cmd/golangci-lint@$version" "${args[@]}"

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -24,4 +24,9 @@ if grep "^\d" <<<"$version"; then
   version="v$version"
 fi
 
+# Use individual directories for golangci-lint cache as opposed to a mono-directory.
+# This helps with the "too many open files" error.
+mkdir -p "$HOME/.outreach/.cache/.golangci-lint" > /dev/null 2>&1
+export GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
+
 exec "$GOBIN" "github.com/jaredallard/golangci-lint/cmd/golangci-lint@$version" "${args[@]}"


### PR DESCRIPTION
* this is a fix that it seems has had some success from my tests. the
error will still occur the first time running in large repos such as
dsngsyncworkflow, but subsequent runs w/changed code seem to be fine.

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
