### PR TITLE
fix: clone protoc import target everytime

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -97,7 +97,7 @@ for import in $imports; do
   # Check to see if we already have this version locally and skip cloning
   # if we already do.
   if [[ -d $import_path && -d "$import_path/.git" ]]; then
-    continue
+      rm -r "$import_path"
   fi
 
   # Clone import into the import path since we don't have it already

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -97,7 +97,7 @@ for import in $imports; do
   # Check to see if we already have this version locally and skip cloning
   # if we already do.
   if [[ -d $import_path && -d "$import_path/.git" ]]; then
-      rm -r "$import_path"
+    rm -r "$import_path"
   fi
 
   # Clone import into the import path since we don't have it already

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -102,7 +102,7 @@ for import in $imports; do
   import_paths+=("$import_path/$path")
 
   # Check to see if we already have this version locally and remove
-  # to allow a fresh clone if we already do
+  # to allow a fresh clone if we already do.
   if [[ -d $import_path && -d "$import_path/.git" ]]; then
     rm -r "$import_path"
   fi

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -94,8 +94,8 @@ for import in $imports; do
   default_args+=("--proto_path=$import_path/$path")
   import_paths+=("$import_path/$path")
 
-  # Check to see if we already have this version locally and skip cloning
-  # if we already do.
+  # Check to see if we already have this version locally and remove
+  # to allow a fresh clone if we already do
   if [[ -d $import_path && -d "$import_path/.git" ]]; then
     rm -r "$import_path"
   fi


### PR DESCRIPTION
ensures that when tagging to a branch (such as for developing) that it is always up to date during generation
