### PR TITLE
fix: don't overwrite prev line if error

### DIFF
--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -138,7 +138,7 @@ run_command() {
     # If the position of the cursor didn't change, and wasn't zero,
     # we can safely assume that the linter didn't output anything,
     # so we can just overwrite the previous line.
-    if [[ $current_pos == "$after_pos" ]] && [[ $current_pos != "0,0" ]]; then
+    if [[ $exit_code -eq 0 ]] && [[ $current_pos == "$after_pos" ]] && [[ $current_pos != "0,0" ]]; then
       tput cuu1 || true
     fi
   fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

There is some logic in shell.sh's run_command function to put the terminal back one line. However, this is currently overwriting parts of error messages.

This changes the code so that the cursor is only moved back if the previous command ran successfully.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3800]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3800]: https://outreach-io.atlassian.net/browse/DT-3800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ