### PR TITLE
feat: support rtx instead of asdf

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -12,7 +12,7 @@ APP                 ?= unset
 ORG                 ?= getoutreach
 
 # Transition
-MAGE_CMD            := MAGEFILE_HASHFAST=true exec $(SHELL) -c 'source "$(BOOTSTRAP_DIR)/shell/lib/asdf.sh" && asdf_devbase_exec mage -d "$(BOOTSTRAP_DIR)/root" -w "$(CURDIR)"'
+MAGE_CMD            := MAGEFILE_HASHFAST=true "$(BOOTSTRAP_DIR)/shell/asdf-exec.sh" mage -d "$(BOOTSTRAP_DIR)/root" -w "$(CURDIR)"
 APP_VERSION         := $(shell $(MAGE_CMD) version)
 
 # go options

--- a/root/Makefile
+++ b/root/Makefile
@@ -12,7 +12,7 @@ APP                 ?= unset
 ORG                 ?= getoutreach
 
 # Transition
-MAGE_CMD            := ASDF_MAGE_VERSION=$(shell cat "$(BOOTSTRAP_DIR)/.tool-versions" | grep mage | awk '{ print $$2 }') MAGEFILE_HASHFAST=true mage -d "$(CURDIR)/$(shell if [[ "$(APP)" != "devbase" ]]; then echo ".bootstrap/"; fi)root" -w "$(CURDIR)"
+MAGE_CMD            := MAGEFILE_HASHFAST=true exec $(SHELL) -c 'source "$(BOOTSTRAP_DIR)/shell/lib/asdf.sh" && asdf_devbase_exec mage -d "$(BOOTSTRAP_DIR)/root" -w "$(CURDIR)"'
 APP_VERSION         := $(shell $(MAGE_CMD) version)
 
 # go options

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -15,7 +15,7 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/bootstrap.sh
 source "$SCRIPTS_DIR/lib/bootstrap.sh"
 
-# shellcheck source=./lib/bootstrap.sh
+# shellcheck source=./lib/asdf.sh
 source "$SCRIPTS_DIR/lib/asdf.sh"
 
 if [[ $VERSION_MANAGER == "asdf" ]]; then

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -19,7 +19,10 @@ source "$SCRIPTS_DIR/lib/bootstrap.sh"
 source "$SCRIPTS_DIR/lib/asdf.sh"
 
 if [[ $VERSION_MANAGER == "asdf" ]]; then
-  TOOLVERSIONS="$(get_repo_directory)/.tool-versions"
+  # TOOLVERSIONS contains all of the `.tool-versions` files that should be
+  # searched for tool versions. The first occurance of a tool in the list will
+  # be used.
+  TOOLVERSIONS=("$(get_repo_directory)/.tool-versions" "$(get_repo_directory)/.bootstrap/.tool-versions")
 
   while read -r line; do
     tool=$(awk '{ print $1 }' <<<"$line" | tr '[:lower:]-' '[:upper:]_')
@@ -35,7 +38,7 @@ if [[ $VERSION_MANAGER == "asdf" ]]; then
     #
     # Uses the `sed` reverse mechanism described here for portability:
     # https://stackoverflow.com/a/744093
-  done < <(sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' "${TOOLVERSIONS}" | sed '1!G;h;$!d')
+  done < <(cat "${TOOLVERSIONS[@]}" | sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' | sed '1!G;h;$!d')
   exec asdf exec "$@"
 else
   asdf_devbase_exec "$@"

--- a/shell/asdf-exec.sh
+++ b/shell/asdf-exec.sh
@@ -15,22 +15,28 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/bootstrap.sh
 source "$SCRIPTS_DIR/lib/bootstrap.sh"
 
-TOOLVERSIONS="$(get_repo_directory)/.tool-versions"
+# shellcheck source=./lib/bootstrap.sh
+source "$SCRIPTS_DIR/lib/asdf.sh"
 
-while read -r line; do
-  tool=$(awk '{ print $1 }' <<<"$line" | tr '[:lower:]-' '[:upper:]_')
-  version=$(awk '{ print $2 }' <<<"$line")
+if [[ $VERSION_MANAGER == "asdf" ]]; then
+  TOOLVERSIONS="$(get_repo_directory)/.tool-versions"
 
-  export "ASDF_${tool}_VERSION"="${version}"
+  while read -r line; do
+    tool=$(awk '{ print $1 }' <<<"$line" | tr '[:lower:]-' '[:upper:]_')
+    version=$(awk '{ print $2 }' <<<"$line")
 
-  # Strip comments just like `asdf` does:
-  # https://github.com/asdf-vm/asdf/blob/711ad991043a1980fa264098f29e78f2ecafd610/lib/utils.bash#L653
-  #
-  # Reverse the file because asdf (buggily? intentionally?)
-  # picks the first version it sees if there are duplicates.
-  #
-  # Uses the `sed` reverse mechanism described here for portability:
-  # https://stackoverflow.com/a/744093
-done < <(sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' "${TOOLVERSIONS}" | sed '1!G;h;$!d')
+    export "ASDF_${tool}_VERSION"="${version}"
 
-exec asdf exec "$@"
+    # Strip comments just like `asdf` does:
+    # https://github.com/asdf-vm/asdf/blob/711ad991043a1980fa264098f29e78f2ecafd610/lib/utils.bash#L653
+    #
+    # Reverse the file because asdf (buggily? intentionally?)
+    # picks the first version it sees if there are duplicates.
+    #
+    # Uses the `sed` reverse mechanism described here for portability:
+    # https://stackoverflow.com/a/744093
+  done < <(sed '/^[[:blank:]]*#/d;s/#.*//;s/[[:blank:]]*$//' "${TOOLVERSIONS}" | sed '1!G;h;$!d')
+  exec asdf exec "$@"
+else
+  asdf_devbase_exec "$@"
+fi

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -2,8 +2,8 @@
 # Utilities for working with asdf
 
 VERSION_MANAGER="asdf"
-if command -v rtx @ >/dev/null && [[ -z "$DEVBASE_DISABLE_RTX" ]]; then
-  echo "[devbase] rtx found in path, using rtx instead of asdf. This is a beta feature."
+if command -v rtx @ >/dev/null && [[ -z $DEVBASE_DISABLE_RTX ]]; then
+  echo "[devbase] rtx found in path, using rtx instead of asdf. This is a beta feature." >&2
   VERSION_MANAGER="rtx"
 
   # alias asdf to rtx because it is compatible with asdf, for the most part.
@@ -61,7 +61,7 @@ asdf_devbase_exec() {
     exit 1
   fi
 
-  if [[ "$VERSION_MANAGER" == "asdf" ]]; then
+  if [[ $VERSION_MANAGER == "asdf" ]]; then
     export "ASDF_${tool_env_var}_VERSION"="${version}"
 
     # Ensure that the tool and/or plugin is installed

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -3,7 +3,10 @@
 
 VERSION_MANAGER="asdf"
 if command -v rtx @ >/dev/null && [[ -z $DEVBASE_DISABLE_RTX ]]; then
-  echo "[devbase] rtx found in path, using rtx instead of asdf. This is a beta feature." >&2
+  if [[ -z $DEVBASE_WARNED_RTX ]]; then
+    export DEVBASE_WARNED_RTX=1
+    echo "[devbase] rtx found in path, using rtx instead of asdf. This is a beta feature." >&2
+  fi
   VERSION_MANAGER="rtx"
 
   # alias asdf to rtx because it is compatible with asdf, for the most part.

--- a/shell/linters/terraform.sh
+++ b/shell/linters/terraform.sh
@@ -13,7 +13,7 @@ tflint() {
       continue
     fi
 
-    if ! terraform fmt -diff -check "$tfdir"; then
+    if ! "$DIR/asdf-exec.sh" terraform fmt -diff -check "$tfdir"; then
       error "terraform fmt (./$tfdir) failed on some files. Run 'make fmt' to fix."
       exit 1
     fi
@@ -26,7 +26,7 @@ terraform_fmt() {
       continue
     fi
 
-    terraform fmt "$tfdir"
+    "$DIR/asdf-exec.sh" terraform fmt "$tfdir"
   done
 }
 


### PR DESCRIPTION
This PR adds support for [rtx](https://github.com/jdxcode/rtx) instead of the asdf version manager.
This functionality can be disabled with `DEVBASE_RTX_DISABLE_RTX` and is
enabled if `rtx` exists in `PATH`.

We're mostly shimming `rtx` support because it is compatible out of the
box with `asdf`. Longer term we should have hot swappable
implementations using interfaces when we move this functionality to Go.
The main driver of this is a desire to move away from `asdf` longer
term.
