### PR TITLE
fix(shell-wrapper): remove libDir before populating

### DIFF
--- a/scripts/devbase.sh
+++ b/scripts/devbase.sh
@@ -32,6 +32,8 @@ version=$(get_field_from_yaml '.modules[] | select(.name == "github.com/getoutre
 existingVersion=$(cat "$libDir/.version" 2>/dev/null || true)
 
 if [[ ! -e $libDir ]] || [[ $existingVersion != "$version" ]] || [[ ! -e "$libDir/.version" ]]; then
+  rm -rf "$libDir"
+
   if [[ $version == "local" ]]; then
     # If we're using a local version, we should use ln
     # to map the local devbase into the bootstrap dir

--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -32,6 +32,8 @@ version=$(get_field_from_yaml '.modules[] | select(.name == "github.com/getoutre
 existingVersion=$(cat "$libDir/.version" 2>/dev/null || true)
 
 if [[ ! -e $libDir ]] || [[ $existingVersion != "$version" ]] || [[ ! -e "$libDir/.version" ]]; then
+  rm -rf "$libDir"
+
   if [[ $version == "local" ]]; then
     # If we're using a local version, we should use ln
     # to map the local devbase into the bootstrap dir


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Fixes a small bug in the new `local` logic that was introduced, when downloading from Github we wouldn't remove that directory first.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
