### PR TITLE
feat(golangci-lint): use asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -8,9 +8,7 @@ protoc 3.19.1
 # CAREFUL with this. If you override a standard version you are
 # reducing compatibility guarantees.
 ###Block(toolver)
-
 # The below tools are used by all repositories when using devbase
 mage 1.13.0
 golangci-lint 1.49.0
-
 ###EndBlock(toolver)

--- a/.tool-versions
+++ b/.tool-versions
@@ -8,5 +8,9 @@ protoc 3.19.1
 # CAREFUL with this. If you override a standard version you are
 # reducing compatibility guarantees.
 ###Block(toolver)
+
+# The below tools are used by all repositories when using devbase
 mage 1.13.0
+golangci-lint 1.49.0
+
 ###EndBlock(toolver)

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -21,7 +21,15 @@ export GOGC=20
 # Use individual directories for golangci-lint cache as opposed to a mono-directory.
 # This helps with the "too many open files" error.
 mkdir -p "$HOME/.outreach/.cache/.golangci-lint" >/dev/null 2>&1
-GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
-export GOLANGCI_LINT_CACHE
+
+# Why: We're OK with masking the return value
+# shellcheck disable=SC2155
+export GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
+
+# Ensure we're using the correct version of golangci-lint
+#
+# Why: We're OK with masking the return value
+# shellcheck disable=SC2155
+export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$(get_repo_directory)/.bootstrap/.tool-versions"
 
 exec golangci-lint "${args[@]}"

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -4,7 +4,6 @@
 # with your editor.
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-GOBIN="$DIR/gobin.sh"
 
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
@@ -25,4 +24,4 @@ mkdir -p "$HOME/.outreach/.cache/.golangci-lint" >/dev/null 2>&1
 GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
 export GOLANGCI_LINT_CACHE
 
-exec "$GOBIN" "github.com/golangci/golangci-lint/cmd/golangci-lint@v$(get_application_version "golangci-lint")" "${args[@]}"
+exec golangci-lint "${args[@]}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,8 +1,6 @@
 shfmt: 3.4.2
 shellcheck: 0.8.0
 grpcui: 1.0.0
-# Remove once https://github.com/golangci/golangci-lint/pull/2595 merges.
-golangci-lint: 1.46.2
 jsonnetfmt: 4906958414ed9617e3fe5acac5752f6f8426551c # use a tagged version whenever they release past v0.18.0 (https://github.com/google/go-jsonnet)
 goimports: 0.1.10
 delve: 1.7.3

--- a/versions.yaml
+++ b/versions.yaml
@@ -5,7 +5,7 @@ jsonnetfmt: 4906958414ed9617e3fe5acac5752f6f8426551c # use a tagged version when
 goimports: 0.1.10
 delve: 1.7.3
 gotestsum: 1.7.0
-lintroller: 1.13.1
+lintroller: 1.14.1
 codeowners-validator: 0.7.1
 clerkgenproto: 1.25.3
 goveralls: 0.0.11


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR moves us to use asdf for `golangci-lint`, which is marginally helpful for Go upgrades (e.g. 1.19) as they tend to use newer Go versions then we do, which prevents us from upgrading across the board because gobin builds them with the host Go version.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
