### PR TITLE
fix: send notification if opslevel check fails

### DIFF
--- a/shell/ci/release/release.sh
+++ b/shell/ci/release/release.sh
@@ -36,7 +36,7 @@ source "${LIB_DIR}/box.sh"
 OPSLEVEL_ENABLED="$(get_box_field '.ci.opslevelEnabled')"
 if [[ $OPSLEVEL_ENABLED == "true" && "$(is_service)" == "false" ]]; then
   echo "checking opslevel"
-  make checkopslevel
+  make checkopslevel || send_failure_notification
 fi
 
 ORIGINAL_VERSION=$(git describe --match 'v[0-9]*' --tags --always HEAD)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

we want to get notified if releases fails because of opslevel check

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
