### PR TITLE
docs(rfc): add declarative configuration rfc

### DIFF
--- a/rfcs/0-template.md
+++ b/rfcs/0-template.md
@@ -1,0 +1,43 @@
+# Declarative Configuration
+
+<!-- Add more dates here post-merge -->
+
+| Date       | Status   |
+|------------|----------|
+| YYYY-MM-DD | Draft    |
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Implementation Details](#implementation-details)
+- [Test Plan](#testing-and-release-plan)
+<!-- /toc -->
+
+
+## Summary
+
+A high level summary, without going into to much technical details, about what this RFC is about.
+
+## Motiviation
+
+Detail why this proposal is needed, without talking about the goals/non-goals and implementation details. Ideally this is just what is causing you to want to do this work. What pain-points are you trying to solve?
+
+### Goals
+
+Add a check list of what the goals of this proposal is, ideally this will help clarify what this is meant to do.
+
+### Non-goals
+
+Add a check list of things this proposal does _not_ intend to solve.
+
+## Implementation Details
+
+Add implementation specific details, the "how" of the proposal.
+
+## Testing and Release Plan
+
+Write details for how you plan to test this, and what the plan is for releasing. Think about how consumers will use this, and consider documenting that here.

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -20,21 +20,23 @@ This proposal replaces environment variable based configuration being used in Ma
 
 ## Motiviation
 
-As we've been writing `devbase`, and other tooling, we've identified that trying to codify all options for tooling to environment variables, bespoke configuration files, and other obscure means has made it difficult for us to provide options and maintain a common set of toolign.
+As we've been writing `devbase`, and other tooling that uses it, we've identified that the current practice of environment variable based configuration as well as opinionated and unchangeable defaults is not flexible enough for using this tooling both outside of stencil-base (where it is primarily used today) and giving our users the flexibility to easily make minor behaviour changes. This has, ultimately created two pain points:
 
-This, combined with a lack of documentation into all of these options, has laregely made `devbase` unconsumable outside of bootstrap/stencil. Thinking of `devbase` as it's own framework to build software makes it more usable in non-stencil projects (like we do already today w/ submodules)
+ * Documentation is hard to write and not easily discoverable
+ * Finding configuration consumption, and configurable areas is difficult
+ * Using `devbase` outside of `stencil-base` projects is not easy (must use sub-modules, and even then it's hard to "plug and play") 
+
 ### Goals
 
- - Documentation for all options in configuration file(s)
+ - All configuration should be written as go structs (as we intend to only write new targets in), and have godoc compatible documentation on each exported field along with examples as needed.
  - Standard location for all configuration for tooling provided by devbase, et. al
- - Documentation mapping 1:1 with Magefile target, with framework to consume/declare it
  - Documentation on how to write Magefile targets, if the framework docs aren't self-explanatory enough
- - Support for usage outside of stencil-base, et. al
+ - Ensure that all targets are "plug-and-play" compatible (e.g. usable by themselves), they shouldn't require stencil modules to be used, and if they do require certain options to work "out of the box" they should be sane defaults and well documented (as per the above goals)
  - Not breaking, while we could do a lot more if we did a breaking release, breaking _all_ of the existing releasing tooling isn't optimal
 
 ### Non-goals
 
- - Expose new functionality. This would be nice to have, but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
+ - Expose new functionality, this would be nice to have but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
  - Migrating `Makefile` to `Magefile`, while it'd be nice to migrate all of them over, that's also an amount of work to do. While moving to `Magefile` would be good, we shouldn't try to move everything to Go at the same time (TL;DR: Wrap shell were needed).
 
 ## Proposal
@@ -79,7 +81,7 @@ The following targets will be available/configurable day one:
  - `e2e`
  - `docker` (includes: `build`, `publish`)
 
-The rest will still be available for compat, but unconfigurable, e.g. `gobuild` will still build go but will not work for non-go repos.
+The rest will still be available for compatibility, but unconfigurable, e.g. `gobuild` will still build go but will not work for non-go repos.
 
 See [Examples](#examples) for an idea of what options will be available/an idea of some of the steps.
 

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -34,7 +34,7 @@ This, combined with a lack of documentation into all of these options, has lareg
 
 ### Non-goals
 
- - Expose new functionality, this would be nice to have but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
+ - Expose new functionality. This would be nice to have, but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
  - Migrating `Makefile` to `Magefile`, while it'd be nice to migrate all of them over, that's also an amount of work to do. While moving to `Magefile` would be good, we shouldn't try to move everything to Go at the same time. (TL;DR: Wrap shell were needed)
 
 ## Proposal

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -1,5 +1,9 @@
 # Declarative Configuration
 
+| Date       | Status   |
+|------------|----------|
+| 2022-09-26 | Draft    |
+
 ## Table of Contents
 
 <!-- toc -->
@@ -7,10 +11,13 @@
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-  - [Implementation Details](#implementation-details)
-  - [Configuration example](#examples)
-- [Test Plan](#testrelease-plan)
+- [Implementation Details](#implementation-details)
+  - [Repository Configuration](#repository-configuration)
+  - [Magefile Targets Implementation Details](#magefile-targets-implementation-details)
+  - [Magefile Targets Available Day One](#magefile-targets-available-day-one)
+  - [Testing Framework](#testing-framework)
+  - [Configuration Examples](#configuration-examples)
+- [Test Plan](#testing-and-release-plan)
 <!-- /toc -->
 
 
@@ -39,13 +46,9 @@ As we've been writing `devbase`, and other tooling that uses it, we've identifie
  - Expose new functionality, this would be nice to have but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
  - Migrating `Makefile` to `Magefile`, while it'd be nice to migrate all of them over, that's also an amount of work to do. While moving to `Magefile` would be good, we shouldn't try to move everything to Go at the same time (TL;DR: Wrap shell were needed).
 
-## Proposal
+## Implementation Details
 
-The high level proposal here is generally covered in the [Summary](#summary) and [Moviation](#motiviation) sections.
-
-### Implementation Details
-
-#### Repository Configuration
+### Repository Configuration
 
 Configuration would live in the root of repository consuming `devbase`, in `.devbase`.
 
@@ -60,11 +63,11 @@ docker.yaml
 
 **Note**: Configuration should be able to be shared between targets (e.g. `docker-build` and `docker-push` today largely share `docker.yaml`), but this should be limited to only being able to consume the same configuration struct, not two different configs in one. The idea is to allow _closely_ related targets to consume the same configuration only. Complicated things like target a and target b sharing two different configs in a file is expressly what this system is _not_ trying to support.
 
-#### Magefile Targets Implementation Details
+### Magefile Targets Implementation Details
 
 Each magefile target that consumes this configuration will live inside of the `devbase` repository in the `targets/<targetName>` package, which will be pulled in by `root/mage.go`. The reasoning for a package per target is to make it easier to test these in isolation, as well as (generated) documentation to be localized to the packages (targets) themselves. A library will be provided at `pkg/targets`, which will provide functionality to read configuration and other shared functions between targets.
 
-#### Magefile Targets Available Day One
+### Magefile Targets Available Day One
 
 The following targets will be available/configurable day one:
 
@@ -81,11 +84,11 @@ The rest will still be available for compatibility, but unconfigurable, e.g. `go
 
 See [Examples](#examples) for an idea of what options will be available/an idea of some of the steps.
 
-#### Testing Framework
+### Testing Framework
 
 Testing would be done via Go Testing, enabling us to easily write unit tests. Integration tests would, unforuantely, still need to be figured out as they rely on being ran in macOS/Linux in a predictable fashion
 
-### Examples
+### Configuration Examples
 
 Below are example configuration objects that would be exposed, note this is not all-inclusive and is purposefully not fully spec'd out to allow for changes during implementation.
 
@@ -119,7 +122,6 @@ image_name:
     - linux/amd64
  ```
 
-## Test/Release Plan
+## Testing and Release Plan
 
 The test plan for this is to ensure that each target has unit and, where possible, integration tests. Releasing would follow the standard DT team releasing process, which is to be released in the next release window, while being put on the `rc` channel to be consumed by Outreach internally first.
-

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -49,7 +49,7 @@ The high level proposal here is generally covered in the [Summary](#summary) and
 
 Configuration would live in the root of repository consuming `devbase`, in `.devbase`.
 
-Each configuration file would match the relevant `mage <target>` target, e.g.
+Each configuration file would match the relevant `make <target>` target, e.g.
 
 ```bash
 $ ls .devbase
@@ -58,7 +58,7 @@ e2e.yaml
 docker.yaml
 ```
 
-**Note**: For shared configuration, e.g. `docker` (which could be shared between `docker-build` and `docker-push`) that's also allowed and can become a unified target.
+**Note**: Configuration should be able to be shared between targets (e.g. `docker-build` and `docker-push` today largely share `docker.yaml`), but this should be limited to only being able to consume the same configuration struct, not two different configs in one. The idea is to allow _closely_ related targets to consume the same configuration only. Complicated things like target a and target b sharing two different configs in a file is expressly what this system is _not_ trying to support.
 
 #### Magefile Targets Implementation Details
 

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -35,7 +35,7 @@ This, combined with a lack of documentation into all of these options, has lareg
 ### Non-goals
 
  - Expose new functionality. This would be nice to have, but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
- - Migrating `Makefile` to `Magefile`, while it'd be nice to migrate all of them over, that's also an amount of work to do. While moving to `Magefile` would be good, we shouldn't try to move everything to Go at the same time. (TL;DR: Wrap shell were needed)
+ - Migrating `Makefile` to `Magefile`, while it'd be nice to migrate all of them over, that's also an amount of work to do. While moving to `Magefile` would be good, we shouldn't try to move everything to Go at the same time (TL;DR: Wrap shell were needed).
 
 ## Proposal
 

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -30,7 +30,7 @@ This, combined with a lack of documentation into all of these options, has lareg
  - Documentation mapping 1:1 with Magefile target, with framework to consume/declare it
  - Documentation on how to write Magefile targets, if the framework docs aren't self-explanatory enough
  - Support for usage outside of stencil-base, et. al
- - Not breaking, while we could do a lot more if we did a breaking release, breaking _all_ of the existing releasing tooling isn't optimal.
+ - Not breaking, while we could do a lot more if we did a breaking release, breaking _all_ of the existing releasing tooling isn't optimal
 
 ### Non-goals
 

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -30,7 +30,7 @@ As we've been writing `devbase`, and other tooling that uses it, we've identifie
 
  - All configuration should be written as go structs (as we intend to only write new targets in), and have godoc compatible documentation on each exported field along with examples as needed.
  - Standard location for all configuration for tooling provided by devbase, et. al
- - Documentation on how to write Magefile targets, if the framework docs aren't self-explanatory enough
+ - Documentation on how to write Magefile targets
  - Ensure that all targets are "plug-and-play" compatible (e.g. usable by themselves), they shouldn't require stencil modules to be used, and if they do require certain options to work "out of the box" they should be sane defaults and well documented (as per the above goals)
  - Not breaking, while we could do a lot more if we did a breaking release, breaking _all_ of the existing releasing tooling isn't optimal
 

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -62,11 +62,7 @@ docker.yaml
 
 #### Magefile Targets Implementation Details
 
-Each magefile target that consumes this configuration will live inside of the `devbase` repository in the `targets/<targetName>` package, which will be pulled in by `root/mage.go`
-
-The reasoning for a package per target is to make it easier to test these in isolation, as well as (generated) documentation to be localized to the packages (targets) themselves.
-
-A library will be provided at `pkg/targets`, which will provide functionality to read configuration, and other shared functions between targets.
+Each magefile target that consumes this configuration will live inside of the `devbase` repository in the `targets/<targetName>` package, which will be pulled in by `root/mage.go`. The reasoning for a package per target is to make it easier to test these in isolation, as well as (generated) documentation to be localized to the packages (targets) themselves. A library will be provided at `pkg/targets`, which will provide functionality to read configuration and other shared functions between targets.
 
 #### Magefile Targets Available Day One
 

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -1,0 +1,127 @@
+# Declarative Configuration
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Implementation Details](#implementation-details)
+  - [Configuration example](#examples)
+- [Test Plan](#testrelease-plan)
+<!-- /toc -->
+
+
+## Summary
+
+This proposal replaces environment variable based configuration being used in Make+Magefiles in favor of using declarative yaml based configuration.
+
+## Motiviation
+
+As we've been writing `devbase`, and other tooling, we've identified that trying to codify all options for tooling to environment variables, bespoke configuration files, and other obscure means has made it difficult for us to provide options and maintain a common set of toolign.
+
+This, combined with a lack of documentation into all of these options, has laregely made `devbase` unconsumable outside of bootstrap/stencil. Thinking of `devbase` as it's own framework to build software makes it more usable in non-stencil projects (like we do already today w/ submodules)
+### Goals
+
+ - Documentation for all options in configuration file(s)
+ - Standard location for all configuration for tooling provided by devbase, et. al
+ - Documentation mapping 1:1 with Magefile target, with framework to consume/declare it
+ - Documentation on how to write Magefile targets, if the framework docs aren't self-explanatory enough
+ - Support for usage outside of stencil-base, et. al
+ - Not breaking, while we could do a lot more if we did a breaking release, breaking _all_ of the existing releasing tooling isn't optimal.
+
+### Non-goals
+
+ - Expose new functionality, this would be nice to have but would balloon the amount of work. We're targeting 1:1 compatibility with features/configuration already exposed today, with nice-to-haves being limited.
+ - Migrating `Makefile` to `Magefile`, while it'd be nice to migrate all of them over, that's also an amount of work to do. While moving to `Magefile` would be good, we shouldn't try to move everything to Go at the same time. (TL;DR: Wrap shell were needed)
+
+## Proposal
+
+The high level proposal here is generally covered in the [Summary](#summary) and [Moviation](#motiviation) sections.
+
+### Implementation Details
+
+#### Repository Configuration
+
+Configuration would live in the root of repository consuming `devbase`, in `.devbase`.
+
+Each configuration file would match the relevant `mage <target>` target, e.g.
+
+```bash
+$ ls .devbase
+build.yaml
+e2e.yaml
+docker.yaml
+```
+
+**Note**: For shared configuration, e.g. `docker` (which could be shared between `docker-build` and `docker-push`) that's also allowed and can become a unified target.
+
+#### Magefile Targets Implementation Details
+
+Each magefile target that consumes this configuration will live inside of the `devbase` repository in the `targets/<targetName>` package, which will be pulled in by `root/mage.go`
+
+The reasoning for a package per target is to make it easier to test these in isolation, as well as (generated) documentation to be localized to the packages (targets) themselves.
+
+A library will be provided at `pkg/targets`, which will provide functionality to read configuration, and other shared functions between targets.
+
+#### Magefile Targets Available Day One
+
+The following targets will be available/configurable day one:
+
+ - `build`
+ - `debug`
+ - `release`
+ - `test` (includes: `coverage` as `--coverage`, `benchmark` as `--bench`)
+ - `lint`
+ - `fmt`
+ - `e2e`
+ - `docker` (includes: `build`, `publish`)
+
+The rest will still be available for compat, but unconfigurable, e.g. `gobuild` will still build go but will not work for non-go repos.
+
+See [Examples](#examples) for an idea of what options will be available/an idea of some of the steps.
+
+#### Testing Framework
+
+Testing would be done via Go Testing, enabling us to easily write unit tests. Integration tests would, unforuantely, still need to be figured out as they rely on being ran in macOS/Linux in a predictable fashion
+
+### Examples
+
+Below are example configuration objects that would be exposed, note this is not all-inclusive and is purposefully not fully spec'd out to allow for changes during implementation.
+
+An example configuration might look like so, for `build`:
+
+```yaml
+golang:
+  dir: ./cmd/...
+  ldflags:
+    github.com/getoutreach/gobox/pkg/app.Version: '{{ .Version }}'
+```
+
+Or `docker.yaml`, that already [exists today](https://github.com/getoutreach/devbase#building-docker-images):
+
+```yaml
+# Corresponds to the directory in `deployments/` and is used, by default, as the image name (see special case below).
+# If this is equal to "appName" then the build context/image name is changed. See docs.
+image_name:
+  # Override the build context for the image. Defaults to '.' if image_name == appName, otherwise ./deployments/<image_name>
+  buildContext: .
+  # pushTo is a different image registry to push to, defaults to:
+  # (box: .devenv.imageRegistry)/$image (or, if not == appName, $appname/$image)
+  pushTo: docker.com/stable/athens
+  # extra secrets to expose to the builder, defaults to NPM_TOKEN being exposed
+  # See: https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information
+  secrets:
+    - id=mySecret,env=MY_SECRET_ENV_VARIABLE
+  # Platforms to build this image for, defaults to linux/amd64,linux/arm64
+  # See: https://github.com/docker/buildx#building-multi-platform-images
+  platforms:
+    - linux/amd64
+ ```
+
+## Test/Release Plan
+
+The test plan for this is to ensure that each target has unit, and where possible, integration tests. Releasing would follow the standard DT team releasing process, which is to be released in the next release window, while being put on the `rc` channel to be consumed by Outreach internally first.
+

--- a/rfcs/1-declarative-configuration.md
+++ b/rfcs/1-declarative-configuration.md
@@ -121,5 +121,5 @@ image_name:
 
 ## Test/Release Plan
 
-The test plan for this is to ensure that each target has unit, and where possible, integration tests. Releasing would follow the standard DT team releasing process, which is to be released in the next release window, while being put on the `rc` channel to be consumed by Outreach internally first.
+The test plan for this is to ensure that each target has unit and, where possible, integration tests. Releasing would follow the standard DT team releasing process, which is to be released in the next release window, while being put on the `rc` channel to be consumed by Outreach internally first.
 


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds an RFC for moving to declarative configuration/better structuring `devbase` in general. This is also the first test of an RFC like system for large scale changes like this.

The idea of an "RFC" is that it will be merged before the work is done on a project, and will contain references to PRs and timelines/plans for a feature. This allows it to gather feedback during the proposal stage, and during implementation for the design to be reviewed/referenced.

[**RENDERED PREVIEW**](https://github.com/getoutreach/devbase/blob/jaredallard/docs/rfc-1-declarative-configuration/rfcs/1-declarative-configuration.md)