### PR TITLE
fix: bumping clerkgen version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -10,7 +10,7 @@ delve: 1.7.3
 gotestsum: 1.7.0
 lintroller: 1.13.1
 codeowners-validator: 0.7.1
-clerkgenproto: 1.21.1
+clerkgenproto: 1.23.0
 goveralls: 0.0.11
 getoutreach/ci: v1.3.0
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Cherry picks [clerkgen version bump](https://github.com/getoutreach/devbase/commit/6fbdfbc79a8b0a41b98cdd72f14100fb9574e35c) into release branch

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
