### PR TITLE
fix: echo upload token if env var is set

### DIFF
--- a/shell/ci/testing/codecov/get-upload-token.sh
+++ b/shell/ci/testing/codecov/get-upload-token.sh
@@ -5,6 +5,7 @@ set -e
 
 if [[ -n $CODECOV_UPLOAD_TOKEN ]]; then
   echo "Using CODECOV_UPLOAD_TOKEN environment variable." >&2
+  echo -n "$CODECOV_UPLOAD_TOKEN"
   exit 0
 fi
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Was just exiting 0 and not actually returning (echoing) anything which i think resulted in https://app.circleci.com/pipelines/github/getoutreach/tollmon/658/workflows/fb299293-be7e-49ba-9f31-353a37ed2341/jobs/2593?invite=true#step-110-4


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
