### PR TITLE
fix: be tolerant to file with not compatible build tags

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -324,8 +324,13 @@ func shouldRunE2ETests() (bool, error) {
 			return nil
 		}
 
-		pkg, err := build.Default.Import(path, filepath.Base(path), build.ImportComment)
+		pkg, err := build.Import(path, filepath.Base(path), build.ImportComment)
 		if err != nil {
+			// Skip files that are not compatible with current build tags like or_int
+			var noGoErr *build.NoGoError
+			if errors.As(err, &noGoErr) {
+				return nil
+			}
 			return errors.Wrap(err, "import")
 		}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

**What this PR does / why we need it:**
make e2e is failing when there are files with only build tag or_int in the folder with err: "import: no buildable Go source files in ..."
JIRA ID: DT-00
<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
