### PR TITLE
fix(docker): fail if no manifest file exists in repo

### DIFF
--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -24,6 +24,11 @@ source "${LIB_DIR}/buildx.sh"
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+if [[ ! -f $MANIFEST ]]; then
+  error "Manifest file '$MANIFEST' required for building Docker images"
+  fatal "See https://github.com/getoutreach/devbase#building-docker-images for details"
+fi
+
 # get_image_field returns a field from the manifest of the image
 get_image_field() {
   local name="$1"


### PR DESCRIPTION
## What this PR does / why we need it

One of the repos I maintain had its Docker image creation CI configuration refactored, but the manifest `deployments/docker.yaml` wasn't created. As a result, no new Docker images have been created since. However, my team wasn't notified of this because despite the "Build and Push Docker Image" job failing, it returned exit code 0, so it wasn't obvious that there was an issue until we dug into the CI logs.

The proposed fix checks for the existence of the manifest and exits early with a non-zero code if it's not there (with a link to the manifest instructions).