### PR TITLE
fix: QSS-1192 Do not `fmt` anything in `.git`

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -41,6 +41,9 @@ for_all_files() {
 
     # Skip node modules
     "*node_modules*"
+
+    # Skip git internals
+    "./.git"
   )
   local glob="$1"
   shift


### PR DESCRIPTION
[QSS-1192](https://outreach-io.atlassian.net/browse/QSS-1192)

Adds `.git` to the set of excluded paths for `make fmt`.

While working on QSS-1192, I encountered PR failures that should have
been fixable with `make fmt`.  When I ran `make fmt`, this happened:
```
$ make fmt
 :: Running Formatters
    -> goimports
./.git/logs/refs/heads/qss_1152_shipper_metrics.go:1:63: expected ';', found d2c8185d8f061a1c9bf6e2748ec6c4fbf33ca65a
./.git/logs/refs/heads/qss_1152_shipper_metrics.go:1:138: illegal character U+0040 '@'
./.git/logs/refs/heads/qss_1152_shipper_metrics.go:2:117: illegal character U+0040 '@'
./.git/logs/refs/heads/qss_1152_shipper_metrics.go:3:117: illegal character U+0040 '@'
./.git/logs/refs/heads/qss_1152_shipper_metrics.go:4:2: expected '}', found 'EOF'
```

That's concerning.  I don't think we should be formatting any of those
files.

It also exited with a non-zero exit status, preventing any of the other
formatters form running.

This small change to ignore the `.git` path should fix all of this.