### PR TITLE
fix: remove unsupported validate proto plugin

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -152,6 +152,10 @@ if has_feature "validation"; then
   )
 fi
 
+delete_validate() {
+  sed -i '' '/validate_pb/d' "$1" 2>/dev/null || sed -i '/validate_pb/d' "$1"
+}
+
 # Make docs output directory if it doesn't exist.
 mkdir -p "$(get_repo_directory)$workDir/doc"
 
@@ -214,10 +218,8 @@ if has_grpc_client "node"; then
 
   # remove unsupported validate proto plugin
   if pushd "$grpc_path"; then
-    for f in * **/*; do
-      if [ -f "$f" ]; then
-        sed -i '' '/validate_pb/d' "$f" 2>/dev/null || sed -i '/validate_pb/d' "$f"
-      fi
+    find . -name '*.js' -or -name '*.ts' | while read -r file; do
+      delete_validate "$file"
     done
     popd || exit 1
   fi
@@ -257,10 +259,8 @@ if has_grpc_client "ruby"; then
 
   # remove unsupported validate proto plugin
   if pushd "$(get_repo_directory)/api/clients/ruby/lib/$(get_app_name)_client$SUBDIR"; then
-    for f in * **/*; do
-      if [ -f "$f" ]; then
-        sed -i '' '/validate_pb/d' "$f" 2>/dev/null || sed -i '/validate_pb/d' "$f"
-      fi
+    find . -name '*.rb' | while read -r file; do
+      delete_validate "$file"
     done
     popd || exit 1
   fi

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -211,6 +211,16 @@ if has_grpc_client "node"; then
   )
 
   "$grpc_tools_node_bin" "${ts_args[@]}" "$(get_repo_directory)$workDir$SUBDIR/"*.proto
+
+  # remove unsupported validate proto plugin
+  if pushd "$grpc_path"; then
+    for f in * **/*; do
+      if [ -f "$f" ]; then
+        sed -i '' '/validate_pb/d' "$f" 2>/dev/null || sed -i '/validate_pb/d' "$f"
+      fi
+    done
+    popd || exit 1
+  fi
 fi
 
 if has_grpc_client "ruby"; then
@@ -244,4 +254,14 @@ if has_grpc_client "ruby"; then
   )
 
   "$grpc_tools_ruby_bin" "${ruby_args[@]}" "$(get_repo_directory)$workDir$SUBDIR/"*.proto
+
+  # remove unsupported validate proto plugin
+  if pushd "$(get_repo_directory)/api/clients/ruby/lib/$(get_app_name)_client$SUBDIR"; then
+    for f in * **/*; do
+      if [ -f "$f" ]; then
+        sed -i '' '/validate_pb/d' "$f" 2>/dev/null || sed -i '/validate_pb/d' "$f"
+      fi
+    done
+    popd || exit 1
+  fi
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Remove the imports of an unsupported plugin from all generated proto files. We still need to keep the plugin because it's heavily used in Go.

We have proved out that removing this manually still keeps the clients working as expected.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3283]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3283]: https://outreach-io.atlassian.net/browse/DT-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ