### PR TITLE
fix(e2e): use correct gpg dearmor command

### DIFF
--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -39,7 +39,7 @@ if [[ -n $CI ]]; then
     # they end up fixing it.
     if grep -q -- "-----BEGIN" "$tmpFile"; then
       # Output is armored, convert to binary
-      gpg --dearmor "$tmpFile" | sudo tee "$keyringLocation" >/dev/null
+      gpg --output - --dearmor "$tmpFile" | sudo tee "$keyringLocation" >/dev/null
       rm "$tmpFile"
     else
       echo "Warning: GCP apt-key is not armored. We can remove this workaround now."


### PR DESCRIPTION
When operating on a file, `gpg --dearmor` will write the output to
another file on disk. However, if you pipe the file it will write to
stdout. I tested this while piping, so this broke once I released it.

Instead we now tell gpg to always output to stdout using `--output -`.
I've tested the entire function in CI now, so I'm confident this works.
