### PR TITLE
fix: use ci docker build script to build docker images

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -202,7 +202,7 @@ docker-build:: pre-docker-build
 	@echo " ===> building docker image <==="
 	@ssh-add -L
 	@echo " ===> If you run into credential issues, ensure that your key is in your SSH agent (ssh-add <ssh-key-path>) <==="
-	@./shell/ci/release/docker.sh
+	@./scripts/shell-wrapper.sh ci/release/docker.sh
 
 ## fmt:             run source code formatters
 .PHONY: fmt

--- a/root/Makefile
+++ b/root/Makefile
@@ -202,7 +202,7 @@ docker-build:: pre-docker-build
 	@echo " ===> building docker image <==="
 	@ssh-add -L
 	@echo " ===> If you run into credential issues, ensure that your key is in your SSH agent (ssh-add <ssh-key-path>) <==="
-	DOCKER_BUILDKIT=1 docker build --ssh default -t gcr.io/outreach-docker/$(APP) -f deployments/$(APP)/Dockerfile . --build-arg VERSION=${APP_VERSION}
+	@./shell/ci/release/docker.sh
 
 ## fmt:             run source code formatters
 .PHONY: fmt

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -142,6 +142,11 @@ build_and_push_image() {
     fi
   fi
 
+  # Build image with registry prefix for devenv
+  if [[ -n "$DEVENV" ]]; then
+      echo "Building Docker Image for devenv"
+      image="gcr.io/outreach-docker/$image"
+  fi
   # Build a quick native image and load it into docker cache for security scanning
   # Scan reports for release images are also uploaded to OpsLevel
   # (test image reports only available on PR runs as artifacts).

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -146,10 +146,10 @@ build_and_push_image() {
   if [[ -n $DEVENV_DOCKER_BUILD ]]; then
     info "Building Docker Image for devenv"
     image="gcr.io/outreach-docker/$image"
-  # Build a quick native image and load it into docker cache for security scanning
-  # Scan reports for release images are also uploaded to OpsLevel
-  # (test image reports only available on PR runs as artifacts).
   else
+    # Build a quick native image and load it into docker cache for security scanning
+    # Scan reports for release images are also uploaded to OpsLevel
+    # (test image reports only available on PR runs as artifacts).
     info "Building Docker Image (for scanning)"
   fi
   (

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -143,14 +143,15 @@ build_and_push_image() {
   fi
 
   # Build image with registry prefix for devenv
-  if [[ -n "$DEVENV" ]]; then
-      echo "Building Docker Image for devenv"
-      image="gcr.io/outreach-docker/$image"
-  fi
+  if [[ -n $DEVENV_DOCKER_BUILD ]]; then
+    info "Building Docker Image for devenv"
+    image="gcr.io/outreach-docker/$image"
   # Build a quick native image and load it into docker cache for security scanning
   # Scan reports for release images are also uploaded to OpsLevel
   # (test image reports only available on PR runs as artifacts).
-  info "Building Docker Image (for scanning)"
+  else
+    info "Building Docker Image (for scanning)"
+  fi
   (
     set -x
     docker buildx build "${args[@]}" -t "$image" --load "$buildContext"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
We already support building docker images defined in `docker.yaml` file, this change reuse the script to allow `devenv deploy` do the same behavior.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3624]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
I ran local tests for some images, and it does not seem to be a breaking change. I could not run full testing for the `ds-mlp-website` repo, because I could not build the `co-service` successfully. I assume my aws access is not permitted to pull the specific S3 bucket.

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3624]: https://outreach-io.atlassian.net/browse/DT-3624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ