### PR TITLE
feat(test): support setup_remote_docker in tests

### DIFF
--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -39,6 +39,9 @@ parameters:
     description: If this is set to true all steps in this job will be skipped
     type: boolean
     default: false
+  setup_remote_docker:
+    type: boolean
+    default: false
 
 resource_class: << parameters.resource_class >>
 
@@ -55,7 +58,8 @@ steps:
       condition:
         not: << parameters.skip >>
       steps:
-        - setup_environment
+        - setup_environment:
+            setup_remote_docker: << parameters.setup_remote_docker >>
         - run:
             name: Run tests
             command: make test


### PR DESCRIPTION
Adds the ability to pass `setup_remote_docker` to the `shared/test` orb.
This enables accessing Docker in tests. Defaults to `false`.
