### PR TITLE
fix: format and check lint for .ts files

### DIFF
--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -11,7 +11,8 @@ extensions=(yaml yml json md ts)
 
 prettier_linter() {
   yarn_install_if_needed >/dev/null
-  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log || return $?
+  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log
+  return $?
 }
 
 prettier_formatter() {

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -7,16 +7,16 @@ source "$DIR/languages/nodejs.sh"
 
 # Why: Used by the script that calls us
 # shellcheck disable=SC2034
-extensions=(yaml yml json md)
+extensions=(yaml yml json md ts)
 
 prettier_linter() {
   yarn_install_if_needed >/dev/null
-  git ls-files '*.yaml' '*.yml' '*.json' '*.md' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel warn
+  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log || exit $?
 }
 
 prettier_formatter() {
   yarn_install_if_needed >/dev/null
-  git ls-files '*.yaml' '*.yml' '*.json' '*.md' | xargs -n40 "node_modules/.bin/prettier" --write --loglevel warn
+  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" --write --loglevel warn
 }
 
 linter() {

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -11,7 +11,7 @@ extensions=(yaml yml json md ts)
 
 prettier_linter() {
   yarn_install_if_needed >/dev/null
-  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log || exit $?
+  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log || return $?
 }
 
 prettier_formatter() {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

- format and check lint .ts files
- change loglevel to log to print files that failed lint check
- break lint check if prettier fails

**test repo:** https://github.com/getoutreach/nirupamaintro/tree/4321fe9ac0adfb2aaa9e53e2c872d06066d37f8a

**before change**

nirupamaintro % make lint 
GOPROXY= GOPRIVATE=github.com/getoutreach/* OUTREACH_ACCOUNTS_BASE_URL=https://accounts.outreach-dev.com SKIP_VALIDATE= SKIP_LINTERS= OSS=false TEST_TAGS=or_test ./scripts/shell-wrapper.sh linters.sh
 :: Running linters
    -> shellcheck (.sh,.bash) (1.134s)
    -> shellfmt (.sh,.bash) (0.990s)
    -> go mod tidy (.go) (0.995s)
    -> golangci-lint (.go)
    -> golangci-lint (.go) (5.638s)
    -> lintroller (.go) (1.412s)
    -> eslint (.js) (0.74s)
    -> prettier (.js) (0.79s)
    -> prettier (.yaml,.yml,.json,.md,.ts) (2.573s)
    -> buf (.proto) (1.933s)
    -> tflint (.tf,.tfvars) (0.748s)
 :: Linters took 16.49s

nirupamaintro % echo $?
0

**after change**

nirupamaintro % make lint
GOPROXY= GOPRIVATE=github.com/getoutreach/* OUTREACH_ACCOUNTS_BASE_URL=https://accounts.outreach-dev.com SKIP_VALIDATE= SKIP_LINTERS= OSS=false TEST_TAGS=or_test ./scripts/shell-wrapper.sh linters.sh
 :: Running linters
    -> shellcheck (.sh,.bash) (1.150s)
    -> shellfmt (.sh,.bash) (1.56s)
    -> go mod tidy (.go) (1.80s)
    -> golangci-lint (.go)
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
    -> golangci-lint (.go) (6.252s)
    -> lintroller (.go) (1.479s)
    -> eslint (.js) (0.54s)
    -> prettier (.js) (0.53s)
    -> prettier (.yaml,.yml,.json,.md,.ts)
api/clients/node/src/client-helpers.spec.ts
api/clients/node/src/client-helpers.ts
api/clients/node/src/grpc/nirupamaintro_grpc_pb.d.ts
api/clients/node/src/grpc/nirupamaintro_pb.d.ts
api/clients/node/src/index.ts
    -> prettier (.yaml,.yml,.json,.md,.ts) (2.731s)
Error: prettier failed with exit code 1
make: *** [lint] Error 1
nirupamaintro % echo $?
2
nirupamaintro % make fmt 
 :: Running formatters
    -> shellfmt (.sh,.bash) (0.971s)
    -> go mod tidy (.go) (0.918s)
    -> goimports (.go) (1.635s)
    -> gofmt (.go) (0.289s)
    -> eslint (.js) (0.51s)
    -> prettier (.js) (0.56s)
    -> jsonnetfmt (.jsonnet,.libsonnet) (1.302s)
    -> prettier (.yaml,.yml,.json,.md,.ts) (2.380s)
    -> buf (.proto) (1.901s)
    -> terraform fmt (.tf,.tfvars) (0.711s)
 :: Formatters took 10.671s

nirupamaintro % git status
On branch main
Your branch is behind 'origin/main' by 2 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   api/clients/node/src/client-helpers.spec.ts
        modified:   api/clients/node/src/client-helpers.ts
        modified:   api/clients/node/src/grpc/nirupamaintro_grpc_pb.d.ts
        modified:   api/clients/node/src/grpc/nirupamaintro_pb.d.ts
        modified:   api/clients/node/src/index.ts

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

https://outreach-io.atlassian.net/browse/DT-3029

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
