### PR TITLE
fix: DT-3372 Make devconfig env `local_development`

### DIFF
--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -80,7 +80,7 @@ info "Generating local config/secrets in '$configDir'"
 envsubst="$("$DIR/gobin.sh" -p github.com/a8m/envsubst/cmd/envsubst@v1.2.0)"
 
 info "Fetching Configuration File(s)"
-DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "ConfigMap") | .data | to_entries[] | [.key, .value] | @tsv' | "$envsubst" |
+DEVENV_DEPLOY_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "ConfigMap") | .data | to_entries[] | [.key, .value] | @tsv' | "$envsubst" |
   while IFS=$'\t' read -r configFile configData; do
 
     saveFile="$configDir/$configFile"


### PR DESCRIPTION
[DT-3372](https://outreach-io.atlassian.net/browse/DT-3372)

Fixes a bug in `devconfig.sh`'s invocation of `build-jsonnet.sh` so it
will render the jsonnets in `local_development` mode instead of
`development` mode.

As I understand it, `local_development` is the environment for
developing on the developer's "host" machine.  The `development`
environment is for deploying to the developer's local k8s instance (ie.
`bento1a`).  The `devconfig` script is only relevant for
`local_development`.

The `devconfig.sh` script made a clear attempt to set the environment to
`local_development`, but it did so via a now-incorrect environment
variable.  In practice, it was rendering jsonnets with an environmetn
value of `development`.

I believe this confusion has been around for roughly six months now.
See ticket for details.  This is unlikely to be a breaking change for
most services, but I am slightly concerned that some services may have
come to depend ont he buggy behavior over this time period.

[DT-3372]: https://outreach-io.atlassian.net/browse/DT-3372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ