### PR TITLE
fix: match source relative behavior from original docker-protoc impl

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -138,7 +138,7 @@ if has_feature "validation"; then
 
   go_args+=(
     --plugin=protoc-gen-validate="$protoc_gen_validate"
-    --validate_out=lang=go,paths=source_relative:"$(get_repo_directory)/api"
+    "--validate_out=lang=go,paths=source_relative:$(get_repo_directory)/api"
   )
 fi
 

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -138,7 +138,7 @@ if has_feature "validation"; then
 
   go_args+=(
     --plugin=protoc-gen-validate="$protoc_gen_validate"
-    --validate_out=lang=go:"$(get_repo_directory)/api"
+    --validate_out=lang=go,paths=source_relative:"$(get_repo_directory)/api"
   )
 fi
 

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -52,14 +52,6 @@ info "Ensuring protoc imports are avaliable locally"
 
 imports=$(
   get_list "go-protoc-imports"
-  if has_feature "validation"; then
-    cat <<EOF
-        {
-           "module":  "github.com/envoyproxy/protoc-gen-validate@v$(get_application_version "protoc-gen-validate")",
-           "path": ""
-        }
-EOF
-  fi
 )
 
 default_args=()


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

* docker-protoc behavior can be seen here:
https://github.com/namely/docker-protoc/blob/master/all/entrypoint.sh#L149
https://github.com/namely/docker-protoc/blob/master/all/entrypoint.sh#L392
* original implementation of this script using
  `--validator-source-relative`
  https://github.com/getoutreach/devbase/blob/d925a545bf978ebb98174edb25d4828cac5c381c/shell/protoc.sh#L82

<!--- Block(custom) -->

<!--- EndBlock(custom) -->