### PR TITLE
fix(docker): properly handle string values again

### DIFF
--- a/root/Magefile.go
+++ b/root/Magefile.go
@@ -89,10 +89,10 @@ func Gobuild(ctx context.Context) error {
 		log.Debug().Msg("Skipping trimpath argument for go build")
 	} else {
 		// Build with -trimpath to ensure we have consistent module filenames embedded.
-		args = append(args, "-trimpath")		
+		args = append(args, "-trimpath")
 	}
 
-	args = append(args, buildPath+"/...");
-	
+	args = append(args, buildPath+"/...")
+
 	return runGoCommand(log, args...)
 }

--- a/shell/ci/release/docker_test.sh
+++ b/shell/ci/release/docker_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Tests docker.sh functions.
+
+# No -e because we want to handle errors to make them
+# obvious.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+export TESTING_DO_NOT_BUILD=1
+# shellcheck source=docker.sh
+source "${DIR}/docker.sh"
+
+test_get_image_field() {
+  local testdata="$DIR/testdata"
+
+  echo "Should be able to get a string value"
+  buildContextTest=$(get_image_field "default" "buildContext" "string" "$testdata/test.yaml")
+  if [[ $buildContextTest != "helloWorld" ]]; then
+    echo "Expected buildContext to be 'helloWorld', got '$buildContextTest'" >&2
+    exit 1
+  fi
+
+  echo "Should be able to get an array value"
+  mapfile -t secretsTest < <(get_image_field "default" "secrets" "array" "$testdata/test.yaml")
+  if [[ ${secretsTest[*]} != "hello world" ]]; then
+    echo "Unexpected secrets value, got '${secretsTest[*]}'" >&2
+    exit 1
+  fi
+}
+
+test_get_image_field

--- a/shell/ci/release/testdata/test.yaml
+++ b/shell/ci/release/testdata/test.yaml
@@ -1,0 +1,5 @@
+default:
+  buildContext: helloWorld
+  secrets:
+    - hello
+    - world

--- a/shell/lib/yaml.sh
+++ b/shell/lib/yaml.sh
@@ -5,6 +5,10 @@
 # from a yaml array. If a value is not set, it will return
 # an empty string.
 #
+# To convert into a bash array, use the following:
+#
+#  mapfile -t my_array < <(yaml_get_array "$filter" "$file")
+#
 # $1 yq filter
 # $2 yaml file
 yaml_get_array() {
@@ -29,4 +33,26 @@ yaml_construct_object_filter() {
     filter+="[\"$arg\"]"
   done
   echo "$filter"
+}
+
+# yaml_get_field returns a value from a yaml file. If the
+# value is not set, or is null, an empty string is returned instead.
+# For array values, use yaml_get_array instead.
+#
+# $1 yq filter
+# $2 yaml file
+yaml_get_field() {
+  local filter="$1"
+  local file="$2"
+
+  returnValue=$(yq -r "$filter" "$file")
+
+  # If the return value was null, we want to return an empty string
+  # since it's more inline with bash's behavior.
+  if [[ $returnValue == "null" ]]; then
+    returnValue=""
+  fi
+
+  # Use printf instead of echo to avoid printing a newline
+  printf "%s" "$returnValue"
 }

--- a/shell/lib/yaml_test.sh
+++ b/shell/lib/yaml_test.sh
@@ -45,4 +45,31 @@ test_yaml_get_array() {
   return 0
 }
 
+test_yaml_get_field() {
+  # should be able to get a string value
+  local yaml_file=$(mktemp)
+  {
+    echo "foo: bar"
+  } >"$yaml_file"
+
+  echo "Should be able to get a string value"
+  local got=$(yaml_get_field ".foo" "$yaml_file")
+  local expected="bar"
+  if [[ $got != "$expected" ]]; then
+    echo "Expected '$expected', got '$got'"
+    exit 1
+  fi
+
+  echo "Should not error if the field is not set"
+  got=$(yaml_get_field ".not_set" "$yaml_file" 2>&1)
+  if [[ $got != "" ]]; then
+    echo "Expected empty value for unset field, got: '$got'" >&2
+    exit 1
+  fi
+
+  rm -f "$yaml_file"
+  return 0
+}
+
 test_yaml_get_array
+test_yaml_get_field


### PR DESCRIPTION
Fixes the new `docker.sh` logic to properly support string values again.
Adds a test for the `get_image_field` function and changes `docker.sh`
to support being tested (albeit a little hackily).

Adds a `yaml_get_field` function that strips `null` for an empty string
to be easier to work with in Bash. Adds tests for the new
`yaml_get_field` function and behaviour.

[DT-3821]


[DT-3821]: https://outreach-io.atlassian.net/browse/DT-3821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ