### PR TITLE
fix: set pipefail for lintroller

### DIFF
--- a/shell/lintroller.sh
+++ b/shell/lintroller.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Runs lintroller
-set -e
+set -e -o pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

set pipefail to break and exit when lintroller fails

**test repo:** https://github.com/getoutreach/rms/commit/9e61156cb77530334bec245fad575a6eaf361771

**before change**

rms % make lint
GOPROXY= GOPRIVATE=github.com/getoutreach/* OUTREACH_ACCOUNTS_BASE_URL=https://accounts.outreach-dev.com SKIP_VALIDATE= SKIP_LINTERS= OSS=false TEST_TAGS=or_test GOLANGCI_LINT_CACHE="/Users/cluangma/.outreach/.cache/.golangci-lint/rms" ./scripts/shell-wrapper.sh linters.sh
 :: Running linters
    -> shellcheck (.sh,.bash) (0.719s)
    -> shellfmt (.sh,.bash) (0.597s)
    -> go mod tidy (.go) (0.681s)
    -> golangci-lint (.go) (5.119s)
    -> lintroller (.go)
-: file "/Users/cluangma/github/rms/internal/validator/result.go" does not contain the required header key "Description" and corresponding value existing before the package keyword
-: file "/Users/cluangma/github/rms/internal/validator/result.go" does not contain the required copyright regular expression [^Copyright 20.*$] (sans-brackets) as a comment on line 1
internal/rms/server/server.go:31:1: function "NewServer" has no comment associated with it (doculint)
internal/rms/flagship/flagship_custom_fields_long_to_model.go:34:1: function "ParseCustomFieldsLongToModel" has no comment associated with it (doculint)
internal/smartstore/rms/ingest/opportunity_prospect_role_flagship_into_opportunity_prospect_role.go:34:6: comment for type "OpportunityProspectRoleFlagshipStoreIntoOpportunityProspectRole" should begin with "OpportunityProspectRoleFlagshipStoreIntoOpportunityProspectRole" (doculint)
internal/validator/result.go:14:6: type "TypeName" has no comment associated with it (doculint)
internal/validator/result.go:16:1: constant block has no comment associated with it (doculint)
internal/validator/result.go:17:2: constant "accountType" has no comment associated with it (doculint)
internal/validator/result.go:18:2: constant "prospectType" has no comment associated with it (doculint)
internal/validator/result.go:19:2: constant "opportunityType" has no comment associated with it (doculint)
internal/validator/result.go:20:2: constant "phoneNumberType" has no comment associated with it (doculint)
internal/validator/result.go:23:6: type "apiModel" has no comment associated with it (doculint)
    -> lintroller (.go) (3.790s)1: function "runComparison" has no comment associated with it (doculint)
    -> eslint (.js) (0.80s)
    -> prettier (.js) (0.76s)
    -> prettier (.yaml,.yml,.json,.md) (3.33s)
    -> buf (.proto) (1.796s)
    -> tflint (.tf,.tfvars) (0.534s)
 :: Linters took 16.904s

rms % echo $?
0


**after change** 

rms % make lint
GOPROXY= GOPRIVATE=github.com/getoutreach/* OUTREACH_ACCOUNTS_BASE_URL=https://accounts.outreach-dev.com SKIP_VALIDATE= SKIP_LINTERS= OSS=false TEST_TAGS=or_test GOLANGCI_LINT_CACHE="/Users/cluangma/.outreach/.cache/.golangci-lint/rms" ./scripts/shell-wrapper.sh linters.sh
 :: Running linters
    -> shellcheck (.sh,.bash) (1.63s)
    -> shellfmt (.sh,.bash) (0.633s)
    -> go mod tidy (.go) (0.776s)
    -> golangci-lint (.go) (5.851s)
    -> lintroller (.go)
-: file "/Users/cluangma/github/rms/internal/validator/result.go" does not contain the required header key "Description" and corresponding value existing before the package keyword
-: file "/Users/cluangma/github/rms/internal/validator/result.go" does not contain the required copyright regular expression [^Copyright 20.*$] (sans-brackets) as a comment on line 1
internal/rms/server/server.go:31:1: function "NewServer" has no comment associated with it (doculint)
internal/rms/flagship/flagship_custom_fields_long_to_model.go:34:1: function "ParseCustomFieldsLongToModel" has no comment associated with it (doculint)
internal/smartstore/rms/ingest/opportunity_prospect_role_flagship_into_opportunity_prospect_role.go:34:6: comment for type "OpportunityProspectRoleFlagshipStoreIntoOpportunityProspectRole" should begin with "OpportunityProspectRoleFlagshipStoreIntoOpportunityProspectRole" (doculint)
internal/validator/result.go:14:6: type "TypeName" has no comment associated with it (doculint)
internal/validator/result.go:16:1: constant block has no comment associated with it (doculint)
internal/validator/result.go:17:2: constant "accountType" has no comment associated with it (doculint)
internal/validator/result.go:18:2: constant "prospectType" has no comment associated with it (doculint)
internal/validator/result.go:19:2: constant "opportunityType" has no comment associated with it (doculint)
internal/validator/result.go:20:2: constant "phoneNumberType" has no comment associated with it (doculint)
internal/validator/result.go:23:6: type "apiModel" has no comment associated with it (doculint)
internal/validator/result.go:29:1: function "runComparison" has no comment associated with it (docu    -> lintroller (.go) (4.320s)
Error: lintroller failed with exit code 3
make: *** [lint] Error 1

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

https://outreach-io.atlassian.net/browse/DT-3040

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
