### PR TITLE
fix: parsing yaml arrays in docker.sh

### DIFF
--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -33,6 +33,7 @@ fi
 get_image_field() {
   local name="$1"
   local field="$2"
+  # shellcheck disable=SC1087 # this is a yq/jq filter that shellcheck thinks is bash
   yq -r ".[\"$name\"]$field[]" "$MANIFEST"
 }
 

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -33,7 +33,7 @@ fi
 get_image_field() {
   local name="$1"
   local field="$2"
-  yq -r ".[\"$name\"]$field" "$MANIFEST"
+  yq -r ".[\"$name\"]$field[]" "$MANIFEST"
 }
 
 # build_and_push_image builds and pushes a docker image to


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This changes how we parse the docker.yaml file to output each secret on a separate line instead of outputting a JSON array.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3807]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3807]: https://outreach-io.atlassian.net/browse/DT-3807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ