### PR TITLE
fix(orb/job/test): dont require pre_setup_script

### DIFF
--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -7,7 +7,8 @@ parameters:
     default: _json_key
     description: Username to use when fetching images from a registry
     type: string
-  pre_test_script:
+  pre_setup_script:
+    default: ""
     description: Environment variable that contains a shell path to run before running tests in CircleCI
     type: string
   docker_password:

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -8,6 +8,7 @@ parameters:
     description: Username to use when fetching images from a registry
     type: string
   pre_setup_script:
+    default: ""
     description: If set, the executable to run before running tests in CircleCI. This may not include arguments.
     type: string
   docker_password:


### PR DESCRIPTION
Fixes the `pre_setup_script` argument to not be required. As per the
[CircleCI documentation](https://circleci.com/docs/reusing-config/#parameter-syntax:~:text=N/A-,default,-The%20default%20value) an argument is required if there is not
'default' key set.
