### PR TITLE
feat(asdf): allow overriding devbase tool-versions

### DIFF
--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -29,7 +29,16 @@ asdf_get_version_from_devbase() {
   # Why: We're OK with this being the way it is.
   # shellcheck disable=SC2155
   local devbase_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd)"
-  grep -E "^$tool_name " "$devbase_dir/.tool-versions" | awk '{print $2}'
+
+  # Check if we have a version override in the repository
+  repo_version_override=$(grep -E "^$tool_name " ".tool-versions" 2>/dev/null | head -n1 | awk '{print $2}')
+  if [[ -n $repo_version_override ]]; then
+    echo "$repo_version_override"
+    return
+  fi
+
+  # Otherwise, use the version from devbase
+  grep -E "^$tool_name " "$devbase_dir/.tool-versions" | head -n1 | awk '{print $2}'
 }
 
 # asdf_devbase_exec executes a command with the versions from the devbase
@@ -56,8 +65,8 @@ asdf_devbase_exec() {
   exec "$@"
 }
 
-# asdf_devbase_ensure ensures that the versions from the devbase
-# .tool-versions file are installed
+# asdf_devbase_ensure ensures that all versions of tools are installed from
+# .tool-version files in the current directory and all subdirectories.
 asdf_devbase_ensure() {
   readarray -t asdf_entries < <(read_all_asdf_tool_versions)
   for entry in "${asdf_entries[@]}"; do
@@ -81,46 +90,22 @@ asdf_devbase_ensure() {
     # Note: This only runs if the plugin doesn't already exist
     asdf_plugin_install "$plugin" || echo "Warning: Failed to install language '$name', may fail to invoke things using that language"
 
-    # If the version doesn't exist, install it.
-    # Note: we don't use asdf list <plugin> here because checking the file system
-    # entry is ~90% faster than running the asdf command.
-    if [[ ! -d "$ASDF_DIR/installs/$plugin/$version" ]]; then
+    # Install the version if it doesn't already exist
+    if ! asdf list "$plugin" | grep -qE "^$version$"; then
       # Install the language, retrying w/ AMD64 emulation if on macOS or just retrying on failure once.
       asdf install "$plugin" "$version" || asdf_install_retry "$plugin" "$version"
     fi
   done
+
+  # Reshim to ensure that the correct versions are used
+  asdf reshim
 }
 
 # asdf_install installs a plugins/version required from a top-level
-# .tool-versions and all subdirectories
+# .tool-versions and all subdirectories.
+# Deprecated: Use asdf_devbase_ensure instead.
 asdf_install() {
-  readarray -t asdf_entries < <(read_all_asdf_tool_versions)
-  for entry in "${asdf_entries[@]}"; do
-    # Why: We're OK not declaring separately here.
-    # shellcheck disable=SC2155
-    local plugin="$(awk '{ print $1 }' <<<"$entry")"
-    # Why: We're OK not declaring separately here.
-    # shellcheck disable=SC2155
-    local version="$(awk '{ print $2 }' <<<"$entry")"
-
-    if [[ -z $plugin ]]; then
-      echo "No plugin found in devbase .tool-versions file"
-      exit 1
-    fi
-    if [[ -z $version ]]; then
-      echo "No version found for $plugin in devbase .tool-versions file"
-      exit 1
-    fi
-
-    # Install the plugin first, so we can install the version
-    asdf_plugin_install "$plugin" || echo "Warning: Failed to install language '$name', may fail to invoke things using that language"
-
-    # Install the language, retrying w/ AMD64 emulation if on macOS or just retrying on failure once.
-    asdf install "$plugin" "$version" || asdf_install_retry "$plugin" "$version"
-  done
-
-  echo "Reshimming asdf (this may take awhile ...)"
-  asdf reshim
+  asdf_devbase_ensure
 }
 
 # asdf_install_retry attempts to retry on certain platforms


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR enables the repository's `.tool-versions` to override any version used by `devbase`, if set.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3749]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3749]: https://outreach-io.atlassian.net/browse/DT-3749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ