### PR TITLE
fix: update jsonnetfmt and golangci-lint

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -12,7 +12,7 @@ source "$SCRIPTS_DIR/languages/nodejs.sh"
 source "$SCRIPTS_DIR/lib/logging.sh"
 
 # Tools
-JSONNETFMT=$("$SCRIPTS_DIR/gobin.sh" -p github.com/google/go-jsonnet/cmd/jsonnetfmt@v"$(get_application_version "jsonnetfmt")")
+JSONNETFMT=$("$SCRIPTS_DIR/gobin.sh" -p github.com/google/go-jsonnet/cmd/jsonnetfmt@"$(get_application_version "jsonnetfmt")")
 GOIMPORTS=$("$SCRIPTS_DIR/gobin.sh" -p golang.org/x/tools/cmd/goimports@v"$(get_application_version "goimports")")
 SHELLFMTPATH="$SCRIPTS_DIR/shfmt.sh"
 GOFMT="${GOFMT:-gofmt}"

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -19,15 +19,10 @@ args=("--config=${workspaceFolder}/scripts/golangci.yml" "$@" "--fast" "--allow-
 # trade memory for CPU when running the linters
 export GOGC=20
 
-version="$(get_application_version "golangci-lint")"
-if grep "^\d" <<<"$version"; then
-  version="v$version"
-fi
-
 # Use individual directories for golangci-lint cache as opposed to a mono-directory.
 # This helps with the "too many open files" error.
 mkdir -p "$HOME/.outreach/.cache/.golangci-lint" >/dev/null 2>&1
 GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
 export GOLANGCI_LINT_CACHE
 
-exec "$GOBIN" "github.com/jaredallard/golangci-lint/cmd/golangci-lint@$version" "${args[@]}"
+exec "$GOBIN" "github.com/golangci/golangci-lint/cmd/golangci-lint@v$(get_application_version "golangci-lint")" "${args[@]}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,8 +3,8 @@ shfmt: 3.4.2
 shellcheck: 0.8.0
 grpcui: 1.0.0
 # Remove once https://github.com/golangci/golangci-lint/pull/2595 merges.
-golangci-lint: jaredallard/feat/severity-extensions
-jsonnetfmt: 0.18.0
+golangci-lint: 1.46.2
+jsonnetfmt: 32b292c9cbb3411414ea7f6f11875c1a8927283c # use a tagged version whenever they release past v0.18.0 (https://github.com/google/go-jsonnet)
 goimports: 0.1.10
 delve: 1.7.3
 gotestsum: 1.7.0


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
* jsonnetfmt update fixes 1.18 errors because of an outdated x/sys package
* unforking and updating golangci-lint to get off of jareds branch - we did that initially because we couldn't update golangci-lint outside of a breaking change release. we're just gonna start updating this linter every breaking change release
<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
