### PR TITLE
fix(localizer): don't use cancelled context

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -322,7 +322,8 @@ func runLocalizer(ctx context.Context) (cleanup func(), err error) {
 
 	return func() {
 		log.Info().Msg("Killing the spawned localizer process (spawned by devenv tunnel)")
-
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
 		if _, err := client.Kill(ctx, &localizerapi.Empty{}); err != nil {
 			log.Warn().Err(err).Msg("failed to kill running localizer server")
 		}


### PR DESCRIPTION
## What this PR does / why we need it

Seeing this error on every e2e test run: 

```
DONE 13 tests in 7.684s
12:39PM INF Killing the spawned localizer process (spawned by devenv tunnel)
12:39PM WRN failed to kill running localizer server error="rpc error: code = Canceled desc = context canceled"
```

It seems that we are using a context which is always going to be cancelled by this point.

This change creates a new context just for the kill operation.

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->



<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
