### PR TITLE
fix: add no_output_timeout to test

### DIFF
--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -15,6 +15,10 @@ parameters:
     description: The resource class to use for the release
     type: string
     default: "large"
+  no_output_timeout:
+    description: The timeout that gets applied when CircleCI receives no output during the running of tests.
+    type: string
+    default: 10m
   docker_image:
     description: The docker image to use for running the test
     type: string
@@ -51,6 +55,7 @@ steps:
         - run:
             name: Run tests
             command: make test
+            no_output_timeout: << parameters.no_output_timeout >>
         - run:
             name: Upload Code Coverage
             command: ./scripts/shell-wrapper.sh ci/testing/coverage.sh /tmp/coverage.out


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adding no_output_timeout arg to test as well (e2e already had it). Matching CI fix is here: https://github.com/getoutreach/stencil-circleci/pull/107

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[CDT-00]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
