### PR TITLE
docs(prettier): better error message

### DIFF
--- a/shell/linters.sh
+++ b/shell/linters.sh
@@ -71,11 +71,20 @@ for languageScript in "$DIR/linters"/*.sh; do
       show=$filesString
     fi
 
+    # Set a trap to print the user-friendly error message
+    # because linters use run_command which exits if there is an error
+    function exit_trap {
+      # Why: We are in a trap
+      # shellcheck disable=SC2181
+      if [[ $? -ne 0 ]]; then
+        error "Linter failed to run, run 'make fmt' to fix"
+        exit $?
+      fi
+    }
+    trap exit_trap EXIT
+
     # Set by the language file
-    if ! linter; then
-      error "Linter failed to run, run 'make fmt' to fix"
-      exit 1
-    fi
+    linter
   )
 done
 finished_at="$(get_time_ms)"

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -12,17 +12,7 @@ extensions=(yaml yml json md ts)
 prettier_linter() {
   yarn_install_if_needed >/dev/null
   git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log
-  
-  # Print out a friendlier error message, because prettier will just print a list of files
-  code=$?
-  if [[ $code == 1 ]]; then
-	  # Clear lines above and below because magic terminal stuff going on
-	  echo
-	  echo "prettier_linter: the above files have not been formatted. Please run \`make fmt\` to fix this."
-	  echo
-  fi
-  
-  return $code
+  return $?
 }
 
 prettier_formatter() {

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -12,7 +12,17 @@ extensions=(yaml yml json md ts)
 prettier_linter() {
   yarn_install_if_needed >/dev/null
   git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log
-  return $?
+  
+  # Print out a friendlier error message, because prettier will just print a list of files
+  code=$?
+  if [[ $code == 1 ]]; then
+	  # Clear lines above and below because magic terminal stuff going on
+	  echo
+	  echo "prettier_linter: the above files have not been formatted. Please run \`make fmt\` to fix this."
+	  echo
+  fi
+  
+  return $code
 }
 
 prettier_formatter() {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

- Prints a more useful error message if prettier linter fails
- https://outreach-hq.slack.com/archives/CN9MU7GLW/p1667860712129589

**Current error**:
```
    -> prettier (.yaml,.yml,.json,.md,.ts)
warning Workspaces can only be enabled in private projects.
manifest.yaml
    -> prettier (.yaml,.yml,.json,.md,.ts) (7.670s)
Error: prettier failed with exit code 123
make: *** [.bootstrap/root/Makefile:109: lint] Error 1
```


**Example error with this patch**
```
    -> prettier (.yaml,.yml,.json,.md,.ts)
manifest.yaml
Error: Linter failed to run, run 'make fmt' to fix
```


**After running make fmt (proving it works if there are no errors)**
```
    -> prettier (.yaml,.yml,.json,.md,.ts) (0.896s)
 :: Linters took 9.174s
```

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Note for reviewers

- This is a bit of a blunt hammer.  Feel free to refactor and return all the proper error codes and such. 

[DT-3150]

[DT-3150]: https://outreach-io.atlassian.net/browse/DT-3150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ