### PR TITLE
feat: Allow to specify provision target for shared/e2e step

### DIFF
--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -122,3 +122,10 @@ Installs all Go dependencies
 Runs tests marked with `or_e2e` build tags after provisioning a [devenv](github.com/getoutreach/devenv).
 If you have a file in your repository, `scripts/devenv/post-e2e-deploy.sh`, it
 will run it right after the devenv has been provisioned (before the tests run).
+
+#### Environment Variables
+
+* `SKIP_DEVENV_PROVISION`: Set "true" to skip provision step. Default false
+* `PROVISION_TARGET`: Maps to `devenv provision --snapshot-target $PROVISION_TARGET`, allowing to specify the provision target used. Otherwise, the default is either "flagship" or "base", latter being used when "outreach" is not included.
+* `SKIP_LOCALIZER`: Set "true" to skip creating a localizer tunnel before test start.
+* `REQUIRE_DEVCONFIG_AFTER_DEPLOY`: Set to "true" to run `devconfig.sh` after deploy. Otherwise, the step is executed before deploy.

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -281,10 +281,14 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 
 			// TODO(jaredallard): outreach specific code
 			target := "base"
-			for _, d := range deps {
-				if d == "outreach" {
-					target = flagship
-					break
+			if os.Getenv("PROVISION_TARGET") != "" {
+				target = os.Getenv("PROVISION_TARGET")
+			} else {
+				for _, d := range deps {
+					if d == "outreach" {
+						target = flagship
+						break
+					}
 				}
 			}
 

--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -4,6 +4,10 @@ parameters:
     description: Vault Instance to use
     type: string
     default: ""
+  provision_target:
+    description: Snapshot target used for provision command
+    type: string
+    default: ""
   devenv_pre_release:
     description: Use devenv release candidate to provision the test cluster.
     type: boolean
@@ -26,6 +30,7 @@ environment:
   VAULT_ADDR: << parameters.vault_address >>
   DEVENV_PRE_RELEASE: << parameters.devenv_pre_release >>
   GO_TEST_TIMEOUT: << parameters.go_test_timeout >>
+  PROVISION_TARGET: << parameters.provision_target >>
 resource_class: << parameters.resource_class >>
 steps:
   - setup_environment:


### PR DESCRIPTION
Allow shared/e2e jobs to specify what snapshot target to use, either "base" or "flagship". This change helps to support new snapshot targets in the future.

[QF-910]

[QF-910]: https://outreach-io.atlassian.net/browse/QF-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ