### PR TITLE
feat(cache): conditionally run daily cache

### DIFF
--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -44,6 +44,19 @@ steps:
       condition:
         not: << parameters.skip >>
       steps:
+        - restore_cache:
+            keys:
+              - v1-toggle-daily-cache-{{ .Revision }}
+        - run:
+            name: Check cache flag
+            command: |
+              if [[ -f "/home/circleci/cache-toggle" ]]; then
+                echo "Cache for this commit already exists"
+                curl -X POST "https://circleci.com/api/v2/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/job/$CIRCLE_BUILD_NUM/cancel?circle-token=$CIRCLECI_API_TOKEN"
+              fi
+        - run:
+            name: Create a cache flag file
+            command: touch ~/cache-toggle && echo "true" > ~/cache-toggle
         - setup_environment:
             restore_cache: false
         - run:
@@ -55,6 +68,11 @@ steps:
               - "~/.cache"
               - "~/.asdf"
               - "~/.outreach/.cache"
+        - save_cache:
+            key: v1-toggle-daily-cache-{{ .Revision }}
+            paths:
+              - "~/cache-toggle"
+
   - when:
       condition: << parameters.skip >>
       steps:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This runs the full cache generation only if there was a new commit since the last run.

The implementation is rather hackey, but CircleCI has no built in way to handle this kind of behavior.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3123]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3123]: https://outreach-io.atlassian.net/browse/DT-3123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ