### PR TITLE
feat: enable e2e job to have resource_class param

### DIFF
--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -8,12 +8,16 @@ parameters:
     description: Use devenv release candidate to provision the test cluster.
     type: boolean
     default: false
+  resource_class:
+    description: The resource class to use for the e2e tests
+    type: string
+    default: "large"
 executor:
   name: testbed-machine
 environment:
   VAULT_ADDR: << parameters.vault_address >>
   DEVENV_PRE_RELEASE: << parameters.devenv_pre_release >>
-resource_class: large
+resource_class: << parameters.resource_class >>
 steps:
   - setup_environment:
       machine: true


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Enables the ability to specify the resource class for e2e test job

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
