### PR TITLE
fix: `upload_prismaci.sh` to handle artifacts that don't exist yet

### DIFF
--- a/shell/opslevel/upload_prismaci.sh
+++ b/shell/opslevel/upload_prismaci.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-#
+
 # This script uploads Twistlock Image Scan results (in a compact format) to OpsLevel.
 # This is not a standalone script - it is meant to be called from the upload.sh script only.
-#
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 IMAGE_SCAN_ARTIFACT_NAME="tmp/test-results/image_scan.json"
@@ -22,10 +22,31 @@ if [[ -z ${ARTIFACT_URL} ]]; then
   exit 0
 fi
 
-# Download the scan results locally
-download_artifact_by_full_url "${ARTIFACT_URL}" "${SCAN_RESULTS_FILE}"
+# Set interval (duration) in seconds.
+SECONDS=1
+# Calculate end timeout.
+ENDTIMEOUT=$(( $(date +%s) + SECONDS )) 
 
-# Generate summary file, see image_scan_filter.jq for more details.
+while [ "$(date +%s)" -lt $ENDTIMEOUT ]; do
+  # Download the scan results locally
+  download_artifact_by_full_url "${ARTIFACT_URL}" "${SCAN_RESULTS_FILE}"
+
+  # check for a message value
+  RESULT_FILE_MESSAGE=$(jq -r .message ${SCAN_RESULTS_OPSLEVEL_FILE})
+
+  # if no message field exists then we can assume that the artifact exists based
+  # on file output
+  if [[ "${RESULT_FILE_MESSAGE}" == "null" ]]; then 
+    break
+  fi
+
+  # check var contains the message "Build not found". If so continue
+  if [[ "${RESULT_FILE_MESSAGE}" == "Build not found" ]]; then
+    continue
+  fi
+done
+
+Generate summary file, see image_scan_filter.jq for more details.
 jq \
   -f "${DIR}/image_scan_filter.jq" \
   --arg url "${ARTIFACT_URL}" \


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
There sometimes is an issue where an artifact will not exist when the script `upload_prismaci.sh` is ran. This PR will implement a loop to retry the check if the artifact is not found.  ([ref](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1680298868480539))


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

DT-3633

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
