### PR TITLE
fix: allow customize image building

### DIFF
--- a/orbs/shared/jobs/docker.yaml
+++ b/orbs/shared/jobs/docker.yaml
@@ -11,7 +11,7 @@ steps:
   - setup_environment:
       machine: true
   - build_docker_image
-      script: './scripts/shell-wrapper.sh ci/release/docker.sh' << parameters.image >>
+      script: './scripts/shell-wrapper.sh ci/release/docker.sh << parameters.image >>'
 
   # IDEA(jaredallard): We'll need to move this out in the future
   - store_artifacts:

--- a/orbs/shared/jobs/docker.yaml
+++ b/orbs/shared/jobs/docker.yaml
@@ -2,10 +2,16 @@ description: Build and (optionally push) a Docker image. Pushes only on release 
 executor:
   name: testbed-machine
 resource_class: xlarge
+parameters:
+  image:
+    default: ''
+    description: allow build a named image besides the default
+    type: string
 steps:
   - setup_environment:
       machine: true
   - build_docker_image
+      script: './scripts/shell-wrapper.sh ci/release/docker.sh' << parameters.image >>
 
   # IDEA(jaredallard): We'll need to move this out in the future
   - store_artifacts:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
in order to build a image with customized name, we need to pass that name to build-docker-image step


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DSC-10739]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DSC-10739]: https://outreach-io.atlassian.net/browse/DSC-10739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ