### PR TITLE
fix: run_command to return exit code back to callers

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -68,7 +68,10 @@ for languageScript in "$DIR/linters"/*.sh; do
     fi
 
     # Set by the language file
-    formatter
+    if ! formatter; then
+      error "Formatter failed to run"
+      exit 1
+    fi
   )
 done
 finished_at="$(get_time_ms)"

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -139,11 +139,7 @@ run_command() {
   # Rewrite the above line, or append, with the time taken
   info_sub "$name ($show) ($(format_diff $duration))"
 
-  # If we failed, display an error and exit
-  if [[ $exit_code -ne 0 ]]; then
-    error "$name failed with exit code $exit_code"
-    exit 1
-  fi
+  return $exit_code
 }
 
 # format_diff takes a diff and formats it into a friendly timestamp


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

update run_command to return exit code back to caller. so that linter.sh (caller) can [print out a recommendation to users
](https://github.com/getoutreach/devbase/blob/main/shell/linters.sh#L76)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

https://outreach-io.atlassian.net/browse/DT-3150

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
