### PR TITLE
feat: don't deploy optional transitive dependencies to speed up e2e tests

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: Logic related to Devenv.yaml config
+
+// Package config contains logic related to Devenv.yaml config
+package config
+
+import (
+	"context"
+	"os"
+
+	"github.com/getoutreach/gobox/pkg/box"
+	"github.com/google/go-github/v47/github"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v2"
+)
+
+// Devenv is a struct that contains the devenv configuration
+// which is usually called "devenv.yaml". This also works for the
+// legacy service.yaml format.
+type Devenv struct {
+	// Service denotes if this repository is a service.
+	Service bool `yaml:"service"`
+
+	Dependencies struct {
+		// Optional is a list of OPTIONAL services e.g. the service can run / gracefully function without it running
+		Optional []string `yaml:"optional"`
+
+		// Required is a list of services that this service cannot function without
+		Required []string `yaml:"required"`
+	} `yaml:"dependencies"`
+}
+
+// FromFile parses the devenv.yaml file and returns a DevenvConfig
+func FromFile(confPath string) (*Devenv, error) {
+	f, err := os.Open(confPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read devenv.yaml or service.yaml")
+	}
+	defer f.Close()
+
+	var dc Devenv
+	if err := yaml.NewDecoder(f).Decode(&dc); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse devenv.yaml or service.yaml")
+	}
+
+	return &dc, nil
+}
+
+// FromGitHub reads and parses DevenvConfig from GitHub
+func FromGitHub(ctx context.Context, conf *box.Config, serviceName string,
+	gh *github.Client, configFileName string) (*Devenv, error) {
+	r, _, err := gh.Repositories.DownloadContents(ctx, conf.Org, serviceName, configFileName, nil)
+	l := log.With().Str("service", serviceName).Str("file", configFileName).Logger()
+	if err != nil {
+		l.Debug().Msg("Unable to find file in GH")
+		return nil, err
+	}
+	defer r.Close()
+	var dc Devenv
+	if err := yaml.NewDecoder(r).Decode(&dc); err != nil {
+		l.Warn().Msg("Unable to parse config file")
+		return nil, err
+	}
+	return &dc, nil
+}
+
+// getDependencies returns dependencies to install based on Devenv config and DEPLOY_OPTIONAL_DEPENDENCIES environment variable
+func (c *Devenv) GetDependencies() []string {
+	deps := make([]string, 0)
+	deps = append(deps, c.Dependencies.Required...)
+	if os.Getenv("DEPLOY_OPTIONAL_DEPENDENCIES") == "true" {
+		deps = append(deps, c.Dependencies.Optional...)
+	}
+	return deps
+}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -66,12 +66,10 @@ func FromGitHub(ctx context.Context, conf *box.Config, serviceName string,
 	return &dc, nil
 }
 
-// getDependencies returns dependencies to install based on Devenv config and DEPLOY_OPTIONAL_DEPENDENCIES environment variable
-func (c *Devenv) GetDependencies() []string {
+// getDependencies returns all dependencies
+func (c *Devenv) GetAllDependencies() []string {
 	deps := make([]string, 0)
 	deps = append(deps, c.Dependencies.Required...)
-	if os.Getenv("DEPLOY_OPTIONAL_DEPENDENCIES") == "true" {
-		deps = append(deps, c.Dependencies.Optional...)
-	}
+	deps = append(deps, c.Dependencies.Optional...)
 	return deps
 }

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -43,7 +43,7 @@ func BuildDependenciesList(ctx context.Context, conf *box.Config) ([]string, err
 		return nil, errors.Wrap(err, "failed to parse devenv.yaml")
 	}
 
-	for _, d := range dc.GetDependencies() {
+	for _, d := range dc.GetAllDependencies() {
 		if err := grabDependencies(ctx, conf, deps, d); err != nil {
 			return nil, err
 		}
@@ -84,7 +84,8 @@ func findDependenciesInRepo(ctx context.Context, conf *box.Config, serviceName s
 	}
 
 	deps := make(map[string]struct{})
-	for _, d := range dc.GetDependencies() {
+	// We deploy just required transitive dependencies
+	for _, d := range dc.Dependencies.Required {
 		deps[d] = struct{}{}
 	}
 

--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -1,9 +1,5 @@
 description: Run E2E tests in a Kubernetes cluster
 parameters:
-  deploy_optional_dependencies:
-    description: Deploy all optional dependencies (defined in devenv.yaml) before running e2e tests
-    type: boolean
-    default: false
   vault_address:
     description: Vault Instance to use
     type: string

--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -1,5 +1,9 @@
 description: Run E2E tests in a Kubernetes cluster
 parameters:
+  deploy_optional_dependencies:
+    description: Deploy all optional dependencies (defined in devenv.yaml) before running e2e tests
+    type: boolean
+    default: false
   vault_address:
     description: Vault Instance to use
     type: string


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
- Currently before running e2e tests, both optional and mandatory dependencies were deployed to the cluster
- This change is about to deploy only optional dependencies of application under test, not optional dependencies of its dependencies


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QF-847]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[QF-847]: https://outreach-io.atlassian.net/browse/QF-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ