### PR TITLE
fix: opt-out devconfig early

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -352,7 +352,7 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 		log.Info().Msg("Running devconfig in background finished")
 	}(&wg)
 
-	if os.Getenv("REQUIRE_DEVCONFIG_BEFORE_DEPLOY") != "true" {
+	if os.Getenv("REQUIRE_DEVCONFIG_BEFORE_DEPLOY") == "true" {
 		log.Info().Msg("Requested waiting for devconfig to finish before app deploy")
 		wg.Wait()
 	}

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -272,7 +272,7 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 		return
 	}
 
-	log.Info().Msg("Building dependency tree")
+	log.Info().Msg("Building dependency tree - MF")
 
 	// Provision a devenv if it doesn't already exist. If it does exist,
 	// warn the user their test is no longer potentially reproducible.

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -279,7 +279,7 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 		return
 	}
 
-	log.Info().Msg("Building dependency tree - MF")
+	log.Info().Msg("Building dependency tree")
 
 	// Provision a devenv if it doesn't already exist. If it does exist,
 	// warn the user their test is no longer potentially reproducible.

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -353,6 +353,7 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 	}(&wg)
 
 	if os.Getenv("REQUIRE_DEVCONFIG_BEFORE_DEPLOY") != "true" {
+		log.Info().Msg("Requested waiting for devconfig to finish before app deploy")
 		wg.Wait()
 	}
 

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -352,6 +352,10 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 		log.Info().Msg("Running devconfig in background finished")
 	}(&wg)
 
+	if os.Getenv("REQUIRE_DEVCONFIG_BEFORE_DEPLOY") != "true" {
+		wg.Wait()
+	}
+
 	// if it's a library we don't need to deploy the application.
 	if dc.Service {
 		log.Info().Msg("Deploying current application into cluster")

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -186,6 +186,13 @@ func deployDependencies(ctx context.Context, deps []string) {
 	}
 }
 
+// runDevconfig executes devconfig command
+func runDevconfig(ctx context.Context) {
+	if err := osStdInOutErr(exec.CommandContext(ctx, ".bootstrap/shell/devconfig.sh")).Run(); err != nil {
+		log.Fatal().Err(err).Msg("Failed to run devconfig")
+	}
+}
+
 // shouldRunE2ETests denotes whether or not this needs to actually
 // run
 func shouldRunE2ETests() (bool, error) {
@@ -340,21 +347,16 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 	}
 
 	var wg sync.WaitGroup
+	requireDevconfigAfterDeploy := os.Getenv("REQUIRE_DEVCONFIG_AFTER_DEPLOY") == "true"
 
-	wg.Add(1)
-
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Info().Msg("Running devconfig in background")
-		if err := osStdInOutErr(exec.CommandContext(ctx, ".bootstrap/shell/devconfig.sh")).Run(); err != nil {
-			log.Fatal().Err(err).Msg("Failed to run devconfig")
-		}
-		log.Info().Msg("Running devconfig in background finished")
-	}(&wg)
-
-	if os.Getenv("REQUIRE_DEVCONFIG_BEFORE_DEPLOY") == "true" {
-		log.Info().Msg("Requested waiting for devconfig to finish before app deploy")
-		wg.Wait()
+	if !requireDevconfigAfterDeploy {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
+			log.Info().Msg("Running devconfig in background")
+			runDevconfig(ctx)
+			log.Info().Msg("Running devconfig in background finished")
+		}(&wg)
 	}
 
 	// if it's a library we don't need to deploy the application.
@@ -365,7 +367,12 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 		}
 	}
 
-	wg.Wait() // Ensure that devconfig is done
+	if requireDevconfigAfterDeploy {
+		log.Info().Msg("Running devconfig")
+		runDevconfig(ctx)
+	} else {
+		wg.Wait() // Ensure that devconfig is done
+	}
 
 	// If the post-deploy script for e2e exists, run it.
 	if _, err := os.Stat("scripts/devenv/post-e2e-deploy.sh"); err == nil {

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -93,6 +93,6 @@ if [[ $PROVISION == "true" ]]; then
 fi
 
 if [[ $E2E == "true" ]]; then
-  info "Starting E2E test runner"
+  info "Starting E2E test runner - MF"
   TEST_TAGS=or_test,or_e2e exec "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/v2/e2e@$(cat "$DIR/../../../.version")")"
 fi

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -93,6 +93,6 @@ if [[ $PROVISION == "true" ]]; then
 fi
 
 if [[ $E2E == "true" ]]; then
-  info "Starting E2E test runner - MF"
+  info "Starting E2E test runner"
   TEST_TAGS=or_test,or_e2e exec "$("$DIR/../../gobin.sh" -p "github.com/getoutreach/devbase/v2/e2e@$(cat "$DIR/../../../.version")")"
 fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
- Allow opt-out from running devconfig in parallel with apps deploy (introduced in https://github.com/getoutreach/devbase/pull/499)
- Based on feedback from copilot project, which has devconfig override that required application to be deployed prior to running it https://github.com/getoutreach/copilot/blob/main/scripts/devconfig.override.sh
- Opt out is based on REQUIRE_DEVCONFIG_AFTER_DEPLOY env var, which can be set on project level in CircleCI 


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
