### PR TITLE
feat: bump golangci to 1.52.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -15,7 +15,7 @@ nodejs 18.14.1
 ## <<Stencil::Block(toolver)>>
 # The below tools are used by all repositories when using devbase
 mage 1.14.0
-golangci-lint 1.50.0
+golangci-lint 1.52.2
 shellcheck 0.9.0
 shfmt 3.6.0
 ## <</Stencil::Block>>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Bumping golangci because we're experiencing this type of issue: https://github.com/golangci/golangci-lint/issues/3582

Unfortunately this looks like `ent` is still broken.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID
OCE WORK
[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
