### PR TITLE
fix(tool-versions): ruby 2.7.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@
 golang 1.17.9
 nodejs 16.13.0
 terraform 0.13.5
-ruby 2.6.6
+ruby 2.7.5
 protoc 3.19.1
 # Note: Versions in this block override the above. Be EXTREMELY
 # CAREFUL with this. If you override a standard version you are


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Backports ruby 2.7.5 to devbase `2.2.x`, which is the [version being used by bootstrap v10.2.x](https://github.com/getoutreach/bootstrap/blob/v10.2.2/versions.yaml#L21). 

For posterity, I created `release-2.2` by doing the following:

```bash
$ git checkout v2.2.1
$ git checkout -b release-2.2
```

```yaml
# Updated .releaserc.yml to be the following:
branches:
- name: release-2.2
  range: 2.2.x
  channel: ''
```

**Note**: `yarn run semantic-release` doesn't work until you push the branch up to the remote, sadly.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
