### PR TITLE
fix(docker): don't print directory when running make version

### DIFF
--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -15,7 +15,7 @@ source "${LIB_DIR}/bootstrap.sh"
 source "${LIB_DIR}/box.sh"
 
 APPNAME="$(get_app_name)"
-VERSION="$(make version)"
+VERSION="$(make --no-print-directory version)"
 MANIFEST="$(get_repo_directory)/deployments/docker.yaml"
 
 # shellcheck source=../../lib/buildx.sh


### PR DESCRIPTION
When we moved to using `ci/release/docker.sh` for docker builds,
that somehow caused `make version` to start printing
"entering directory" from `make`. So, we pass `--no-print-directory`
to prevent that message, since we don't want or need that.
