### PR TITLE
feat(make): add a test-e2e command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,17 +77,6 @@ workflows:
     jobs:
       - shared/save_cache: *test
 
-  manual-rebuild-cache:
-    when: << pipeline.parameters.rebuld_cache >>
-    jobs:
-      - shared/save_cache:
-          context: *contexts
-          app_name: devbase
-          ### Start parameters from test
-          ### End parameters from test
-          ### Start parameters inserted by other modules
-          ### End parameters inserted by other modules
-
   release:
     when:
       not: << pipeline.parameters.rebuild_cache >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,17 @@ workflows:
     jobs:
       - shared/save_cache: *test
 
+  manual-rebuild-cache:
+    when: << pipeline.parameters.rebuld_cache >>
+    jobs:
+      - shared/save_cache:
+          context: *contexts
+          app_name: devbase
+          ### Start parameters from test
+          ### End parameters from test
+          ### Start parameters inserted by other modules
+          ### End parameters inserted by other modules
+
   release:
     when:
       not: << pipeline.parameters.rebuild_cache >>

--- a/root/Makefile
+++ b/root/Makefile
@@ -116,16 +116,16 @@ lint:: pre-test pre-lint
 test:: pre-test lint
 	$(BASE_TEST_ENV) ./scripts/shell-wrapper.sh test.sh
 
+## test-e2e:        run only e2e test (use inside a dev pod)
+.PHONY: test-e2e
+test-e2e:: pre-test
+	$(BASE_TEST_ENV) TEST_TAGS=or_test,or_e2e ./scripts/shell-wrapper.sh test.sh
+
 ## coverage:        generate code coverage
 .PHONY: coverage
 coverage:: pre-coverage
 	 WITH_COVERAGE=true GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) ./scripts/shell-wrapper.sh test.sh
 	 go tool cover --html=/tmp/coverage.out
-
-## test-e2e:        run only e2e test (use inside a dev pod)
-.PHONY: test-e2e
-test-e2e:: pre-test
-	$(BASE_TEST_ENV) TEST_TAGS=or_test,or_e2e ./scripts/shell-wrapper.sh test.sh
 
 .PHONY: e2e
 e2e:: pre-e2e

--- a/root/Makefile
+++ b/root/Makefile
@@ -122,6 +122,11 @@ coverage:: pre-coverage
 	 WITH_COVERAGE=true GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) ./scripts/shell-wrapper.sh test.sh
 	 go tool cover --html=/tmp/coverage.out
 
+## test-e2e:        run only e2e test (use inside a dev pod)
+.PHONY: test-e2e
+test-e2e:: pre-test
+	$(BASE_TEST_ENV) TEST_TAGS=or_test,or_e2e ./scripts/shell-wrapper.sh test.sh
+
 .PHONY: e2e
 e2e:: pre-e2e
 	$(BASE_TEST_ENV) E2E=true OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) \

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -77,7 +77,7 @@ elif [[ -n $E2E ]]; then
   # We need to have a git repo test files added so that make test can see them
   git init >/dev/null 2>&1
   git add -A >/dev/null 2>&1
-  TEST_TAGS=or_test,or_e2e make test | tee -ai "${DEV_CONTAINER_LOGFILE:-/tmp/app.log}"
+  make test-e2e | tee -ai "${DEV_CONTAINER_LOGFILE:-/tmp/app.log}"
   exit "${PIPESTATUS[0]}"
 else
   make dev


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Adds a command for running e2e tests inside a session of `devenv apps e2e`. This runs e2e tests without a linter which should help with general performance of e2e tests in devspace.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2967]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2967]: https://outreach-io.atlassian.net/browse/DT-2967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ