### PR TITLE
fix: linter not exiting on error

### DIFF
--- a/shell/linters/bash.sh
+++ b/shell/linters/bash.sh
@@ -20,8 +20,8 @@ shellfmt_formatter() {
 }
 
 linter() {
-  run_command "shellcheck" shellcheck_linter || exit 1
-  run_command "shellfmt" shellfmt_linter || exit 1
+  run_command "shellcheck" shellcheck_linter || return 1
+  run_command "shellfmt" shellfmt_linter || return 1
 }
 
 formatter() {

--- a/shell/linters/bash.sh
+++ b/shell/linters/bash.sh
@@ -20,8 +20,8 @@ shellfmt_formatter() {
 }
 
 linter() {
-  run_command "shellcheck" shellcheck_linter
-  run_command "shellfmt" shellfmt_linter
+  run_command "shellcheck" shellcheck_linter || exit 1
+  run_command "shellfmt" shellfmt_linter || exit 1
 }
 
 formatter() {

--- a/shell/linters/go.sh
+++ b/shell/linters/go.sh
@@ -35,14 +35,14 @@ gofmt() {
 }
 
 linter() {
-  run_command "go mod tidy" go_mod_tidy || exit 1
+  run_command "go mod tidy" go_mod_tidy || return 1
   run_command "golangci-lint" \
-    "$DIR/golangci-lint.sh" --build-tags "or_e2e,or_test" --timeout 10m run --out-format colored-line-number ./... || exit 1
-  run_command "lintroller" lintroller || exit 1
+    "$DIR/golangci-lint.sh" --build-tags "or_e2e,or_test" --timeout 10m run --out-format colored-line-number ./... || return 1
+  run_command "lintroller" lintroller || return 1
 }
 
 formatter() {
-  run_command "go mod tidy" go_mod_tidy || exit 1
-  run_command "goimports" goimports || exit 1
-  run_command "gofmt" gofmt || exit 1
+  run_command "go mod tidy" go_mod_tidy || return 1
+  run_command "goimports" goimports || return 1
+  run_command "gofmt" gofmt || return 1
 }

--- a/shell/linters/go.sh
+++ b/shell/linters/go.sh
@@ -35,14 +35,14 @@ gofmt() {
 }
 
 linter() {
-  run_command "go mod tidy" go_mod_tidy
+  run_command "go mod tidy" go_mod_tidy || exit 1
   run_command "golangci-lint" \
-    "$DIR/golangci-lint.sh" --build-tags "or_e2e,or_test" --timeout 10m run --out-format colored-line-number ./...
-  run_command "lintroller" lintroller
+    "$DIR/golangci-lint.sh" --build-tags "or_e2e,or_test" --timeout 10m run --out-format colored-line-number ./... || exit 1
+  run_command "lintroller" lintroller || exit 1
 }
 
 formatter() {
-  run_command "go mod tidy" go_mod_tidy
-  run_command "goimports" goimports
-  run_command "gofmt" gofmt
+  run_command "go mod tidy" go_mod_tidy || exit 1
+  run_command "goimports" goimports || exit 1
+  run_command "gofmt" gofmt || exit 1
 }

--- a/shell/linters/js.sh
+++ b/shell/linters/js.sh
@@ -45,11 +45,11 @@ eslint_formatter() {
 }
 
 linter() {
-  run_command "eslint" eslint_linter || exit 1
-  run_command "prettier" prettier_linter || exit 1
+  run_command "eslint" eslint_linter || return 1
+  run_command "prettier" prettier_linter || return 1
 }
 
 formatter() {
-  run_command "eslint" eslint_formatter || exit 1
-  run_command "prettier" prettier_formatter || exit 1
+  run_command "eslint" eslint_formatter || return 1
+  run_command "prettier" prettier_formatter || return 1
 }

--- a/shell/linters/js.sh
+++ b/shell/linters/js.sh
@@ -45,11 +45,11 @@ eslint_formatter() {
 }
 
 linter() {
-  run_command "eslint" eslint_linter
-  run_command "prettier" prettier_linter
+  run_command "eslint" eslint_linter || exit 1
+  run_command "prettier" prettier_linter || exit 1
 }
 
 formatter() {
-  run_command "eslint" eslint_formatter
-  run_command "prettier" prettier_formatter
+  run_command "eslint" eslint_formatter || exit 1
+  run_command "prettier" prettier_formatter || exit 1
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
There are instances when running `make test` where an error that is thrown but the terminal will not exit and instead continue. There is a weird issue where if the linter function contains multiple commands and one fails the exit code does not explicitly return an exit value `1`.  This is the work around we came up with for now until we can further figure out a better solution 


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

DT-3405

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
