### PR TITLE
fix: publish all files every release

### DIFF
--- a/root/Magefile.go
+++ b/root/Magefile.go
@@ -80,6 +80,6 @@ func Gobuild(ctx context.Context) error {
 		buildPath = "./plugin"
 	}
 
-        // Build with -trimpath to ensure we have consistent module filenames embedded.
+	// Build with -trimpath to ensure we have consistent module filenames embedded.
 	return runGoCommand("build", "-v", "-trimpath", "-o", buildDir, "-ldflags", ldFlags, buildPath+"/...")
 }

--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -77,4 +77,4 @@ while read -r file; do
   else
     info_sub "no space directive found, skipping ${file}"
   fi
-done < <(git diff --name-only HEAD.."$previousTag" -- '*.md')
+done < <(git ls-files -- '*.md')

--- a/shell/ci/release/docs.sh
+++ b/shell/ci/release/docs.sh
@@ -9,7 +9,7 @@ LIB_DIR="${DIR}/../../lib"
 source "${LIB_DIR}/logging.sh"
 
 TAG="$CIRCLE_TAG"
-# Do not update engdocs every run
+# Do not update engdocs unless there is a tag
 if [[ -n $TAG ]]; then
   # We need to use the module path to support major versions properly
   MODULE_PATH="$(go list -f '{{ .Path }}' -m)"

--- a/shell/ci/release/docs.sh
+++ b/shell/ci/release/docs.sh
@@ -10,7 +10,7 @@ source "${LIB_DIR}/logging.sh"
 
 TAG="$CIRCLE_TAG"
 # Do not update engdocs every run
-if [[ ! -z "$TAG" ]]; then
+if [[ -n $TAG ]]; then
   # We need to use the module path to support major versions properly
   MODULE_PATH="$(go list -f '{{ .Path }}' -m)"
 

--- a/shell/ci/release/docs.sh
+++ b/shell/ci/release/docs.sh
@@ -9,20 +9,18 @@ LIB_DIR="${DIR}/../../lib"
 source "${LIB_DIR}/logging.sh"
 
 TAG="$CIRCLE_TAG"
-if [[ -z $TAG ]]; then
-  # Calculate the psuedo-semver tag, this is used for non-v2 services
-  # (things without semantic-release, generally)
-  TAG="v0.0.0-$(TZ=UTC git --no-pager show --quiet --abbrev=12 --date='format-local:%Y%m%d%H%M%S' --format='%cd-%h')"
+# Do not update engdocs every run
+if [[ ! -z "$TAG" ]]; then
+  # We need to use the module path to support major versions properly
+  MODULE_PATH="$(go list -f '{{ .Path }}' -m)"
+
+  # TODO(jaredallard): Move this into box configuration?
+  URL="https://engdocs.outreach.cloud/fetch/$MODULE_PATH@$TAG"
+
+  info "updating engdocs"
+  curl -X POST "$URL"
 fi
 
-# We need to use the module path to support major versions properly
-MODULE_PATH="$(go list -f '{{ .Path }}' -m)"
-
-# TODO(jaredallard): Move this into box configuration?
-URL="https://engdocs.outreach.cloud/fetch/$MODULE_PATH@$TAG"
-
-info "updating engdocs"
-curl -X POST "$URL"
-
+# Confluence docs get updated every run
 info "publishing eligible markdown documents to confluence"
 "$DIR/confluence-publish.sh"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
There are times when a release fails and docs don't get published, and when a future release happens the older docs (since we compare current diff vs. previous diff) don't get updated. The preferred behavior is to publish all docs to confluence each release, and only update engdocs/godocs on semantic/tagged releases.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3205]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3205]: https://outreach-io.atlassian.net/browse/DT-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ