### PR TITLE
fix: handle newer commits in confluence publish

### DIFF
--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -75,5 +75,5 @@ while read -r file; do
   else
     info_sub "no space directive found, skipping ${file}"
   fi
-  previousTag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)" || printf '' | git hash-object -t tree --stdin)
+  previousTag=$(git describe --abbrev=0 --tags HEAD^ || printf '' | git hash-object -t tree --stdin)
 done < <(git diff --name-only HEAD.."$previousTag" -- '*.md')


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This fixes confluence publish to handle an additional case where there is a commit after the current tag. Some publish jobs are failing due to this.

This handles all previous cases plus the case where there was a commit after the current tag.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-1838]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-1838]: https://outreach-io.atlassian.net/browse/DTSS-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ