### PR TITLE
fix: copy generated imported proto ts files to correct path

### DIFF
--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -187,7 +187,7 @@ if has_grpc_client "node"; then
   for import_path in "${import_paths[@]}"; do
     import_grpc_path="$import_path/clients/node/src/grpc"
     if [[ -d $import_grpc_path ]]; then
-      cp -r "$import_grpc_path/" "$grpc_path"
+      cp -r "$import_grpc_path/." "$grpc_path"
     fi
   done
 


### PR DESCRIPTION
## What this PR does / why we need it
Copy the files to `api/clients/node/src/grpc/` instead of `api/clients/node/src/grpc/grpc`.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[VXP-6273]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
