### PR TITLE
fix(executor/testbed-machine): use newer ubuntu image + remove heroku APT

### DIFF
--- a/orbs/shared/executors/testbed-machine.yml
+++ b/orbs/shared/executors/testbed-machine.yml
@@ -1,6 +1,6 @@
 description: Standard executor for machine runtimes
 machine:
-  image: ubuntu-2004:2022.04.2
+  image: ubuntu-2204:2022.10.2
   docker_layer_caching: true
 environment:
   TEST_RESULTS: /tmp/test-results

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -1,32 +1,53 @@
 #!/usr/bin/env bash
 # Install dependencies that are required in a machine environment.
 # These are usually already installed in a CircleCI docker image.
+set -e
+
+# should_install_vault is a helper function that checks if the vault
+# binary is already installed, if so it returns false. Otherwise, it
+# returns true.
+should_install_vault() {
+  ! command -v vault >/dev/null 2>&1
+}
+
+# Remove APT repositories we don't need.
+# We remove the heroku apt repository because we don't
+# heroku, but also due to a potential hostile takeover
+# on Nov 14th, 2022.
+if [[ -e "/etc/apt/sources.list.d/heroku.list" ]]; then
+  sudo rm /etc/apt/sources.list.d/heroku.list
+fi
+
+# Add APT repositories we do need.
+if should_install_vault; then
+  wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
+  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+fi
+
+# Rebuild the apt list
+sudo apt-get update -y
 
 # Install Python and pip
 if ! command -v pip3 >/dev/null; then
   echo "Installing pip3"
-  sudo apt-get update -y
   sudo apt-get install --no-install-recommends -y python3-pip
-  sudo apt-get clean -y
 fi
 
 if ! command -v gh >/dev/null; then
   echo "Installing gh"
-  wget -O gh.deb https://github.com/cli/cli/releases/download/v2.12.1/gh_2.12.1_linux_amd64.deb
+  wget -O gh.deb https://github.com/cli/cli/releases/download/v2.20.0/gh_2.20.0_linux_amd64.deb
   sudo apt install -yf ./gh.deb
   rm gh.deb
 fi
 
 echo "Installing yq"
-# remove the existing yq, if it already exists
+# Remove the existing yq, if it already exists
+# (usually the Go Version we don't support)
 sudo rm "$(command -v yq)" || true
 sudo pip3 install yq
 
 # Vault
-if ! command -v vault >/dev/null; then
+if should_install_vault; then
   echo "Installing Vault"
-  wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
-  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-  sudo apt-get update
   sudo apt-get install -y vault
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR updates the `testbed-machine` executor to use a new version of Ubuntu. This, hopefully, fixes issues in e2e tests like such:

```
Reading package lists... Done       
E: Repository 'https://cli-assets.heroku.com/apt ./ InRelease' changed its 'Origin' value from 'Heroku' to 'Jeff Dickey @jdxcode'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```

If the Heroku APT repository had a hostile takeover and the newer image still includes it, this will not fix the issue. Going to wait to merge until I validate that this does, in fact, fix the issue.

This PR also removes the `heroku.list` APT entry to remove issues with it.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-0]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
