### PR TITLE
fix: e2e runner skip submodules

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"go/build"
 	"os"
 	"os/exec"
@@ -315,6 +316,8 @@ func shouldRunE2ETests() (bool, error) {
 		}
 
 		if info.IsDir() && path != "." {
+			fmt.Println("is dir", path)
+
 			// Skip submodule directories.
 			if hasGitFolder, err := os.Stat(filepath.Join(path, ".git")); err == nil {
 				if hasGitFolder.IsDir() {

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -314,9 +314,9 @@ func shouldRunE2ETests() (bool, error) {
 			return err
 		}
 
-		if info.IsDir() && info.Name() != "." {
+		if info.IsDir() && path != "." {
 			// Skip submodule directories.
-			if hasGitFolder, err := os.Stat(filepath.Join(info.Name(), ".git")); err == nil {
+			if hasGitFolder, err := os.Stat(filepath.Join(path, ".git")); err == nil {
 				if hasGitFolder.IsDir() {
 					return filepath.SkipDir
 				}

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -314,6 +314,15 @@ func shouldRunE2ETests() (bool, error) {
 			return err
 		}
 
+		if info.IsDir() && info.Name() != "." {
+			// Skip submodule directories.
+			if hasGitFolder, err := os.Stat(filepath.Join(info.Name(), ".git")); err == nil {
+				if hasGitFolder.IsDir() {
+					return filepath.SkipDir
+				}
+			}
+		}
+
 		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 			// Skip symlinks.
 			return nil


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
* attempt to skip submodule directories when determining whether or not
  to run e2e tests.
<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
