### PR TITLE
fix: bump terraform

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-terraform: 0.13.5
+terraform: 1.2.6
 shfmt: 3.4.2
 shellcheck: 0.8.0
 grpcui: 1.0.0


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

The older version of terraform does not support Go 1.18. With some service like https://github.com/getoutreach/stork that need to depend on stencil, we have to upgrade them to 1.18 now.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
