### PR TITLE
fix: use stencil arguments for looking up keys

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -87,7 +87,7 @@ for ext in "yaml" "yml" "json" "md"; do
   for_all_files '*.'${ext} "node_modules/.bin/prettier" --write --loglevel warn
 done
 
-if has_feature "grpc"; then
+if has_service_activity "grpc"; then
   if has_grpc_client "node"; then
     nodeSourceDir="$(pwd)/api/clients/node"
     pushd "$nodeSourceDir" >/dev/null 2>&1 || exit 1
@@ -102,7 +102,7 @@ if has_feature "grpc"; then
   fi
 fi
 
-if ! has_feature "library"; then
+if has_feature "service"; then
   if [[ -e deployments ]] && [[ -e monitoring ]]; then
     info_sub "terraform fmt (.tf/.tfvars)"
     for tfdir in deployments monitoring; do

--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -53,7 +53,7 @@ get_application_version() {
 has_feature() {
   local feat="$1"
 
-  val=$(yq -r ".[\"$feat\"]" <"$(get_service_yaml)")
+  val=$(yq -r ".arguments[\"$feat\"]" <"$(get_service_yaml)")
 
   if [[ $val == "true" ]]; then
     return 0
@@ -84,21 +84,21 @@ has_resource() {
 get_resource_version() {
   local name="$1"
 
-  if [[ "$(yq -r ".resources[\"$name\"]" <"$(get_service_yaml)")" == "null" ]]; then
+  if [[ "$(yq -r ".arguments.resources[\"$name\"]" <"$(get_service_yaml)")" == "null" ]]; then
     echo ""
   else
-    yq -r ".resources[\"$name\"]" <"$(get_service_yaml)"
+    yq -r ".arguments.resources[\"$name\"]" <"$(get_service_yaml)"
   fi
 }
 
 has_grpc_client() {
   local name="$1"
 
-  if [[ "$(yq -r '.grpcClients' <"$(get_service_yaml)")" == "null" ]]; then
+  if [[ "$(yq -r '.arguments.grpcClients' <"$(get_service_yaml)")" == "null" ]]; then
     return 1
   fi
 
-  if [[ -n "$(yq -r ".grpcClients[] | select(. == \"$name\")" <"$(get_service_yaml)")" ]]; then
+  if [[ -n "$(yq -r ".arguments.grpcClients[] | select(. == \"$name\")" <"$(get_service_yaml)")" ]]; then
     return 0
   fi
 
@@ -108,19 +108,19 @@ has_grpc_client() {
 get_list() {
   local name="$1"
 
-  if [[ "$(yq -rc ".\"$name\"" <"$(get_service_yaml)")" == "null" ]]; then
+  if [[ "$(yq -rc ".arguments.\"$name\"" <"$(get_service_yaml)")" == "null" ]]; then
     echo ""
   else
-    yq -rc ".\"$name\"[]" <"$(get_service_yaml)"
+    yq -rc ".arguments.\"$name\"[]" <"$(get_service_yaml)"
   fi
 }
 
 get_keys() {
   local name="$1"
 
-  if [[ "$(yq -r ".\"$name\"" <"$(get_service_yaml)")" == "null" ]]; then
+  if [[ "$(yq -r ".arguments.\"$name\"" <"$(get_service_yaml)")" == "null" ]]; then
     echo ""
   else
-    yq -r ".\"$name\" | keys[]" <"$(get_service_yaml)"
+    yq -r ".arguments.\"$name\" | keys[]" <"$(get_service_yaml)"
   fi
 }

--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -105,6 +105,20 @@ has_grpc_client() {
   return 1
 }
 
+has_service_activity() {
+  local name="$1"
+
+  if [[ "$(yq -r '.arguments.serviceActivities' <"$(get_service_yaml)")" == "null" ]]; then
+    return 1
+  fi
+
+  if [[ -n "$(yq -r ".arguments.serviceActivities[] | select(. == \"$name\")" <"$(get_service_yaml)")" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 get_list() {
   local name="$1"
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Switches `bootstrap.sh` to use `arguments` prefix when looking up keys in `services.yaml`.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
