### PR TITLE
fix: ensure yarn is present before running yarn install

### DIFF
--- a/shell/languages/nodejs.sh
+++ b/shell/languages/nodejs.sh
@@ -7,6 +7,10 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../lib/she
 yarn_install_if_needed() {
   local stateFile="node_modules/devbase.lock"
 
+  if ! yarn -v >/dev/null 2>&1; then
+    npm install -g yarn
+  fi
+
   if [[ ! -e "node_modules" ]]; then
     yarn_install "$stateFile"
     return


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

If we change node versions for the client, this issue can happen. This ensure that we always have yarn before running it.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2927]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2927]: https://outreach-io.atlassian.net/browse/DT-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ