### PR TITLE
fix: upload_prismaci.sh to use SCAN_RESULTS_FILE

### DIFF
--- a/shell/opslevel/upload_prismaci.sh
+++ b/shell/opslevel/upload_prismaci.sh
@@ -34,7 +34,7 @@ while [ "$(date +%s)" -lt $ENDTIMEOUT ]; do
   download_artifact_by_full_url "${ARTIFACT_URL}" "${SCAN_RESULTS_FILE}"
 
   # check for a message value
-  RESULT_FILE_MESSAGE=$(jq -r .message ${SCAN_RESULTS_OPSLEVEL_FILE})
+  RESULT_FILE_MESSAGE=$(jq -r .message ${SCAN_RESULTS_FILE})
 
   # if no message field exists then we can assume that the artifact exists based
   # on file output


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Looks like the prisma script is reading from the wrong file when determining if the artifact exists.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
