### PR TITLE
fix(asdf): if plugins list fails, empty output

### DIFF
--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -3,7 +3,7 @@
 
 # asdf_plugins_list stores a list of all asdf plugins
 # this is done to speed up the plugin install
-asdf_plugins_list=$(asdf plugin list 2>/dev/null)
+asdf_plugins_list=$(asdf plugin list 2>/dev/null || echo "")
 
 # read_all_asdf_tool_versions combines all .tool-versions found in this directory
 # and the child directories minus node_modules and vendor.


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

When we first install `asdf`, we have no plugins, so... it errors when we try to list plugins. Nice.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2808]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ