### PR TITLE
fix: Path to node grpc client tests

### DIFF
--- a/orbs/shared/jobs/test_node_client.yaml
+++ b/orbs/shared/jobs/test_node_client.yaml
@@ -12,4 +12,4 @@ steps:
   - run:
       name: Test Node gRPC client
       working_directory: api/clients/node/
-      command: cd *-client; yarn --frozen-lockfile test-ci
+      command: yarn --frozen-lockfile test-ci


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
The  path generated by stencil-golang is different now.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-2004]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-2004]: https://outreach-io.atlassian.net/browse/DTSS-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ