### PR TITLE
feat: Add `SHUFFLE=disabled` test env option

### DIFF
--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -29,7 +29,8 @@ This uses [gotestsum](https://github.com/gotestyourself/gotestsum) to run the te
 * `BENCH_FLAGS` (env var): Flags to pass to `go test -bench` when `make benchmark` is run
 * `GO_TEST_TIMEOUT` (env var): Timeout for `go test`
 * `TEST_TAGS` (env var): Tags to pass to `go test` (default: `or_test`)
-* `RACE` (env var): Enables race condition testings (default: ''). Set to `disabled` to disable.
+* `RACE` (env var): Enables `-race` testflag (default: ''). Set to `disabled` to disable.
+* `SHUFFLE` (env var): Enables `-shuffle` testflag (default: ''). Set to `disabled` to disable.
 * `TEST_PACKAGES` (env var): Packages to test. Defaults to `./...`
 * `PACKAGE_TO_DEBUG` (env var): Set to debug a specific package.
 

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -79,6 +79,13 @@ GO_TEST_TIMEOUT="${GO_TEST_TIMEOUT:-}"
 # will not be passed to 'go test'. Defaults to 'enabled'.
 RACE="${RACE:-enabled}"
 
+# SHUFFFLE determines if 'go test -shuffle' should be enabled or not. If set to
+# 'disabled', test order randomization will not be enabled and the flag will
+# not be passed to 'go test'. Note that `-shuffle` is incompatible with test
+# caching, so disabling it can result in a substantial speedup in development.
+# Defaults to 'enabled'.
+SHUFFLE="${SHUFFLE:-enabled}"
+
 # TEST_OUTPUT_FORMAT is the format to pass to gotestsum. If not set,
 # the default value of "dots-v2" will be used. If CI is set, the default
 # value is "pkgname". If 'TEST_FLAGS' contains '-v', the default value
@@ -110,7 +117,7 @@ REPODIR=$(get_repo_directory)
 # Catches test dependencies by shuffling tests if the installed Go version supports it
 currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
 requiredver="1.17.0"
-if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$requiredver" ]]; then
+if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$requiredver" && $SHUFFLE != "disabled" ]]; then
   TEST_FLAGS+=(-shuffle=on)
 fi
 

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -83,7 +83,7 @@ RACE="${RACE:-enabled}"
 # 'disabled', test order randomization will not be enabled and the flag will
 # not be passed to 'go test'. Note that `-shuffle` is incompatible with test
 # caching, so disabling it can result in a substantial speedup in development.
-# Defaults to 'enabled'.
+# Defaults to 'enabled' if the version of Go supports it (>=1.17).
 SHUFFLE="${SHUFFLE:-enabled}"
 
 # TEST_OUTPUT_FORMAT is the format to pass to gotestsum. If not set,


### PR DESCRIPTION
Adds the option to remove the `-shuffle=on` flag.  The use of `-shuffle`
disables test caching, which is not a great experience for TDD.  Many
devs will want to turn this off during local development.