### PR TITLE
feat: protoc multiple directories support

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -115,14 +115,15 @@ go_args+=(
   --plugin=protoc-gen-go="$protoc_gen_go"
   # --plugin=protoc-gen-go-grpc="$protoc_gen_go_grpc"
   # --go_out=.
-  --go_out=plugins=grpc:. # Remove this line when we upgrade golang protobuf generation (and uncomment everything else).
+  --go_out="$(get_repo_directory)/"
+  # --go_out=plugins=grpc:. # Remove this line when we upgrade golang protobuf generation (and uncomment everything else).
   --go_opt=paths=source_relative
   # --go-grpc_out=.
   # --go-grpc_opt=paths=source_relative
   --plugin=protoc-gen-doc="$protoc_gen_doc"
   --doc_out="$(get_repo_directory)/api/doc"
   "--doc_opt=html,index.html"
-  --proto_path="$(get_repo_directory)/api"
+  --proto_path="$(get_repo_directory)/"
 )
 
 if has_feature "validation"; then
@@ -138,7 +139,7 @@ fi
 mkdir -p "$(get_repo_directory)/api/doc"
 
 # Run protoc for Go.
-protoc "${go_args[@]}" "$(get_repo_directory)/api/"*.proto
+protoc "${go_args[@]}" "$(pwd)/"*.proto
 
 # Move docs into the actual docs directory.
 mkdir -p "$PROTO_DOCS_DIR"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Mainly, if we need to generate go classes, the first thing we have to do - provide `go:generate` instructions, like this
`//go:generate ../scripts/shell-wrapper.sh protoc.sh` 
The problem is that at this point this script will search for proto files in a hardcoded api directory only. It's pretty weird, and thus each time developer put proto file to other package, we need a workaround and cannot rely on make gogenerate

As long as protoc compiler does not support recursive search in a nested directories, we need to pass `-proto_path` as well as `--go-out` for the input and output. Mainly we can use repository directory `$(get_repo_directory)` for both, input and output and provide an absolute path to the actual proto file using `pwd` function. This way protoc will detect the package and generate go files in exact same directory where proto files are located (of course, if developer did not forget to provide `go:generate` instructions in the same package)



<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
