### PR TITLE
Revert "fix(golangci-lint): 1.51.2"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -15,7 +15,7 @@ protoc 21.5
 ## <<Stencil::Block(toolver)>>
 # The below tools are used by all repositories when using devbase
 mage 1.14.0
-golangci-lint 1.51.2
+golangci-lint 1.50.0
 shellcheck 0.9.0
 shfmt 3.6.0
 ## <</Stencil::Block>>


### PR DESCRIPTION
Reverts getoutreach/devbase#471
Still breaks `ent`. Sad.