### PR TITLE
feat:  pre-setup-script for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,7 @@ test: &test
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>
-  environment:
-    PRETEST_SCRIPT: ./bin/echo
+
   ## <</Stencil::Block>>
 
 # Branches used for releasing code, pre-release or not

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ test: &test
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>
-
+  environment:
+    PRETEST_SCRIPT: ./bin/echo
   ## <</Stencil::Block>>
 
 # Branches used for releasing code, pre-release or not

--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -7,6 +7,9 @@ parameters:
     default: _json_key
     description: Username to use when fetching images from a registry
     type: string
+  pre_test_script:
+    description: Environment variable that contains a shell path to run before running tests in CircleCI
+    type: string
   docker_password:
     default: $GCLOUD_SERVICE_ACCOUNT
     description: Environment variable to read docker password from

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -8,7 +8,7 @@ parameters:
     description: Username to use when fetching images from a registry
     type: string
   pre_setup_script:
-    description: Environment variable that contains a shell path to execute before running tests in CircleCI
+    description: Environment variable that contains an executable to run before running tests in CircleCI. This may not include arguments.
     type: string
   docker_password:
     default: $GCLOUD_SERVICE_ACCOUNT

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -7,6 +7,9 @@ parameters:
     default: _json_key
     description: Username to use when fetching images from a registry
     type: string
+  pre_setup_script:
+    description: Environment variable that contains a shell path to execute before running tests in CircleCI
+    type: string
   docker_password:
     default: $GCLOUD_SERVICE_ACCOUNT
     description: Environment variable to read docker password from
@@ -41,7 +44,7 @@ executor:
 
 environment:
   AWS_REGION: << parameters.aws_region >>
-
+  PRE_SETUP_SCRIPT: << parameters.pre_setup_script >>
 steps:
   - when:
       condition:

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -8,7 +8,7 @@ parameters:
     description: Username to use when fetching images from a registry
     type: string
   pre_setup_script:
-    description: Environment variable that contains an executable to run before running tests in CircleCI. This may not include arguments.
+    description: If set, the executable to run before running tests in CircleCI. This may not include arguments.
     type: string
   docker_password:
     default: $GCLOUD_SERVICE_ACCOUNT

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -35,7 +35,7 @@ fi
 if [[ -n $PRE_SETUP_SCRIPT ]]; then
   echo "⚙️ Running setup script \"${PRE_SETUP_SCRIPT}\" (from PRE_SETUP_SCRIPT)"
   # shellcheck source=/dev/null
-  source "${PRE_SETUP_SCRIPT}"
+  "${PRE_SETUP_SCRIPT}"
 fi
 
 # Setup a box stub

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -31,8 +31,11 @@ if [[ -n $TEST_RESULTS ]]; then
   mkdir -p "$TEST_RESULTS"
 fi
 
-if [[ -n $PRETEST_SCRIPT ]]; then
-  source "${PRETEST_SCRIPT}
+# run prescript if user specified to install packages etc. before tests
+if [[ -n $PRE_SETUP_SCRIPT ]]; then
+  echo "⚙️ Running setup script \"${PRE_SETUP_SCRIPT}\" (from PRE_SETUP_SCRIPT)"
+  # shellcheck source=/dev/null
+  source "${PRE_SETUP_SCRIPT}"
 fi
 
 # Setup a box stub

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -33,7 +33,7 @@ fi
 
 # run prescript if user specified to install packages etc. before tests
 if [[ -n $PRE_SETUP_SCRIPT ]]; then
-  echo "⚙️ Running setup script \"${PRE_SETUP_SCRIPT}\" (from PRE_SETUP_SCRIPT)"
+  echo "⚙️ Running setup script \"${PRE_SETUP_SCRIPT}\" (from pre_setup_script)"
   # shellcheck source=/dev/null
   "${PRE_SETUP_SCRIPT}"
 fi

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -31,6 +31,10 @@ if [[ -n $TEST_RESULTS ]]; then
   mkdir -p "$TEST_RESULTS"
 fi
 
+if [[ -n $PRETEST_SCRIPT ]]; then
+  source "${PRETEST_SCRIPT}
+fi
+
 # Setup a box stub
 boxPath="$HOME/.outreach/.config/box/box.yaml"
 mkdir -p "$(dirname "$boxPath")"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Users would like the ability to add packages or even run a script before running unit tests. This PR will allow users to specify a path that contains a shell script to run before test.


Tested successfully with this [CircleCI pipeline](https://app.circleci.com/pipelines/github/getoutreach/devbase/2701/workflows/a19e9c98-9ae5-44de-b050-acbca4f1d6c4/jobs/6509)


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

DT-3641

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
