### PR TITLE
fix: allow ctrl-c to kill headless delve in make debug

### DIFF
--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -106,13 +106,12 @@ else
     # a container so the output can be processed by devspace.
     echo -e "\n\n\n\n\n\n\n\n" >>"$DEV_CONTAINER_LOGFILE"
     "${delve[@]}" >>"$DEV_CONTAINER_LOGFILE" 2>&1 &
-    IS_LOGGING="true"
   fi
 
   DLV_PID=$!
   echo "delve pid is: $DLV_PID"
 
-  if [[ $IS_LOGGING == "true" ]]; then
+  if [[ $HEADLESS != "false" ]]; then
     # tail to watch logs here
     tail -n 5 -f "$DEV_CONTAINER_LOGFILE"
   fi

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -111,7 +111,7 @@ else
   DLV_PID=$!
   echo "delve pid is: $DLV_PID"
 
-  if [[ $HEADLESS != "false" ]]; then
+  if [[ $IN_CONTAINER != "false" ]]; then
     # tail to watch logs here
     tail -n 5 -f "$DEV_CONTAINER_LOGFILE"
   fi

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -100,12 +100,6 @@ else
   echo -e "\n\n\n\n\n\n\n\n" >>"$DEV_CONTAINER_LOGFILE"
 
   # Start delve in the background so we can kill it on ctrl-c.
-
-  # This is a bit of a hack, but this is the best way I could find to
-  # send the logs to stdout and the logfile. Using tee overwrites
-  # the most recent PID and makes it hard to get the delve PID, which
-  # we need if we want to kill delve.
-
   "${delve[@]}" >>"$DEV_CONTAINER_LOGFILE" 2>&1 &
   DLV_PID=$!
   echo "delve pid is: $DLV_PID"

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -83,10 +83,9 @@ if [[ $HEADLESS == "true" ]]; then
   )
 fi
 
-function ctrl_c_trap()
-{
+function ctrl_c_trap() {
   echo "killing delve with PID: $DLV_PID"
-  kill $DLV_PID
+  kill "$DLV_PID"
   exit
 }
 
@@ -98,7 +97,7 @@ trap ctrl_c_trap SIGINT
 if [[ $IN_CONTAINER == "false" ]]; then
   exec "${delve[@]}"
 else
-  echo -e "\n\n\n\n\n\n\n\n" >> $DEV_CONTAINER_LOGFILE
+  echo -e "\n\n\n\n\n\n\n\n" >>"$DEV_CONTAINER_LOGFILE"
 
   # Start delve in the background so we can kill it on ctrl-c.
 
@@ -107,7 +106,7 @@ else
   # the most recent PID and makes it hard to get the delve PID, which
   # we need if we want to kill delve.
 
-  "${delve[@]}" 2>&1 >> $DEV_CONTAINER_LOGFILE &
+  "${delve[@]}" 2>&1 >>"$DEV_CONTAINER_LOGFILE" &
   DLV_PID=$!
   echo "delve pid is: $DLV_PID"
 

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -106,12 +106,12 @@ else
   # the most recent PID and makes it hard to get the delve PID, which
   # we need if we want to kill delve.
 
-  "${delve[@]}" 2>&1 >>"$DEV_CONTAINER_LOGFILE" &
+  "${delve[@]}" >>"$DEV_CONTAINER_LOGFILE" 2>&1 &
   DLV_PID=$!
   echo "delve pid is: $DLV_PID"
 
   # tail to watch logs here
-  tail -f "$DEV_CONTAINER_LOGFILE"
+  tail -n 5 -f "$DEV_CONTAINER_LOGFILE"
 fi
 
 wait

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -58,9 +58,11 @@ echo "Starting debugger for package '$PACKAGE_TO_DEBUG' (headless: $HEADLESS)" >
 if [[ $HEADLESS == "true" ]]; then
   echo "Headless Information:" >&2
   echo "  - DLV_PORT: $DLV_PORT" >&2
-  echo "  - DEV_CONTAINER_LOGFILE: $DEV_CONTAINER_LOGFILE" >&2
 
-  mkdir -p "$(dirname "$DEV_CONTAINER_LOGFILE")" 2>/dev/null >&2 || true
+  if [[ $IN_CONTAINER == "true" ]]; then
+    echo "  - DEV_CONTAINER_LOGFILE: $DEV_CONTAINER_LOGFILE" >&2
+    mkdir -p "$(dirname "$DEV_CONTAINER_LOGFILE")" 2>/dev/null >&2 || true
+  fi
 fi
 echo
 
@@ -86,26 +88,34 @@ fi
 function ctrl_c_trap() {
   echo "killing delve with PID: $DLV_PID"
   kill "$DLV_PID"
-  exit
+  exit 0
 }
-
 trap ctrl_c_trap SIGINT
 
-# When not running in a container, we can start without logging.
-# Otherwise, we need to log to a file so that the output can be
-# processed by devspace.
-if [[ $IN_CONTAINER == "false" ]]; then
+if [[ $HEADLESS == "false" ]]; then
   exec "${delve[@]}"
 else
-  echo -e "\n\n\n\n\n\n\n\n" >>"$DEV_CONTAINER_LOGFILE"
 
-  # Start delve in the background so we can kill it on ctrl-c.
-  "${delve[@]}" >>"$DEV_CONTAINER_LOGFILE" 2>&1 &
+  # Start headless delve in the background so we can kill it with ctrl-c.
+
+  if [[ $IN_CONTAINER == "false" ]]; then
+    # no need to log outside of a container
+    "${delve[@]}" &
+  else
+    # We only need to start logging if we are running in a
+    # a container so the output can be processed by devspace.
+    echo -e "\n\n\n\n\n\n\n\n" >>"$DEV_CONTAINER_LOGFILE"
+    "${delve[@]}" >>"$DEV_CONTAINER_LOGFILE" 2>&1 &
+    IS_LOGGING="true"
+  fi
+
   DLV_PID=$!
   echo "delve pid is: $DLV_PID"
 
-  # tail to watch logs here
-  tail -n 5 -f "$DEV_CONTAINER_LOGFILE"
+  if [[ $IS_LOGGING == "true" ]]; then
+    # tail to watch logs here
+    tail -n 5 -f "$DEV_CONTAINER_LOGFILE"
+  fi
 fi
 
 wait


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Allow users to kill make debug with ctrl from inside the devenv

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3698](https://outreach-io.atlassian.net/browse/DT-3698)

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3698]: https://outreach-io.atlassian.net/browse/DT-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ