### PR TITLE
fix(debug): correct environmental variable that make debug evaluates

### DIFF
--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -10,9 +10,9 @@ source "$DIR/lib/bootstrap.sh"
 # PACKAGE_TO_DEBUG is the package to debug. If not set, it will default to the
 # main package, which is cmd/<app_name>.
 if [[ -z $PACKAGE_TO_DEBUG ]]; then
-PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-$(get_repo_directory)/cmd/$(get_app_name)}"
+  PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-$(get_repo_directory)/cmd/$(get_app_name)}"
 else
-PACKAGE_TO_DEBUG="${DEV_CONTAINER_EXECUTABLE:-$(get_repo_directory)/cmd/$(get_app_name)}"
+  PACKAGE_TO_DEBUG="${DEV_CONTAINER_EXECUTABLE:-$(get_repo_directory)/cmd/$(get_app_name)}"
 fi
 
 # IN_CONTAINER is a flag that indicates whether or not we are running in a

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -9,7 +9,11 @@ source "$DIR/lib/bootstrap.sh"
 
 # PACKAGE_TO_DEBUG is the package to debug. If not set, it will default to the
 # main package, which is cmd/<app_name>.
+if [[ -z $PACKAGE_TO_DEBUG ]]; then
 PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-$(get_repo_directory)/cmd/$(get_app_name)}"
+else
+PACKAGE_TO_DEBUG="${DEV_CONTAINER_EXECUTABLE:-$(get_repo_directory)/cmd/$(get_app_name)}"
+fi
 
 # IN_CONTAINER is a flag that indicates whether or not we are running in a
 # container or not. If not set, will be determined automatically.

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -12,7 +12,7 @@ source "$DIR/lib/bootstrap.sh"
 DEV_CONTAINER_EXECUTABLE="${DEV_CONTAINER_EXECUTABLE:-$(get_app_name)}"
 
 # PACKAGE_TO_DEBUG is the package to debug. If not set, it will default to the
-# main package, which is cmd/<app_name>.
+# to `./cmd/$DEV_CONTAINER_EXECUTABLE`
 PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-$(get_repo_directory)/cmd/${DEV_CONTAINER_EXECUTABLE}}"
 
 # IN_CONTAINER is a flag that indicates whether or not we are running in a

--- a/shell/debug.sh
+++ b/shell/debug.sh
@@ -7,13 +7,13 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
 
+# DEV_CONTAINER_EXECUTABLE is set by Devspace here: https://github.com/getoutreach/stencil-golang/blob/cb950f2fc050bb112492626d70c772dc15ffc4ae/templates/devspace.yaml.tpl#LL19C17-L19C17
+# If it is set, use it, otherwise use the application name.
+DEV_CONTAINER_EXECUTABLE="${DEV_CONTAINER_EXECUTABLE:-$(get_app_name)}"
+
 # PACKAGE_TO_DEBUG is the package to debug. If not set, it will default to the
 # main package, which is cmd/<app_name>.
-if [[ -z $PACKAGE_TO_DEBUG ]]; then
-  PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-$(get_repo_directory)/cmd/$(get_app_name)}"
-else
-  PACKAGE_TO_DEBUG="${DEV_CONTAINER_EXECUTABLE:-$(get_repo_directory)/cmd/$(get_app_name)}"
-fi
+PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-$(get_repo_directory)/cmd/${DEV_CONTAINER_EXECUTABLE}}"
 
 # IN_CONTAINER is a flag that indicates whether or not we are running in a
 # container or not. If not set, will be determined automatically.


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This changes the behavior of to prioritize `PACKAGE_TO_DEBUG` environmental variable if it's set, and otherwise sets the `PACKAGE_TO_DEBUG` to `DEV_CONTAINER_EXECUTABLE` which is the environmental variable that we're adding with devspace profiles. 

I'm not tied to the if statement here, and if someone else has opinions I'd be fine changing it.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3757]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3757]: https://outreach-io.atlassian.net/browse/DT-3757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ