### PR TITLE
fix(build): skip gobuild when no cmd directory exists

### DIFF
--- a/root/Magefile.go
+++ b/root/Magefile.go
@@ -33,6 +33,12 @@ func Gobuild(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	if _, err := os.Stat("cmd"); os.IsNotExist(err) {
+		log.Warn().Msg("This repository produces no artifacts (no 'cmd' directory found)")
+		return nil
+	}
+
 	buildDir := filepath.Join(cwd, "bin")
 
 	honeycombKey, err := readSecret(ctx, "honeycomb/apiKey")


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR unbreaks `make build` on repositories with no artifacts, where CI will attempt to call `make build` (e.g. for custom `make build` additions)

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
