### PR TITLE
fix: use api-version=2 in debug.sh

### DIFF
--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -21,6 +21,7 @@ delve=(
   exec
   "$(get_repo_directory)/bin/${DEV_CONTAINER_EXECUTABLE:-$(get_app_name)}"
   --headless
+  --api-version=2
   --listen=":${DLV_PORT}"
 )
 


### PR DESCRIPTION
api-version=2 is required for goland and doesn't hurt vscode
