### PR TITLE
feat: QSS-1704 Support secrets in devconfig

### DIFF
--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -107,7 +107,7 @@ DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r
 
     info_sub "$secretName ($secretKey)"
     mkdir -p "$saveDir"
-    echo -n "$secretValueBase64" | base64 --decode >"$saveFile"
+    base64 --decode >"$saveFile" <<<"$secretValueBase64"
   done
 
 # Fetch secrets from Vault and store them at ~/.outreach/<appName>

--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -96,6 +96,20 @@ DEVENV_DEPLOY_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r
     rm "$tmpFile" "$mergedFile" >/dev/null 2>&1 || true
   done
 
+info "Fetching non-Vault Secret(s)"
+# Why: `$secretName` is intended as a yq variable not a shell variable.
+# shellcheck disable=SC2016
+DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "Secret") | .metadata.name as $secretName | (.data | to_entries[] | [$secretName, .key, .value] | @tsv)' | "$envsubst" |
+  while IFS=$'\t' read -r secretName secretKey secretValueBase64; do
+
+    saveDir="$configDir/$secretName"
+    saveFile="$configDir/$secretName/$secretKey"
+
+    info_sub "$secretName ($secretKey)"
+    mkdir -p "$saveDir"
+    echo -n "$secretValueBase64" | base64 --decode >"$saveFile"
+  done
+
 # Fetch secrets from Vault and store them at ~/.outreach/<appName>
 # In Kubernetes these will be stored in the same format, but at the path
 # /run/secrets/outreach.io/<basename vaultKey>/<vault subKey>


### PR DESCRIPTION
[QSS-1704](https://outreach-io.atlassian.net/browse/QSS-1704)

Update `devconfig.sh` to support the installation of local overrides for kubernetes secrets defined in deployment jsonnets.

While `devconfig.sh` has long supported local installation of secrets defined via the `VaultSecret` CRD, it hasn't supported plain old k8s secrets until now.

We do not expect this feature to be widely used.  In 99% of cases, a `VaultSecret` defined in the service's `service.yaml` is the right way to handle secrets.  However, there are rare use cases, like the one described in the attached ticket, where one might want to hard-code a secret in jsonnets and have `devconfig.sh` know how to install it in `$HOME/.outreach`.

[QSS-1704]: https://outreach-io.atlassian.net/browse/QSS-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ