### PR TITLE
fix: generate protobuf TS code for grpc properly

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -164,7 +164,7 @@ if has_grpc_client "node"; then
   ts_args=("${default_args[@]}")
   ts_args+=(
     --plugin=protoc-gen-ts="$(which protoc-gen-ts)"
-    --ts_out="$(get_repo_directory)/api/clients/node/src/grpc"
+    --ts_out=grpc_js:"$(get_repo_directory)/api/clients/node/src/grpc"
     --proto_path "$(get_repo_directory)/api"
   )
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Protoc is currently creating wrong imports for grpc package:

```
-import * as grpc from "@grpc/grpc-js";
+import * as grpc from "grpc";
```

<!--- Block(jiraPrefix) --->

## Jira ID

[RMS-743]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[RMS-743]: https://outreach-io.atlassian.net/browse/RMS-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ