### PR TITLE
fix(asdf): regenerate plugins list caching on plugin-add

### DIFF
--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -3,7 +3,12 @@
 
 # asdf_plugins_list stores a list of all asdf plugins
 # this is done to speed up the plugin install
-asdf_plugins_list=$(asdf plugin list 2>/dev/null || echo "")
+asdf_plugins_list=""
+
+# asdf_plugins_list_regenerate regenerates the list of plugins
+asdf_plugins_list_regenerate() {
+  asdf_plugins_list=$(asdf plugin list 2>/dev/null || echo "")
+}
 
 # read_all_asdf_tool_versions combines all .tool-versions found in this directory
 # and the child directories minus node_modules and vendor.
@@ -59,4 +64,5 @@ asdf_plugin_install() {
   fi
 
   asdf plugin-add "$name"
+  asdf_plugins_list_regenerate
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This pr fixes the asdf plugin list logic, plugin-add would be ran but the list wouldn't be updated, so the NOOP logic wouldn't trigger. Now, we regenerate after plugin-add

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2808]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ