### PR TITLE
fix(setup-devenv): use new gcp kubectl key

### DIFF
--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -29,8 +29,9 @@ if [[ -n $CI ]]; then
 
   if ! command -v kubectl >/dev/null; then
     info "Installing kubectl"
-    sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    # Taken from: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
+    sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     sudo apt-get update -y
     sudo apt-get install -y kubectl
   fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

It looks like they changed their GPG key path and then rotated their keys and didn't update the old path (but still serve it). So, we're using the new path. Updated to their new instructions, including a new path to download it to. Love it.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
