### PR TITLE
fix(lint): properly calculate when to erase contents, run devbase locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ Pulumi.*.yaml
 
 ## <<Stencil::Block(extras)>>
 orb.*
+.version
 ## <</Stencil::Block>>

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -163,8 +163,8 @@ func grabDependencies(ctx context.Context, deps map[string]struct{}, serviceName
 }
 
 // parseDevenvConfig parses the devenv.yaml file and returns a struct
-func parseDevenvConfig(path string) (*DevenvConfig, error) {
-	f, err := os.Open(path)
+func parseDevenvConfig(confPath string) (*DevenvConfig, error) {
+	f, err := os.Open(confPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read devenv.yaml or service.yaml")
 	}

--- a/scripts/devbase.sh
+++ b/scripts/devbase.sh
@@ -5,6 +5,13 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 libDir="$DIR/../.bootstrap"
 lockfile="$DIR/../stencil.lock"
+serviceYaml="$DIR/../service.yaml"
+
+# get_absolute_path returns the absolute path of a file
+get_absolute_path() {
+  python="$(command -v python3 || command -v python)"
+  "$python" -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+}
 
 # get_field_from_yaml reads a field from a yaml file using either go-yq or python-yq
 get_field_from_yaml() {
@@ -25,13 +32,21 @@ version=$(get_field_from_yaml '.modules[] | select(.name == "github.com/getoutre
 existingVersion=$(cat "$libDir/.version" 2>/dev/null || true)
 
 if [[ ! -e $libDir ]] || [[ $existingVersion != "$version" ]] || [[ ! -e "$libDir/.version" ]]; then
-  rm -rf "$libDir" || true
+  if [[ $version == "local" ]]; then
+    # If we're using a local version, we should use ln
+    # to map the local devbase into the bootstrap dir
 
-  git clone -q --single-branch --branch "$version" git@github.com:getoutreach/devbase \
-    "$libDir" >/dev/null
+    path=$(get_field_from_yaml '.replacements["github.com/getoutreach/devbase"]' "$serviceYaml")
+    absolute_path=$(get_absolute_path "$path")
+
+    ln -sf "$absolute_path" "$libDir"
+  else
+    git clone -q --single-branch --branch "$version" git@github.com:getoutreach/devbase \
+      "$libDir" >/dev/null
+
+    # Don't let devbase be confused by the existence of one there :(
+    rm "$libDir/service.yaml" || true # ignore errors
+  fi
 
   echo -n "$version" >"$libDir/.version"
-
-  # Don't let devbase be confused by the existence of one there :(
-  rm "$libDir/service.yaml" || true # ignore errors
 fi

--- a/service.yaml
+++ b/service.yaml
@@ -30,4 +30,6 @@ modules:
     # Removes ruby requirement
     version: ">=v1.8.0-rc.2"
   - name: github.com/getoutreach/devbase
+replacements:
+  github.com/getoutreach/devbase: ./
 migrated: true

--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -29,8 +29,6 @@ info "srcPath: ${srcPath}"
 defaultBranch="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
 info "defaultBranch: ${defaultBranch}"
 
-previousTag=$(git describe --abbrev=0 --tags HEAD^ || printf '' | git hash-object -t tree --stdin)
-
 while read -r file; do
   info "inspecting found markdown file: ${file}"
   if grep -Eq '^\s*<!--\s*Space:\s*\w+\s*-->\s*$' "${file}"; then

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -135,10 +135,10 @@ run_command() {
   local duration="$((finished_at - started_at))"
 
   if is_terminal; then
-    # If the position of the cursor didn't change, we can safely assume
-    # that the linter didn't output anything, so we can just overwrite
-    # the previous line.
-    if [[ $current_pos == "$after_pos" ]]; then
+    # If the position of the cursor didn't change, and wasn't zero,
+    # we can safely assume that the linter didn't output anything,
+    # so we can just overwrite the previous line.
+    if [[ $current_pos == "$after_pos" ]] && [[ $current_pos != "0,0" ]]; then
       tput cuu1 || true
     fi
   fi

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,7 +1,7 @@
-version: v1.30.0
+version: v0.0.0-unstable+8fbd9332465faadac4180438a11eec4984df8bdb
 modules:
     - name: github.com/getoutreach/devbase
-      url: https://github.com/getoutreach/devbase
+      url: file://./
       version: local
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base

--- a/stencil.lock
+++ b/stencil.lock
@@ -2,7 +2,7 @@ version: v1.30.0
 modules:
     - name: github.com/getoutreach/devbase
       url: https://github.com/getoutreach/devbase
-      version: v2.9.1
+      version: local
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
       version: v0.8.0

--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -5,6 +5,13 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 libDir="$DIR/../.bootstrap"
 lockfile="$DIR/../stencil.lock"
+serviceYaml="$DIR/../service.yaml"
+
+# get_absolute_path returns the absolute path of a file
+get_absolute_path() {
+  python="$(command -v python3 || command -v python)"
+  "$python" -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+}
 
 # get_field_from_yaml reads a field from a yaml file using either go-yq or python-yq
 get_field_from_yaml() {
@@ -25,13 +32,21 @@ version=$(get_field_from_yaml '.modules[] | select(.name == "github.com/getoutre
 existingVersion=$(cat "$libDir/.version" 2>/dev/null || true)
 
 if [[ ! -e $libDir ]] || [[ $existingVersion != "$version" ]] || [[ ! -e "$libDir/.version" ]]; then
-  rm -rf "$libDir" || true
+  if [[ $version == "local" ]]; then
+    # If we're using a local version, we should use ln
+    # to map the local devbase into the bootstrap dir
 
-  git clone -q --single-branch --branch "$version" git@github.com:getoutreach/devbase \
-    "$libDir" >/dev/null
+    path=$(get_field_from_yaml '.replacements["github.com/getoutreach/devbase"]' "$serviceYaml")
+    absolute_path=$(get_absolute_path "$path")
+
+    ln -sf "$absolute_path" "$libDir"
+  else
+    git clone -q --single-branch --branch "$version" git@github.com:getoutreach/devbase \
+      "$libDir" >/dev/null
+
+    # Don't let devbase be confused by the existence of one there :(
+    rm "$libDir/service.yaml" || true # ignore errors
+  fi
 
   echo -n "$version" >"$libDir/.version"
-
-  # Don't let devbase be confused by the existence of one there :(
-  rm "$libDir/service.yaml" || true # ignore errors
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes the tests to not wipe contents out on failure to calculate cursor position, only when able to do so.

I also added support for running devbase on devbase to enable better testing of devbase changes.
<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3487]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3487]: https://outreach-io.atlassian.net/browse/DT-3487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ