### PR TITLE
fix(lint/fmt): dont error on deleted files

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -1,5 +1,12 @@
 # linters
 
-### Why linters is returning `return 1` after each command
-There is currently a bash issue where the exit code is not getting detected when there is multiple commands being ran. 
-The easy solution for now is to return the value 1 from the function indicating an error has occured and terminating the `make test/lint` command that triggered it
+## Ignoring files
+
+Files are ignored through the usage of `.gitignore`. This is done to ensure that the linters are not ran on files that are not meant to be committed.
+
+There is currently no way to ignore files outside of the `.gitignore` file.
+
+## Why linters is returning `return 1` after each command
+
+There is currently a bash issue where the exit code is not getting detected when there is multiple commands being ran.
+The easy solution for now is to return the value 1 from the function indicating an error has occurred and terminating the `make test/lint` command that triggered it

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -37,6 +37,8 @@ This uses [gotestsum](https://github.com/gotestyourself/gotestsum) to run the te
 
 Runs the linters for the project. This defaults to running all linters.
 
+See [linters](linters.md) for more information.
+
 ### `coverage`
 
 **Note**: The options here are shared with `make test`.
@@ -46,6 +48,8 @@ Runs the tests for the project and generates a coverage report. This defaults to
 ### `fmt`
 
 Runs all formatting tools for the project.
+
+Formatters share most of the same options as `make lint`, see the [linters](linters.md) documentation for more information.
 
 ### `gogenerate`
 

--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -26,28 +26,16 @@ for languageScript in "$DIR/linters"/*.sh; do
     # Note: These are modified by the source'd language file
     # extensions are the extensions this linter should run on
     extensions=()
-    # files are the files this linter should run on
-    files=()
 
     # Why: Dynamic
     # shellcheck disable=SC1090
     source "$DIR/linters/$languageName.sh"
 
     matched=false
-    for extension in "${extensions[@]}"; do
-      # If we don't find any files with the extension, skip the run.
-      if [[ "$(git ls-files '*'."$extension" | wc -l | tr -d ' ')" -le 0 ]]; then
-        continue
-      fi
+    if [[ "$(find_files_with_extensions "${extensions[@]}" | wc -l | tr -d ' ')" -gt 0 ]]; then
       matched=true
-    done
-    for file in "${files[@]}"; do
-      # If there are no matching files, skip the run.
-      if [[ "$(git ls-files "$file" | wc -l | tr -d ' ')" -le 0 ]]; then
-        continue
-      fi
-      matched=true
-    done
+    fi
+
     if [[ $matched == "false" ]]; then
       exit 0
     fi
@@ -59,13 +47,6 @@ for languageScript in "$DIR/linters"/*.sh; do
 
     # show is used by run_command as metadata to be shown along with the command name
     show=$extensionsString
-
-    # If we don't have any extensions, show the files this was ran on
-    if [[ $extensionsString == "." ]]; then
-      # shellcheck disable=SC2155,SC2001
-      filesString=$(sed 's/ /,/g' <<<"${files[*]}")
-      show=$filesString
-    fi
 
     # Set by the language file
     if ! formatter; then

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -156,3 +156,24 @@ format_diff() {
   local ms=$((diff % 1000))
   printf "%d.%02ds" "$seconds" "$ms"
 }
+
+# find_files_with_extensions returns a newline separated list of files
+# that contain one of the provided extensions.
+#
+# Usage: find_files_with_extensions <extensions...>
+find_files_with_extensions() {
+  local extensions=("$@")
+
+  local git_ls_files_extensions=()
+  for ext in "${extensions[@]}"; do
+    git_ls_files_extensions+=("*.$ext")
+  done
+
+  # Find all files that match the extension, including untracked and tracked files. Excluding
+  # files in the .gitignore.
+  git ls-files --cached --others --modified --exclude-standard "${git_ls_files_extensions[@]}" |
+    # Remove duplicates.
+    sort | uniq |
+    # Remove deleted files from the list.
+    grep -vE "^$(git ls-files --deleted | paste -sd "|" -)$"
+}

--- a/shell/linters.sh
+++ b/shell/linters.sh
@@ -30,28 +30,17 @@ for languageScript in "$DIR/linters"/*.sh; do
     # Note: These are modified by the source'd language file
     # extensions are the extensions this linter should run on
     extensions=()
-    # files are the files this linter should run on
-    files=()
 
     # Why: Dynamic
     # shellcheck disable=SC1090
     source "$DIR/linters/$languageName.sh"
 
+    # If we don't find any files with the extension, skip the run.
     matched=false
-    for extension in "${extensions[@]}"; do
-      # If we don't find any files with the extension, skip the run.
-      if [[ "$(git ls-files '*'."$extension" | wc -l | tr -d ' ')" -le 0 ]]; then
-        continue
-      fi
+    if [[ "$(find_files_with_extensions "${extensions[@]}" | wc -l | tr -d ' ')" -gt 0 ]]; then
       matched=true
-    done
-    for file in "${files[@]}"; do
-      # If there are no matching files, skip the run.
-      if [[ "$(git ls-files "$file" | wc -l | tr -d ' ')" -le 0 ]]; then
-        continue
-      fi
-      matched=true
-    done
+    fi
+
     if [[ $matched == "false" ]]; then
       exit 0
     fi
@@ -63,13 +52,6 @@ for languageScript in "$DIR/linters"/*.sh; do
 
     # show is used by run_command as metadata to be shown along with the command name
     show=$extensionsString
-
-    # If we don't have any extensions, show the files this was ran on
-    if [[ $extensionsString == "." ]]; then
-      # shellcheck disable=SC2155,SC2001
-      filesString=$(sed 's/ /,/g' <<<"${files[*]}")
-      show=$filesString
-    fi
 
     # Set by the language file
     if ! linter; then

--- a/shell/linters/bash.sh
+++ b/shell/linters/bash.sh
@@ -8,15 +8,15 @@ SHELLCHECKPATH="$DIR/shellcheck.sh"
 extensions=(sh bash)
 
 shellcheck_linter() {
-  git ls-files '*.sh' | xargs -n40 "$SHELLCHECKPATH" -x -P SCRIPTDIR
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$SHELLCHECKPATH" -x -P SCRIPTDIR
 }
 
 shellfmt_linter() {
-  git ls-files '*.sh' | xargs -n40 "$SHELLFMTPATH" -s -d
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$SHELLFMTPATH" -s -d
 }
 
 shellfmt_formatter() {
-  git ls-files '*.sh' | xargs -n40 "$SHELLFMTPATH" -w -l
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$SHELLFMTPATH" -w -l
 }
 
 linter() {

--- a/shell/linters/go.sh
+++ b/shell/linters/go.sh
@@ -27,11 +27,11 @@ goimports() {
   # Why: We're OK with this.
   # shellcheck disable=SC2155
   local GOIMPORTS=$("$DIR/gobin.sh" -p golang.org/x/tools/cmd/goimports@v"$(get_application_version "goimports")")
-  git ls-files '*.go' | xargs -n40 "$GOIMPORTS" -w
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$GOIMPORTS" -w
 }
 
 gofmt() {
-  git ls-files '*.go' | xargs -n40 "$(command -v gofmt)" -s -w
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$(command -v gofmt)" -s -w
 }
 
 linter() {

--- a/shell/linters/js.sh
+++ b/shell/linters/js.sh
@@ -10,7 +10,7 @@ source "$DIR/languages/nodejs.sh"
 extensions=(js)
 
 find_node_projects() {
-  git ls-files "*.package.json"
+  find_files_with_extensions "package.json"
 }
 
 # for_each_package runs a command for each package found in the repo

--- a/shell/linters/jsonnet.sh
+++ b/shell/linters/jsonnet.sh
@@ -9,7 +9,7 @@ jsonnetfmt() {
   # Why: We're OK with this.
   # shellcheck disable=SC2155
   local JSONNETFMT=$("$DIR/gobin.sh" -p github.com/google/go-jsonnet/cmd/jsonnetfmt@v"$(get_application_version "jsonnetfmt")")
-  git ls-files '*.jsonnet' '*.libsonnet' | xargs -n40 "$JSONNETFMT" -i
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$JSONNETFMT" -i
 }
 
 linter() {

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -11,13 +11,13 @@ extensions=(yaml yml json md ts)
 
 prettier_linter() {
   yarn_install_if_needed >/dev/null
-  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "node_modules/.bin/prettier" -l --loglevel log
   return $?
 }
 
 prettier_formatter() {
   yarn_install_if_needed >/dev/null
-  git ls-files '*.yaml' '*.yml' '*.json' '*.md' '*.ts' | xargs -n40 "node_modules/.bin/prettier" --write --loglevel warn
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "node_modules/.bin/prettier" --write --loglevel warn
 }
 
 linter() {

--- a/shell/linters/protobuf.sh
+++ b/shell/linters/protobuf.sh
@@ -9,14 +9,14 @@ buf_linter() {
   # Why: We're OK with this.
   # shellcheck disable=SC2155
   local PROTOFMT=$("$DIR/gobin.sh" -p github.com/bufbuild/buf/cmd/buf@v"$(get_tool_version "buf")")
-  git ls-files '*.proto' | xargs -n1 "$PROTOFMT" format --exit-code --diff
+  find_files_with_extensions "${extensions[@]}" | xargs -n1 "$PROTOFMT" format --exit-code --diff
 }
 
 buf_formatter() {
   # Why: We're OK with this.
   # shellcheck disable=SC2155
   local PROTOFMT=$("$DIR/gobin.sh" -p github.com/bufbuild/buf/cmd/buf@v"$(get_tool_version "buf")")
-  git ls-files '*.proto' | xargs -n1 "$PROTOFMT" format -w
+  find_files_with_extensions "${extensions[@]}" | xargs -n1 "$PROTOFMT" format -w
 }
 
 linter() {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR changes the file detection logic for `fmt` and `lint` targets to not error on deleted files. This also optimizes them to use the same function for getting files, minus go linters which require package paths, and thus aren't applicable.

This is done by using `git ls-file` with support for untracked files and filtering out deleted files. `find` could've been used, but running `git check-ignore` would've been required to be ran on each file and would be expensive. So, `git ls-files` is continued to be used in this nuanced way.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3548]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3548]: https://outreach-io.atlassian.net/browse/DT-3548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ