### PR TITLE
docs(shellcheck): clarify wrapper comments

### DIFF
--- a/shell/shellcheck.sh
+++ b/shell/shellcheck.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This is a wrapper around gobin.sh to run shellcheck.
+# This is a wrapper around asdf to run shellcheck.
 # Useful for using the correct version of shellcheck
 # with your editor.
 set -e


### PR DESCRIPTION
## What this PR does / why we need it

The shellcheck wrapper uses asdf, not gobin.