### PR TITLE
fix(vscode): don't pass golangci-lint flags to lintroller (DT-3864)

### DIFF
--- a/shell/vscode/golang-linters.sh
+++ b/shell/vscode/golang-linters.sh
@@ -8,7 +8,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 trap 'kill $(jobs -p)' EXIT
 
 # run in background so we can forward signals
-"$DIR/../lintroller.sh" "$@" &
+"$DIR/../lintroller.sh" ./... &
 
 # Wait for lintroller to finish
 wait


### PR DESCRIPTION
## What this PR does / why we need it

VSCode wasn't showing `lintroller` warnings because the `golangs-linter.sh` script was passing through `golangci-lint` flags to `lintroller`, even though they are not valid for it:

```
-: package run is not in GOROOT (~/.asdf/installs/golang/1.19.8/go/src/run)
-: malformed import path "--print-issued-lines=false": leading dash
-: malformed import path "--out-format=colored-line-number": leading dash
-: malformed import path "--issues-exit-code=0": leading dash
lintroller: 4 errors during loading
```

Instead we just have lintroller run for the entire service. (It appears that VSCode does not send package names to the golangci-lint script...)

## Jira ID

[DT-3864]

[DT-3864]: https://outreach-io.atlassian.net/browse/DT-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ