### PR TITLE
fix: Update lintroller to the latest version.

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@ jsonnetfmt: 4906958414ed9617e3fe5acac5752f6f8426551c # use a tagged version when
 goimports: 0.1.12
 delve: 1.9.1
 gotestsum: 1.7.0
-lintroller: 1.14.1
+lintroller: 1.15.1
 clerkgenproto: 1.28.1
 goveralls: 0.0.11
 getoutreach/ci: v1.3.0


### PR DESCRIPTION
## What this PR does / why we need it

Picks up changes related to copyright statements & some other stuff for silver.

