### PR TITLE
fix: DTSS-1744 Correct vault secret fetching env

### DIFF
--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -99,7 +99,7 @@ DEVENV_DEPLOY_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r
 info "Fetching non-Vault Secret(s)"
 # Why: `$secretName` is intended as a yq variable not a shell variable.
 # shellcheck disable=SC2016
-DEPLOY_TO_DEV_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "Secret") | .metadata.name as $secretName | (.data | to_entries[] | [$secretName, .key, .value] | @tsv)' | "$envsubst" |
+DEVENV_DEPLOY_ENVIRONMENT=local_development "$DIR/build-jsonnet.sh" show | yq -r 'select(.kind == "Secret") | .metadata.name as $secretName | (.data | to_entries[] | [$secretName, .key, .value] | @tsv)' | "$envsubst" |
   while IFS=$'\t' read -r secretName secretKey secretValueBase64; do
 
     saveDir="$configDir/$secretName"


### PR DESCRIPTION
[DTSS-1744](https://outreach-io.atlassian.net/browse/DTSS-1744)

Updates the environment override for the `build-jsonnet.sh` invocation
for fetching non-vault secrets to `DEVENV_DEPLOY_ENVIRONMENT`.  This
is analogous to the fix in [1].

The feature to render non-vault secrets in [2] just a few days after [1] 
was merged.  However, it seems we made the same mistake as had been
historically present in the config-rendering `build-jsonnet.sh`.  Oops.

[1] https://github.com/getoutreach/devbase/pull/411
[2] https://github.com/getoutreach/devbase/pull/416