### PR TITLE
feat: configurable no output timeout for e2e job

### DIFF
--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The resource class to use for the e2e tests
     type: string
     default: "large"
+  no_output_timeout:
+    description: The timeout that gets applied when CircleCI receives no output during the running of e2e tests.
+    type: string
+    default: 10m
 executor:
   name: testbed-machine
 environment:
@@ -25,6 +29,7 @@ steps:
   - run:
       name: Run E2E Tests
       command: KUBECONFIG="$HOME/.outreach/kubeconfig.yaml" make e2e
+      no_output_timeout: << parameters.no_output_timeout >>
   - run:
       name: Upload Code Coverage
       command: ./scripts/shell-wrapper.sh ci/testing/coveralls.sh e2e


### PR DESCRIPTION
* adds a way to configure the no_output_timeout for the actual step
  that runs e2e for the e2e job

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it



<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
