### PR TITLE
feat: Add 'asdf-exec.sh' and 'go.sh'

### DIFF
--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -35,4 +35,4 @@ while read -r line; do
   # https://stackoverflow.com/a/744093
 done < <(sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' "${TOOLVERSIONS}" | sed '1!G;h;$!d')
 
-asdf exec "$@"
+exec asdf exec "$@"

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -20,8 +20,8 @@ source "$SCRIPTS_DIR/lib/bootstrap.sh"
 TOOLVERSIONS="$(get_repo_directory)/.tool-versions"
 
 while read -r line; do
-  tool=$(awk '{ print $1 }' <<< "$line" | tr '[:lower:]-' '[:upper:]_')
-  version=$(awk '{ print $2 }' <<< "$line")
+  tool=$(awk '{ print $1 }' <<<"$line" | tr '[:lower:]-' '[:upper:]_')
+  version=$(awk '{ print $2 }' <<<"$line")
 
   export "ASDF_${tool}_VERSION"="${version}"
 
@@ -36,4 +36,3 @@ while read -r line; do
 done < <(sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' "${TOOLVERSIONS}" | sed '1!G;h;$!d')
 
 asdf exec "$@"
-

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -20,8 +20,8 @@ source "$SCRIPTS_DIR/lib/bootstrap.sh"
 TOOLVERSIONS="$(get_repo_directory)/.tool-versions"
 
 while read -r line; do
-  tool=$(echo "$line" | awk '{ print $1 }' | tr '[:lower:]-' '[:upper:]_')
-  version=$(echo "$line" | awk '{ print $2 }')
+  tool=$(awk '{ print $1 }' <<< "$line" | tr '[:lower:]-' '[:upper:]_')
+  version=$(awk '{ print $2 }' <<< "$line")
 
   export "ASDF_${tool}_VERSION"="${version}"
 done < <(grep -v '^#' "${TOOLVERSIONS}")

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Runs the provided tool in an `asdf exec` under an environment that respects
+# the tool versions defined in this project's `.tool-versions` file.
+#
+# This allows scripts to invoke the "right" version of a tool for the given
+# project without having to source `asdf`'s setup scripts or be in any
+# particular directory.
+#
+# The idea here is that `some_project/.bootstrap/shell/exec.sh go` will always
+# invoke the right go version for that particular `some_project`.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=./lib/bootstrap.sh
+source "$SCRIPTS_DIR/lib/bootstrap.sh"
+
+TOOLVERSIONS="$(get_repo_directory)/.tool-versions"
+
+while read -r line; do
+  tool=$(echo "$line" | awk '{ print $1 }' | tr '[:lower:]-' '[:upper:]_')
+  version=$(echo "$line" | awk '{ print $2 }')
+
+  export "ASDF_${tool}_VERSION"="${version}"
+done < <(grep -v '^#' "${TOOLVERSIONS}")
+
+asdf exec "$@"
+

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -24,7 +24,16 @@ while read -r line; do
   version=$(awk '{ print $2 }' <<< "$line")
 
   export "ASDF_${tool}_VERSION"="${version}"
-done < <(grep -v '^#' "${TOOLVERSIONS}")
+
+  # Strip comments just like `asdf` does:
+  # https://github.com/asdf-vm/asdf/blob/711ad991043a1980fa264098f29e78f2ecafd610/lib/utils.bash#L653
+  #
+  # Reverse the file because asdf (buggily? intentionally?)
+  # picks the first version it sees if there are duplicates.
+  #
+  # Uses the `sed` reverse mechanism described here for portability:
+  # https://stackoverflow.com/a/744093
+done < <(sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' "${TOOLVERSIONS}" | sed '1!G;h;$!d')
 
 asdf exec "$@"
 

--- a/shell/go.sh
+++ b/shell/go.sh
@@ -10,4 +10,4 @@ set -e
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-$SCRIPTS_DIR/asdf-exec.sh go "$@"
+"$SCRIPTS_DIR/asdf-exec.sh" go "$@"

--- a/shell/go.sh
+++ b/shell/go.sh
@@ -10,4 +10,4 @@ set -e
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-"$SCRIPTS_DIR/asdf-exec.sh" go "$@"
+exec "$SCRIPTS_DIR/asdf-exec.sh" go "$@"

--- a/shell/go.sh
+++ b/shell/go.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Parses the embedding project's `.tool-versions` file to find which is the
+# currently active version of Go, then invokes it explicitly through `asdf`.
+#
+# The idea here is that `some_project/.bootstrap/shell/go.sh` will will always
+# point to the "right" go for that particular `some_project`.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+$SCRIPTS_DIR/asdf-exec.sh go "$@"


### PR DESCRIPTION
Adds an `asdf-exec.sh` script that will `asdf exec` the given arguments
in an environment that respects the embedding project's `.tool-versions`
file.

In a perfect world, this functionality would be baked in to `asdf`
upstream.  For now we build this functionality from hacky shell scripts.
It may break in some edge case scenarios, but it should be good enough
for all the situations we're likely to encounter int he real world.

Also adds a `go.sh` that does `asdf-exec.sh go`.  This is intended to
provide compatibility for tools require us to point at the "Go
executable".
