### PR TITLE
fix(e2e): handle armored/dearmored apt key GCP

### DIFF
--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -29,9 +29,23 @@ if [[ -n $CI ]]; then
 
   if ! command -v kubectl >/dev/null; then
     info "Installing kubectl"
-    # Taken from: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
-    sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    tmpFile=$(mktemp)
+    keyringLocation=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+    sudo curl -fsSLo "$tmpFile" https://packages.cloud.google.com/apt/doc/apt-key.gpg
+
+    # 2023-05-23: GCP changed their key to be armored and their location. Currently
+    # the file extension is incorrect. So, we handle if it is armored or not in case
+    # they end up fixing it.
+    if grep -q -- "-----BEGIN" "$tmpFile"; then
+      # Output is armored, convert to binary
+      gpg --dearmor "$tmpFile" | sudo tee "$keyringLocation" >/dev/null
+      rm "$tmpFile"
+    else
+      echo "Warning: GCP apt-key is not armored. We can remove this workaround now."
+      # Otherwise, just copy the file
+      sudo cp "$tmpFile" "$keyringLocation"
+    fi
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
     sudo apt-get update -y
     sudo apt-get install -y kubectl
   fi


### PR DESCRIPTION
Currently, the GCP key is using the wrong file extension for their GPG
key. They have armored it, when that should be a `.asc` file instead.
This causes `apt` to ignore the file silently. We work around this by
dearmoring the file ourself. We also handle if the file potentially gets
fixed one day and no longer needs to be dearmored.

I'm not very attached/satisfied with my grep approach, I'm open to other
ideas (e.g., always attempting to dearmor).
