### PR TITLE
fix: devconfig stdout race condition

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,6 +1,9 @@
 // Copyright 2022 Outreach Corporation. All Rights Reserved.
 
-// Description: This file has the package main.
+// Description: This is the entrypoint of the e2e runner for the devenv.
+
+// TODO(george-e-shaw-iv): Remove all calls to log.Fatal with graceful exits in mind.
+
 package main
 
 import (


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


* fixes a race condition that puts my terminal into raw mode basically
  because two different unsynchronoized processes are writing to stdout
  at the same time? I don't know. It's my best guess. All I know is that
  removing this from running in the background OR not outputting to
  stdout fixes the problem.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

Example of what happens (This is consistent 100% of the time) when this runs in the background the way it has been the past month or two: https://cl.outreach.io/RBuJ9PRo

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
