### PR TITLE
fix: correctly detect e2e tests in devspace

### DIFF
--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -67,9 +67,9 @@ This is how you can work with it:
 if [[ -z $DEV_CONTAINER_LOGFILE ]] || [[ $DEVENV_DEV_TERMINAL == "true" ]]; then
   echo -e "$BANNER"
   bash
-elif [[ -z $E2E ]]; then
+elif [[ -n $E2E ]]; then
   git init >/dev/null 2>&1
-  TEST_TAGS=or_test,or_e2e make test | tee -a "${DEV_CONTAINER_LOGFILE:-/tmp/app.log}"
+  TEST_TAGS=or_test,or_e2e make test | tee -ai "${DEV_CONTAINER_LOGFILE:-/tmp/app.log}"
   exit "${PIPESTATUS[0]}"
 else
   make dev


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Uses the correct bash flag to test for e2e tests.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
