### PR TITLE
fix: add region to build-jsonnet kubecfg command

### DIFF
--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -25,6 +25,7 @@ kubecfg \
   -n "$namespace" \
   --context "dev-environment" "$action" "$(get_repo_directory)/deployments/$appName/$appName.jsonnet" \
   -V cluster="development.us-west-2" \
+  -V region="us-west-2" \
   -V namespace="$namespace" \
   -V environment="$environment" \
   -V version="$version" \


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Adds a region variable to be passed into the kubecfg command. 
The reason for this is that trying to reference `app.region` in an overrides jsonnet file is erroring on e2e tests in circleci.
<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
