### PR TITLE
fix(gobuild): ensure we have secrets for build

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -144,6 +144,8 @@ gogenerate:: pre-gogenerate
 ## gobuild:         build application binary
 .PHONY: gobuild
 gobuild:
+	# ensure that we have secrets for the build phase
+	if [[ -z $$SKIP_DEVCONFIG ]]; then ./scripts/shell-wrapper.sh devconfig.sh; fi
 	@$(MAGE_CMD) gobuild
 
 ## grpcui:          run grpcui for an already locally running service
@@ -165,13 +167,11 @@ dev:: pre-dev
 ## devserver:       run the service
 .PHONY: devserver
 devserver:: pre-devserver build
-	if [[ -z $$SKIP_DEVCONFIG ]]; then ./scripts/shell-wrapper.sh devconfig.sh; fi
 	OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) MY_CLUSTER=$(E2E_CLUSTER) MY_ENVIRONMENT=$(E2E_ENVIRONMENT) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) MY_POD_SERVICE_ACCOUNT=$(E2E_SERVICE_ACCOUNT) $(BINDIR)/$(BIN_NAME)
 
 ## debug:           run the service via delve
 .PHONY: debug
 debug:: pre-debug build
-	@if [[ -z $$SKIP_DEVCONFIG ]]; then DEVBOX_LOGFMT="$(LOGFMT)" ./scripts/shell-wrapper.sh devconfig.sh; fi
 	@if [[ -n $$DLV_PORT ]]; then DEVBOX_LOGFMT="$(LOGFMT)" ./scripts/shell-wrapper.sh debug.sh; fi
 	@if [[ -z $$DLV_PORT ]]; then OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) ./scripts/shell-wrapper.sh debug.sh; fi
 

--- a/root/Makefile
+++ b/root/Makefile
@@ -58,7 +58,7 @@ OSS                 ?= false
 default: build
 
 # All the pre-action steps are bunched together here.
-.PHONY: pre-release pre-build pre-lint pre-run pre-test pre-coverage pre-integration pre-e2e pre-benchmark pre-gogenerate pre-devserver pre-dev pre-debug pre-docker-build pre-fmt pre-docs pre-docs-publish
+.PHONY: pre-release pre-build pre-lint pre-run pre-test pre-coverage pre-integration pre-e2e pre-benchmark pre-gogenerate pre-devconfig pre-devserver pre-dev pre-debug pre-docker-build pre-fmt pre-docs pre-docs-publish
 pre-release::
 pre-build::
 pre-run::
@@ -69,6 +69,7 @@ pre-integration::
 pre-e2e::
 pre-benchmark::
 pre-gogenerate::
+pre-devconfig::
 pre-devserver::
 pre-dev::
 pre-debug::
@@ -144,8 +145,6 @@ gogenerate:: pre-gogenerate
 ## gobuild:         build application binary
 .PHONY: gobuild
 gobuild:
-	# ensure that we have secrets for the build phase
-	if [[ -z $$SKIP_DEVCONFIG ]]; then ./scripts/shell-wrapper.sh devconfig.sh; fi
 	@$(MAGE_CMD) gobuild
 
 ## grpcui:          run grpcui for an already locally running service
@@ -164,14 +163,20 @@ run:: pre-run build
 dev:: pre-dev
 	@DEVBOX_LOGFMT="$(LOGFMT)" ./scripts/shell-wrapper.sh gobin.sh github.com/cosmtrek/air@f7ec5b5ac29540748772dd4deb24a39f81ba9a47 -c $(CURDIR)/.air.toml
 
+## devconfig:       generates the required configuration to run the service locally
+.PHONY: devconfig
+devconfig:: pre-devconfig
+	if [[ -z $$SKIP_DEVCONFIG ]]; then ./scripts/shell-wrapper.sh devconfig.sh; fi
+
 ## devserver:       run the service
 .PHONY: devserver
-devserver:: pre-devserver build
+devserver:: pre-devserver build devconfig
 	OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) MY_CLUSTER=$(E2E_CLUSTER) MY_ENVIRONMENT=$(E2E_ENVIRONMENT) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) MY_POD_SERVICE_ACCOUNT=$(E2E_SERVICE_ACCOUNT) $(BINDIR)/$(BIN_NAME)
 
 ## debug:           run the service via delve
 .PHONY: debug
 debug:: pre-debug build
+	@if [[ -z $$SKIP_DEVCONFIG ]]; then DEVBOX_LOGFMT="$(LOGFMT)" ./scripts/shell-wrapper.sh devconfig.sh; fi
 	@if [[ -n $$DLV_PORT ]]; then DEVBOX_LOGFMT="$(LOGFMT)" ./scripts/shell-wrapper.sh debug.sh; fi
 	@if [[ -z $$DLV_PORT ]]; then OUTREACH_ACCOUNTS_BASE_URL=$(ACCOUNTS_URL) MY_NAMESPACE=$(E2E_NAMESPACE) OUTREACH_DOMAIN=$(OUTREACH_DOMAIN) ./scripts/shell-wrapper.sh debug.sh; fi
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Since we still embed honeycomb and telefork keys in the binaries, this ensure that we have the keys available when we run `make build`.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2717]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2717]: https://outreach-io.atlassian.net/browse/DT-2717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ