### PR TITLE
feat: Add -trimpath to go builds.

### DIFF
--- a/root/Magefile.go
+++ b/root/Magefile.go
@@ -80,5 +80,6 @@ func Gobuild(ctx context.Context) error {
 		buildPath = "./plugin"
 	}
 
-	return runGoCommand("build", "-v", "-o", buildDir, "-ldflags", ldFlags, buildPath+"/...")
+        // Build with -trimpath to ensure we have consistent module filenames embedded.
+	return runGoCommand("build", "-v", "-trimpath", "-o", buildDir, "-ldflags", ldFlags, buildPath+"/...")
 }


### PR DESCRIPTION
This makes filenames consistent across builds.

This could be breaking for people filtering logs based on very specific stack traces. I think that's probably fine.
