### PR TITLE
fix(publish): only push to github package

### DIFF
--- a/shell/ruby/publish.sh
+++ b/shell/ruby/publish.sh
@@ -39,12 +39,8 @@ fi
 
 pushd "$clientDir" >/dev/null || exit 1
 info "Pushing package to Github Packages"
-# TODO: Read the org from box when this is in CI.
+# TODO(jaredallard): Read the org from box when this is in CI.
 gem push --key github \
   --host https://rubygems.pkg.github.com/getoutreach \
   "$gemFile"
-
-warn "DEPRECATED: Pushing to packagecloud, if this is being used please migrate to Github Packages"
-gem install package_cloud
-package_cloud push outreach/rubygems "$gemFile"
 popd >/dev/null || exit 1


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

We no longer push to package cloud for Ruby packages. This has been deprecated for over a year and currently has broken.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
