### PR TITLE
feat(linters): add kubecfg validation

### DIFF
--- a/shell/linters/kubecfg.sh
+++ b/shell/linters/kubecfg.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Ensure that deployments, if they exist, are able to be rendered by
+# kubecfg and are valid Kubernetes manifests.
+
+BUILDJSONNETPATH="$DIR/build-jsonnet.sh"
+KUBECONFORM=("$DIR/gobin.sh" github.com/yannh/kubeconform/cmd/kubeconform@v0.6.3)
+
+# Why: Used by the script that calls us
+# shellcheck disable=SC2034
+extensions=(jsonnet)
+
+kubecfg_kubeconform() {
+  tempFile=$(mktemp)
+  if ! "$BUILDJSONNETPATH" show >"$tempFile"; then
+    echo "Failed to render jsonnet" >&2
+    return 1
+  fi
+
+  if ! "${KUBECONFORM[@]}" \
+    -schema-location default \
+    -ignore-missing-schemas \
+    -strict \
+    -kubernetes-version 1.24.15 \
+    -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+    <"$tempFile"; then
+    echo "Failed to validate generated yaml" >&2
+    return 1
+  fi
+}
+
+linter() {
+  run_command "kubecfg" kubecfg_kubeconform
+}
+
+# formatter is a stub, since this doesn't format anything.
+formatter() {
+  true
+}


### PR DESCRIPTION
Adds a `kubecfg` linter that renders development manifests and ensures
they pass [`kubeconform`](https://github.com/yannh/kubeconform).

This doesn't get perfect coverage, since it doesn't generate them for
production (and all other possible cominations), but this should get us
a lot more coverage than what we had before (nothing).

Alternatively, we could try to generate it for all bentos using
Discovery, but given this repository is open-source -- that's a lot
harder to implement at the moment.

Success Case:

```bash
    -> kubecfg (.jsonnet) (3.976s)
```

Error Case (bad env var value):

```bash
stdin - Deployment discovery is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/template/spec/containers/0/env/1/value' does not validate with https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.24.15-standalone-strict/deployment-apps-v1.json#/properties/spec/properties/template/properties/spec/properties/containers/items/properties/env/items/properties/value/type: expected string or null, but got number
```

[DT-3738]


[DT-3738]: https://outreach-io.atlassian.net/browse/DT-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ