### PR TITLE
feat: build docker early to speedup e2e

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -326,7 +326,7 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 	// Docker build in devenv apps deploy . will be superfast then.
 	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
-		log.Info().Msg("Starting early docker build docker build")
+		log.Info().Msg("Starting early docker build")
 		if err := exec.CommandContext(ctx, "make", "docker-build").Run(); err != nil {
 			log.Warn().Err(err).Msg("Error when running early docker build")
 		} else {

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -326,6 +326,7 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 	// Docker build in devenv apps deploy . will be superfast then.
 	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
+		log.Info().Msg("Starting early docker build docker build")
 		if err := exec.CommandContext(ctx, "make", "docker-build").Run(); err != nil {
 			log.Warn().Err(err).Msg("Error when running early docker build")
 		} else {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
- Docker build takes e.g. in `rms` 6 minutes which were previously added to `make e2e` execution time
- This change is about not building docker in the critical path, but together with app dependencies deployment where CPU load is low


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QF-848]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[QF-848]: https://outreach-io.atlassian.net/browse/QF-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ