### PR TITLE
feat!: flagship -> outreach, read vault addr from box config

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -211,6 +211,7 @@ func main() { //nolint:funlen,gocyclo
 
 	conf, err := box.LoadBox()
 	if err != nil {
+		//nolint:exitAfterDefer // Why: We're OK with this.
 		log.Fatal().Err(err).Msg("Failed to load box config")
 	}
 

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -360,7 +360,7 @@ func main() { //nolint:funlen,gocyclo
 			async.Sleep(ctx, time.Second*1)
 		}
 
-		client, closer, err := localizer.Connect(ctx, grpc.WithBlock(), insecure.NewCredentials())
+		client, closer, err := localizer.Connect(ctx, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to connect to localizer server to kill running instance")
 		}

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/getoutreach/gobox/pkg/async"
+	"github.com/getoutreach/gobox/pkg/box"
 	"github.com/getoutreach/gobox/pkg/sshhelper"
 	localizerapi "github.com/getoutreach/localizer/api"
 	"github.com/getoutreach/localizer/pkg/localizer"
@@ -22,12 +23,14 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v2"
 )
 
 var virtualDeps = map[string][]string{
 	// TODO(jaredallard): [DT-510] Store flagship dependencies in the outreach repository
-	"flagship": {
+	// This will be removed once reactor is dead.
+	"outreach": {
 		"outreach-templating-service",
 		"olis",
 		"mint",
@@ -206,14 +209,24 @@ func main() { //nolint:funlen,gocyclo
 
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
+	conf, err := box.LoadBox()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load box config")
+	}
+
+	if conf.DeveloperEnvironmentConfig.VaultConfig.Enabled {
+		log.Info().Str("vault-addr", conf.DeveloperEnvironmentConfig.VaultConfig.Address).Msg("Set Vault Address")
+		os.Setenv("VAULT_ADDR", conf.DeveloperEnvironmentConfig.VaultConfig.Address)
+	}
+
 	// runEndToEndTests is a flag that denotes whether or not this needs to actually
 	// run or not based off of the filepath.Walk function immediately proceeding.
 	var runEndToEndTests bool
 
-	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if runEndToEndTests {
 			// No need to keep walking through files if we've already found one file
-			// that requries e2e tests.
+			// that requires e2e tests.
 			return nil
 		}
 
@@ -268,7 +281,13 @@ func main() { //nolint:funlen,gocyclo
 	// TODO(jaredallard): outreach specific code
 	target := "base"
 	for _, d := range deps {
+		// Error on flagship dependency. This can be removed later as this was a breaking change
+		// and is just a nice to have.
 		if d == "flagship" {
+			log.Fatal().Msg("flagship has been replaced by outreach, please update your dependency list")
+		}
+
+		if d == "outreach" {
 			target = "flagship"
 			break
 		}
@@ -316,7 +335,7 @@ func main() { //nolint:funlen,gocyclo
 	}
 
 	if !localizer.IsRunning() {
-		// Preemptively ask for sudo to prevent input mangaling with o.LocalApps
+		// Preemptively ask for sudo to prevent input mangling with o.LocalApps
 		log.Info().Msg("You may get a sudo prompt so localizer can create tunnels")
 		cmd = exec.CommandContext(ctx, "sudo", "true")
 		cmd.Stderr = os.Stderr
@@ -341,9 +360,7 @@ func main() { //nolint:funlen,gocyclo
 			async.Sleep(ctx, time.Second*1)
 		}
 
-		// TODO(jaredallard): Move to insecure.NewCredentials()
-		//nolint:staticcheck // Why: See above
-		client, closer, err := localizer.Connect(ctx, grpc.WithBlock(), grpc.WithInsecure())
+		client, closer, err := localizer.Connect(ctx, grpc.WithBlock(), insecure.NewCredentials())
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to connect to localizer server to kill running instance")
 		}
@@ -378,8 +395,7 @@ func main() { //nolint:funlen,gocyclo
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
-	err = cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		log.Fatal().Err(err).Msg("E2E tests failed, or failed to run")
 	}
 }

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -211,7 +211,7 @@ func main() { //nolint:funlen,gocyclo
 
 	conf, err := box.LoadBox()
 	if err != nil {
-		//nolint:exitAfterDefer // Why: We're OK with this.
+		//nolint:gocritic // Why: We're OK with this.
 		log.Fatal().Err(err).Msg("Failed to load box config")
 	}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR moves us from using `flagship` as the `outreach` dependency name to `outreach` to match our deployment name. We'll be able to remove the flagship dependency list once reactor is dead as well.

This is a BREAKING CHANGE because users will need to change their `flagship` dependency to `outreach.

A side change here is we now also read `VAULT_ADDR` from the box config. This may be slightly adjusted soon to allow setting a vault address just for CI

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-2007]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-2007]: https://outreach-io.atlassian.net/browse/DTSS-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ