### PR TITLE
fix: add error message when `make grpcui` fails

### DIFF
--- a/shell/grpcui.sh
+++ b/shell/grpcui.sh
@@ -10,10 +10,8 @@ source "$DIR/lib/bootstrap.sh"
 # We set -plaintext here because we don't use GRPC TLS
 args=("-plaintext" "$@")
 
-"$GOBIN" "github.com/fullstorydev/grpcui/cmd/grpcui@v$(get_application_version "grpcui")" "${args[@]}"
-
-# check if the grpcui command failed
-if [ $? -ne 0 ]; then
+# check if the grpcui command failes and if so echo error message
+if ! "$GOBIN" "github.com/fullstorydev/grpcui/cmd/grpcui@v$(get_application_version "grpcui")" "${args[@]}"; then
   echo
   echo 'this expects your service to either be running locally or have port forward running.
 to port forward:

--- a/shell/grpcui.sh
+++ b/shell/grpcui.sh
@@ -14,9 +14,9 @@ args=("-plaintext" "$@")
 
 # check if the grpcui command failed
 if [ $? -ne 0 ]; then
-    echo
-    echo "this expects your service to either be running locally or have a prot forward.
+  echo
+  echo 'this expects your service to either be running locally or have a prot forward.
 to port forward:
-  - deploy to devenv (i.e. \"devenv app deploy .\")
-  - run \"kubectl port-forward service/[SERVICE-NAME] 5000:5000 -n [NAMESPACE]\""
+  - deploy to devenv (i.e. "devenv app deploy .")
+  - run "kubectl port-forward service/[SERVICE-NAME] 5000:5000 -n [NAMESPACE]"'
 fi

--- a/shell/grpcui.sh
+++ b/shell/grpcui.sh
@@ -10,4 +10,13 @@ source "$DIR/lib/bootstrap.sh"
 # We set -plaintext here because we don't use GRPC TLS
 args=("-plaintext" "$@")
 
-exec "$GOBIN" "github.com/fullstorydev/grpcui/cmd/grpcui@v$(get_application_version "grpcui")" "${args[@]}"
+"$GOBIN" "github.com/fullstorydev/grpcui/cmd/grpcui@v$(get_application_version "grpcui")" "${args[@]}"
+
+# check if the grpcui command failed
+if [ $? -ne 0 ]; then
+    echo
+    echo "this expects your service to either be running locally or have a prot forward.
+to port forward:
+  - deploy to devenv (i.e. \"devenv app deploy .\")
+  - run \"kubectl port-forward service/[SERVICE-NAME] 5000:5000 -n [NAMESPACE]\""
+fi

--- a/shell/grpcui.sh
+++ b/shell/grpcui.sh
@@ -15,7 +15,7 @@ args=("-plaintext" "$@")
 # check if the grpcui command failed
 if [ $? -ne 0 ]; then
   echo
-  echo 'this expects your service to either be running locally or have a prot forward.
+  echo 'this expects your service to either be running locally or have port forward running.
 to port forward:
   - deploy to devenv (i.e. "devenv app deploy .")
   - run "kubectl port-forward service/[SERVICE-NAME] 5000:5000 -n [NAMESPACE]"'


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Provide better error message to users when they run `make grpcui`. The rendered output message will look like:

```
this expects your service to either be running locally or have port forward running.
to port forward:
  - deploy to devenv (i.e. "devenv app deploy .")
  - run "kubectl port-forward service/[SERVICE-NAME] 5000:5000 -n [NAMESPACE]"'
 ```


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

DT-3582

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
