### PR TITLE
feat: allow configuring lint cache directory

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -37,14 +37,15 @@ FLY                 ?= $(shell ./scripts/shell-wrapper.sh gobin.sh -p github.com
 BENCH_FLAGS         := "-bench=Bench $(BENCH_FLAGS)"
 TEST_TAGS           ?= or_test
 SKIP_VALIDATE       ?=
-LOGFMT				      ?=
+LOGFMT				?=
+GOLANGCI_LINT_CACHE ?= "$(HOME)/.outreach/.cache/.golangci-lint/$(APP)"
 
 # Outreach stuff, will be moved out... one day.
 OUTREACH_DOMAIN     ?= outreach-dev.com
 ACCOUNTS_URL        ?= https://accounts.$(OUTREACH_DOMAIN)
 
 # E2E
-BASE_TEST_ENV       ?= GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) SKIP_VALIDATE=${SKIP_VALIDATE} SKIP_LINTERS=${SKIP_LINTERS} OSS=$(OSS) TEST_TAGS=$(TEST_TAGS)
+BASE_TEST_ENV       ?= GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) SKIP_VALIDATE=${SKIP_VALIDATE} SKIP_LINTERS=${SKIP_LINTERS} OSS=$(OSS) TEST_TAGS=$(TEST_TAGS) GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE)
 E2E_NAMESPACE       ?= $(APP)--bento1a
 E2E_SERVICE_ACCOUNT ?= $(APP)-e2e-client-svc
 E2E_CLUSTER         ?= development.us-west-2

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -24,8 +24,4 @@ export GOGC=20
 # This helps with the "too many open files" error.
 mkdir -p "$HOME/.outreach/.cache/.golangci-lint" >/dev/null 2>&1
 
-# Why: We're OK with masking the return value
-# shellcheck disable=SC2155
-export GOLANGCI_LINT_CACHE="$HOME/.outreach/.cache/.golangci-lint/$(get_app_name)"
-
 asdf_devbase_exec golangci-lint "${args[@]}"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This allows configuring the cache directory so that we can still use a cache while running an application in `devenv`.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2966]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2966]: https://outreach-io.atlassian.net/browse/DT-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ