### PR TITLE
fix: skip docker and e2e ci steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,15 +117,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-      - shared/e2e:
-          context: *contexts
-          ## <<Stencil::Block(circleE2EExtra)>>
-
-          ## <</Stencil::Block>>
-      - shared/docker:
-          context: *contexts
-          filters:
-            branches:
-              ignore: *release_branches
-            tags:
-              only: /v\d+(\.\d+)*(-.*)*/

--- a/service.yaml
+++ b/service.yaml
@@ -1,6 +1,9 @@
 name: devbase
 arguments:
   circleAPIKey: ""
+  ciOptions:
+    skipE2e: true
+    skipDocker: true
   commands: []
   commitGuard: false
   dependencies:

--- a/stencil.lock
+++ b/stencil.lock
@@ -17,10 +17,10 @@ modules:
       version: v1.3.3
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
-      version: v1.6.0
+      version: v1.6.1
     - name: github.com/getoutreach/stencil-outreach
       url: https://github.com/getoutreach/stencil-outreach
-      version: v0.5.0
+      version: v0.5.1
     - name: github.com/getoutreach/stencil-pipeline
       url: https://github.com/getoutreach/stencil-pipeline
       version: v1.0.2


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Skips e2e test since we don't have any, and skips docker since it will no longer work with the newest devbase.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
