### PR TITLE
fix: misc RMS fixes, localizer cleanup, jq error

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -16,7 +16,6 @@ import (
 	"github.com/getoutreach/gobox/pkg/sshhelper"
 	localizerapi "github.com/getoutreach/localizer/api"
 	"github.com/getoutreach/localizer/pkg/localizer"
-	"github.com/getoutreach/orgapi/api"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/storage/memory"
@@ -258,7 +257,7 @@ func ensureRunningLocalizerWorks(ctx context.Context) error {
 		defer closer()
 
 		// Responding to pings, return nil
-		if _, err := client.Ping(ctx, &api.PingRequest{}); err == nil {
+		if _, err := client.Ping(ctx, &localizerapi.PingRequest{}); err == nil {
 			return nil
 		}
 	}

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -263,6 +263,7 @@ func ensureRunningLocalizerWorks(ctx context.Context) error {
 	}
 
 	// not responding to pings, or failed to connect, remove the socket
+	//nolint:gosec // Why: We're OK with this. It's a constant.
 	return osStdInOutErr(exec.CommandContext(ctx, "sudo", "rm", "-f", localizer.Socket)).Run()
 }
 

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -264,7 +264,7 @@ func ensureRunningLocalizerWorks(ctx context.Context) error {
 
 	// not responding to pings, or failed to connect, remove the socket
 	//nolint:gosec // Why: We're OK with this. It's a constant.
-	return osStdInOutErr(exec.CommandContext(ctx, "sudo", "rm", "-f", localizer.Socket)).Run()
+	return osStdInOutErr(exec.Command("sudo", "rm", "-f", localizer.Socket)).Run()
 }
 
 func runLocalizer(ctx context.Context) (cleanup func(), err error) {

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
+	google.golang.org/genproto v0.0.0-20220111164026-67b88f271998 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1363,8 +1363,9 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
-google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 h1:NHN4wOCScVzKhPenJ2dt+BTs3X/XkBVI/Rh4iDt55T8=
 google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
+google.golang.org/genproto v0.0.0-20220111164026-67b88f271998 h1:g/x+MYjJYDEP3OBCYYmwIbt4x6k3gryb+ohyOR7PXfI=
+google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -80,7 +80,7 @@ info "Generating local config/secrets in '$configDir'"
 envsubst="$("$DIR/gobin.sh" -p github.com/a8m/envsubst/cmd/envsubst@v1.2.0)"
 
 info "Fetching Configuration File(s)"
-DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/deploy-to-dev.sh" show | yq -r 'select(.kind == "ConfigMap") | .data | to_entries[] | [.key, .value] | @tsv' | "$envsubst" |
+DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "ConfigMap") | .data | to_entries[] | [.key, .value] | @tsv' | "$envsubst" |
   while IFS=$'\t' read -r configFile configData; do
 
     saveFile="$configDir/$configFile"
@@ -101,9 +101,7 @@ DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/deploy-to-dev.sh" show | yq -r
 # /run/secrets/outreach.io/<basename vaultKey>/<vault subKey>
 info "Fetching Secret(s) from Vault"
 
-# DEVENV_VERSION is set to get around the deprecation for now. The script is deprecated for normal users
-# but is still needed for rendering manifests.
-DEVENV_VERSION="xyz" "$DIR/deploy-to-dev.sh" show | yq -r 'select(.kind == "VaultSecret") | .spec.path' |
+"$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "VaultSecret") | .spec.path' |
   while IFS=$'\n' read -r vaultKey; do
     info_sub "$vaultKey"
     get_vault_secrets "$vaultKey" "$HOME/.outreach/$APPNAME"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes a few misc RMS team issues:

 * Localizer wouldn't always be killed when `/var/run/localizer.sock` was left over from a previous process, this is now detected and cleaned up.
 * `devconfig.sh` would sometimes output a false `jq` error, this was because `deploy-to-dev.sh` had more output added to it. Now we use the dedicated `build-jsonnet.sh` script instead which only returns the YAML.


<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
