### PR TITLE
fix(lib/shell): get_cursor_pos validates format better (DT-3132)

### DIFF
--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -93,6 +93,13 @@ get_cursor_pos() {
   # tput u7 > /dev/tty    # when TERM=xterm (and relatives)
   IFS=';' read -r -d R -a pos
   stty "$oldstty"
+
+  # Check if the output is in the format we expect
+  if [[ ${pos[0]} != $'\033['* ]] || [[ ${pos[1]} != *[0-9] ]]; then
+    echo "0,0"
+    return
+  fi
+
   # change from one-based to zero based so they work with: tput cup $row $col
   row=$((${pos[0]:2} - 1)) # strip off the esc-[
   col=$((pos[1] - 1))


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

For some reason stdin can mutate what `get_cursor_pos` returns, so attempt to validate that. If it fails, return `0,0`. This results in mangled output, but really the user shouldn't be writing to their terminal as they are running something non-interactively so I'm OK with that.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3132]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3132]: https://outreach-io.atlassian.net/browse/DT-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ