### PR TITLE
fix(shell-wrapper): always remove service.yaml if exists in libDir

### DIFF
--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -45,10 +45,16 @@ if [[ ! -e $libDir ]] || [[ $existingVersion != "$version" ]] || [[ ! -e "$libDi
   else
     git clone -q --single-branch --branch "$version" git@github.com:getoutreach/devbase \
       "$libDir" >/dev/null
-
-    # Don't let devbase be confused by the existence of one there :(
-    rm "$libDir/service.yaml" || true # ignore errors
   fi
 
   echo -n "$version" >"$libDir/.version"
+fi
+
+# If we're not using a local version, ensure that service.yaml doesn't exist
+# in the library directory. This is because of the repo detection logic
+# which looks for the base directory through the existence of that file.
+if [[ $version != "local" ]]; then
+    if [[ -e "$libDir/service.yaml" ]]; then
+      rm "$libDir/service.yaml"
+    fi
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR changes the logic to delete `service.yaml` to always run, in case the initial clone logic failed or some other issue. This is only ran when `version != local`, because if it's local the baseDir is symlinked and thus still works (also that would remove the real `service.yaml` of devbase)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
