### PR TITLE
fix: asdf_devbase_exec no longer ensures install.

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -109,6 +109,8 @@ build:: pre-build gobuild
 .PHONY: lint
 # Note: We run pre-test for compat. Remove on the next breaking change.
 lint:: pre-test pre-lint
+	# Note that this requires the ensure_asdf.sh invocation at the top of
+	# this file.
 	$(BASE_TEST_ENV) ./scripts/shell-wrapper.sh linters.sh
 
 ## test:            run unit tests

--- a/shell/ci/env/asdf.sh
+++ b/shell/ci/env/asdf.sh
@@ -92,4 +92,4 @@ if [[ $installedAsdf == "true" ]]; then
 fi
 
 echo "🛠 Installing languages/plugins from all .tool-version files"
-asdf_install
+asdf_devbase_ensure

--- a/shell/ci/env/asdf.sh
+++ b/shell/ci/env/asdf.sh
@@ -91,5 +91,5 @@ if [[ $installedAsdf == "true" ]]; then
   fi
 fi
 
-echo "🛠 Installing languages/plugins from all .tool-version files"
+echo "🛠 Installing languages/plugins from all .tool-versions files"
 asdf_devbase_ensure

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -42,7 +42,8 @@ asdf_get_version_from_devbase() {
 }
 
 # asdf_devbase_exec executes a command with the versions from the devbase
-# .tool-versions file without influencing all versions of other tools
+# .tool-versions file. This will fail if the tool isn't installed, so callers
+# should invoke asdf_devbase_ensure first.
 asdf_devbase_exec() {
   local tool="$1"
   # Why: We're OK with this being the way it is.
@@ -58,9 +59,6 @@ asdf_devbase_exec() {
   fi
 
   export "ASDF_${tool_env_var}_VERSION"="${version}"
-
-  # Ensure that the tool and/or plugin is installed
-  asdf_devbase_ensure
 
   exec "$@"
 }


### PR DESCRIPTION
This is used only in linter scripts, which are run via `make`, which already invokes asdf_devbase_ensure.

Remove deprecated function call.

---

`make lint` invokes this ensure function an extra three times, which adds a surprising amount of time.