### PR TITLE
fix: don't fail if the field is not an array

### DIFF
--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -34,7 +34,7 @@ get_image_field() {
   local name="$1"
   local field="$2"
   # shellcheck disable=SC1087 # this is a yq/jq filter that shellcheck thinks is bash
-  yq -r ".[\"$name\"]$field[]" "$MANIFEST"
+  yq -r ".[\"$name\"]$field[]?" "$MANIFEST"
 }
 
 # build_and_push_image builds and pushes a docker image to


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Prevent yq from throwing an error when there is no array in the given field.

https://stackoverflow.com/questions/28213232/docker-error-jq-error-cannot-iterate-over-null

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
