### PR TITLE
fix(fly): do not run brew on Linux/WSL

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -31,7 +31,7 @@ TOOL_DEPS           := ${GO}
 # formatters / misc
 JSONNET             ?= $(CURDIR)/scripts/shell-wrapper.sh gobin.sh github.com/google/go-jsonnet/cmd/jsonnet@v0.19.0
 LOG                 := ./scripts/shell-wrapper.sh makefile-logger.sh
-FLY                 ?= fly
+FLY                 := $(CURDIR)/scripts/shell-wrapper.sh fly.sh
 BOX_CONFIG          := ./scripts/shell-wrapper.sh boxconfig.sh
 CONCOURSE_URL       := $(shell $(BOX_CONFIG) '.cd.concourse.address')
 
@@ -211,8 +211,6 @@ docs-publish:: pre-docs-publish
 ## fly-login:       log into concourse
 .PHONY: fly-login
 fly-login:
-	brew list fly >/dev/null 2>&1 || brew install fly
-	xattr -c $(shell brew --prefix)/bin/fly >/dev/null 2>&1 || true
 	${FLY} sync -c $(CONCOURSE_URL)
 	${FLY} -t devs userinfo || ${FLY} -t devs login -c $(CONCOURSE_URL) -n devs
 

--- a/shell/fly.sh
+++ b/shell/fly.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=./lib/logging.sh
+source "$DIR/lib/logging.sh"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  if ! brew list fly >/dev/null 2>&1; then
+    brew install fly
+    xattr -c "$(brew --prefix)"/bin/fly >/dev/null 2>&1
+  fi
+elif ! command -v fly >/dev/null; then
+  error "fly not found, re-run 'orc setup'"
+  exit 1
+fi
+
+fly "$@"


### PR DESCRIPTION
## What this PR does / why we need it

This allows `make update-pipeline` to be run on non-macOS systems.

## Jira ID

[DT-3750]

[DT-3750]: https://outreach-io.atlassian.net/browse/DT-3750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ