### PR TITLE
feat: rewrite test.sh to be better documented and use bash arrays

### DIFF
--- a/orbs/shared/commands/use_docker.yml
+++ b/orbs/shared/commands/use_docker.yml
@@ -2,4 +2,4 @@ description: Sets up a remote docker image with a standard version being used
 steps:
   - setup_remote_docker:
       docker_layer_caching: true
-      version: 20.10.7
+      version: 20.10.24

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -144,7 +144,7 @@ if [[ "$(git ls-files '*_test.go' | wc -l | tr -d ' ')" -gt 0 ]]; then
     # If we have -v passed as a test flag, we use the standard-verbose
     # format which is equal to 'go test -v'. Without this, we would
     # silently ignore the flag.
-    if [[ "$flag" == "-v" ]]; then
+    if [[ $flag == "-v" ]]; then
       format="standard-verbose"
     fi
   done
@@ -154,7 +154,10 @@ if [[ "$(git ls-files '*_test.go' | wc -l | tr -d ' ')" -gt 0 ]]; then
 
   # Convert TEST_TAGS into the expected format for `go test -tags`,
   # which is a comma-separated string.
-  test_tags_string=$(IFS=","; echo "${TEST_TAGS[*]}")
+  test_tags_string=$(
+    IFS=","
+    echo "${TEST_TAGS[*]}"
+  )
 
   if [[ -n $PACKAGE_TO_DEBUG ]]; then
     TESTBIN=$(mktemp)

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -1,18 +1,96 @@
 #!/usr/bin/env bash
+# Runs tests for the current project.
+set -euo pipefail
 
-set -e
-
-# The linter is flaky in some environments so we allow it to be overridden.
-# Also, if your editor already supports linting, you can make your tests run
-# faster at little cost with:
-# `LINTER=/bin/true make test``
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 LINTER="${LINTER:-"$DIR/golangci-lint.sh"}"
 
-# If you want to run tests under a debugger, use this ENV var to specify the
-# name of the package you wish to debug.  You can only debug one package at a
-# time.
-## PACKAGE_TO_DEBUG=
+# CI denotes if we're in CI or not. When running in CI, certain
+# environment variables below behaviour may differ. Check each
+# environment variables' documentation for more information.
+CI="${CI:-}"
+
+# TEST_FLAGS is an array of flags to pass to `go test`. TEST_FLAGS must
+# be a string value. It will be split on spaces.
+#
+# Why: We need to support importing flags from a string variable, e.g.,
+# CircleCI in-line environment variables or contexts.
+# shellcheck disable=SC2206
+TEST_FLAGS=(${TEST_FLAGS:-})
+
+# TEST_TAGS is an array of tags to pass to `go test -tags`. TEST_TAGS
+# must be a string value. It will be split on spaces.
+#
+# Why: We need to support importing flags from a string variable, e.g.,
+# CircleCI in-line environment variables or contexts.
+# shellcheck disable=SC2206
+TEST_TAGS=(${TEST_TAGS:-})
+
+# TEST_PACKAGES is the packages to test. Defaults to "./...".
+# TEST_PACKAGES must be a string value. It will be split on spaces.
+#
+# If PACKAGE_TO_DEBUG is set, TEST_PACKAGES will be ignored.
+#
+# Why: We need to support importing flags from a string variable, e.g.,
+# CircleCI in-line environment variables or contexts.
+# shellcheck disable=SC2206
+TEST_PACKAGES=(${TEST_PACKAGES:-"./..."})
+
+# PACKAGE_TO_DEBUG is a package that will be built and run under the
+# delve debugger. When set, TEST_PACKAGE will have no effect.
+PACKAGE_TO_DEBUG="${PACKAGE_TO_DEBUG:-}"
+
+# BENCH_FLAGS is an array of flags to pass to `go test -bench`.
+# BENCH_FLAGS must be a string value. It will be split on spaces.
+#
+# Why: We need to support importing flags from a string variable, e.g.,
+# CircleCI in-line environment variables or contexts.
+# shellcheck disable=SC2206
+BENCH_FLAGS=(${BENCH_FLAGS:-})
+
+# GO_FLAGS is an array of flags to pass to any go command being ran.
+# GO_FLAGS must be a string value. It will be split on spaces.
+#
+# Why: We need to support importing flags from a string variable, e.g.,
+# CircleCI in-line environment variables or contexts.
+# shellcheck disable=SC2206
+GO_FLAGS=(${GO_FLAGS:-})
+
+# COVER_FLAGS is an array of flags to pass to `go test -cover`.
+# COVER_FLAGS must be a string value. It will be split on spaces.
+#
+# Why: We need to support importing flags from a string variable, e.g.,
+# CircleCI in-line environment variables or contexts.
+# shellcheck disable=SC2206
+COVER_FLAGS=(${COVER_FLAGS:-})
+
+# WITH_COVERAGE is a boolean flag that enables coverage reporting. If
+# set at all, a coverage file will be generated during the test. It
+# will be outputted to /tmp/coverage.out. When running in CI, this is
+# always enabled.
+WITH_COVERAGE="${WITH_COVERAGE:-}"
+
+# GO_TEST_TIMEOUT is the timeout to pass to `go test -timeout`. If not
+# set, no timeout will be passed.
+GO_TEST_TIMEOUT="${GO_TEST_TIMEOUT:-}"
+
+# RACE determines if 'go test -race' should be enabled or not. If set to
+# 'disabled', race condition testing will not be enabled and the flag
+# will not be passed to 'go test'. Defaults to 'enabled'.
+RACE="${RACE:-enabled}"
+
+if [[ -n $CI ]]; then
+  GOFLAGS+=(-mod=readonly)
+  WITH_COVERAGE="true"
+
+  # Ensure that all processes recieve the value of GOFLAGS.
+  export GOFLAGS
+fi
+
+# If GO_TEST_TIMEOUT is set, we pass it to `go test` as a timeout.
+if [[ -n $GO_TEST_TIMEOUT ]]; then
+  TEST_FLAGS+=(-timeout "$GO_TEST_TIMEOUT")
+fi
 
 # shellcheck source=./lib/logging.sh
 source "$DIR/lib/logging.sh"
@@ -20,63 +98,63 @@ source "$DIR/lib/logging.sh"
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
 
-# This comes from the Makefile. This makes the linter aware of it.
-export TEST_TAGS=$TEST_TAGS
-
-if [[ -z $TEST_PACKAGES ]]; then
-  TEST_PACKAGES="./..."
-fi
-
-if [[ -n $CI ]]; then
-  export GOFLAGS="${GOFLAGS} -mod=readonly"
-fi
-
-if [[ -n $GO_TEST_TIMEOUT ]]; then
-  export TEST_FLAGS=${TEST_FLAGS:--timeout "$GO_TEST_TIMEOUT"}
-fi
+# REPODIR is the base directory of the repository.
+REPODIR=$(get_repo_directory)
 
 # Catches test dependencies by shuffling tests if the installed Go version supports it
 currentver="$(go version | awk '{ print $3 }' | sed 's|go||')"
 requiredver="1.17.0"
 if [[ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" == "$requiredver" ]]; then
-  TEST_FLAGS="$TEST_FLAGS -shuffle=on"
+  TEST_FLAGS+=(-shuffle=on)
 fi
 
 # Although we highly encourage all projects to run test with a check for race coditions, teams can
 # choose to temporarily disable this option
 if [[ $RACE != "disabled" ]]; then
-  TEST_FLAGS="$TEST_FLAGS -race"
+  TEST_FLAGS+=(-race)
 fi
 
-if [[ -n $WITH_COVERAGE || -n $CI ]]; then
-  COVER_FLAGS=${COVER_FLAGS:- -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out -cover}
+# If WITH_COVERAGE is set, we pass flags to 'go test' to enable coverage
+# file generation.
+if [[ -n $WITH_COVERAGE ]]; then
+  COVER_FLAGS+=(-coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out -cover)
 fi
 
 testInclude="$(get_repo_directory)/scripts/test.include.sh"
 if [[ -e $testInclude ]]; then
+  info "Running project specific test file: $testInclude"
   # Why: This is dynamic and can't be parsed
   # shellcheck disable=SC1090
   source "$testInclude"
 fi
 
 if [[ "$(git ls-files '*_test.go' | wc -l | tr -d ' ')" -gt 0 ]]; then
-  info "Running go test ($TEST_TAGS)"
+  info "Running go test (${TEST_TAGS[*]})"
 
-  format="dots-v2"
+  # If TEST_OUTPUT_FORMAT is set, we use it instead of the default value
+  # of "dots-v2"
+  format="${TEST_OUTPUT_FORMAT:-"dots-v2"}"
   if [[ -n $CI ]]; then
+    # When in CI, always use the pkgname format because it's easier to
+    # read.
     format="pkgname"
   fi
 
-  if [[ -n $TEST_OUTPUT_FORMAT ]]; then
-    format="$TEST_OUTPUT_FORMAT"
-  fi
-
-  if [[ -n $BENCH_FLAGS ]]; then
-    format="dots-v2"
-  fi
+  for flag in "${TEST_FLAGS[@]}"; do
+    # If we have -v passed as a test flag, we use the standard-verbose
+    # format which is equal to 'go test -v'. Without this, we would
+    # silently ignore the flag.
+    if [[ "$flag" == "-v" ]]; then
+      format="standard-verbose"
+    fi
+  done
 
   # Ensure this exists for tests results, just in case
   mkdir -p "bin"
+
+  # Convert TEST_TAGS into the expected format for `go test -tags`,
+  # which is a comma-separated string.
+  test_tags_string=$(IFS=","; echo "${TEST_TAGS[*]}")
 
   if [[ -n $PACKAGE_TO_DEBUG ]]; then
     TESTBIN=$(mktemp)
@@ -84,31 +162,32 @@ if [[ "$(git ls-files '*_test.go' | wc -l | tr -d ' ')" -gt 0 ]]; then
     # We build the binary ourselves, rather than doing it implicitly via the
     # Delve command line, because the Delve command line doesn't handle our
     # complex linker flags very well right now (v1.7.3).
-    #
-    # shellcheck disable=SC2086
     go test -c -o "${TESTBIN}" \
-      $BENCH_FLAGS $COVER_FLAGS $TEST_FLAGS \
-      -ldflags "-X github.com/getoutreach/go-outreach/v2/pkg/app.Version=testing -X github.com/getoutreach/gobox/pkg/app.Version=testing" -tags="$TEST_TAGS" "$PACKAGE_TO_DEBUG"
+      "${BENCH_FLAGS[@]}" "${COVER_FLAGS[@]}" "${TEST_FLAGS[@]}" \
+      -ldflags "-X github.com/getoutreach/go-outreach/v2/pkg/app.Version=testing -X github.com/getoutreach/gobox/pkg/app.Version=testing" \
+      -tags="$test_tags_string" "$PACKAGE_TO_DEBUG"
 
     # We pass along command line args to the executable so you can specify
     # `-test.run <regex>`, `-test.bench <regex>`, etc. if desired.  Try `-help`
     # for more information.
-    "$DIR/gobin.sh" github.com/go-delve/delve/cmd/dlv@v"$(get_application_version "delve")" exec "${TESTBIN}" -- "$@"
+    exec "$DIR/gobin.sh" github.com/go-delve/delve/cmd/dlv@v"$(get_application_version "delve")" exec "${TESTBIN}" -- "$@"
   else
     exitCode=0
-    # Why: We want these to split. For those wondering about "$@":
-    # https://stackoverflow.com/questions/5720194/how-do-i-pass-on-script-arguments-that-contain-quotes-spaces
-    # shellcheck disable=SC2086
-    "$DIR/gobin.sh" gotest.tools/gotestsum@v"$(get_application_version "gotestsum")" \
-      --junitfile "$(get_repo_directory)/bin/unit-tests.xml" --format "$format" -- $BENCH_FLAGS $COVER_FLAGS $TEST_FLAGS \
-      -ldflags "-X github.com/getoutreach/go-outreach/v2/pkg/app.Version=testing -X github.com/getoutreach/gobox/pkg/app.Version=testing" -tags="$TEST_TAGS" \
-      "$@" $TEST_PACKAGES || exitCode=$?
+
+    GOTESTSUMPATH=$("$DIR/gobin.sh" -p gotest.tools/gotestsum@v"$(get_application_version "gotestsum")")
+    (
+      set -x
+      "$GOTESTSUMPATH" --junitfile "$REPODIR/bin/unit-tests.xml" --format "$format" -- \
+        "${BENCH_FLAGS[@]}" "${COVER_FLAGS[@]}" "${TEST_FLAGS[@]}" \
+        -ldflags "-X github.com/getoutreach/go-outreach/v2/pkg/app.Version=testing -X github.com/getoutreach/gobox/pkg/app.Version=testing" \
+        -tags="$test_tags_string" "$@" "${TEST_PACKAGES[@]}"
+    ) || exitCode=$?
 
     if [[ -n $CI ]]; then
-      # Move this to a temporary directoy so that we can control
+      # Move this to a temporary directory so that we can control
       # what gets uploaded via the store_test_results call
       mkdir -p /tmp/test-results
-      mv "$(get_repo_directory)/bin/unit-tests.xml" /tmp/test-results/
+      mv "$REPODIR/bin/unit-tests.xml" /tmp/test-results/
     fi
 
     exit $exitCode

--- a/shell/test.sh
+++ b/shell/test.sh
@@ -79,6 +79,12 @@ GO_TEST_TIMEOUT="${GO_TEST_TIMEOUT:-}"
 # will not be passed to 'go test'. Defaults to 'enabled'.
 RACE="${RACE:-enabled}"
 
+# TEST_OUTPUT_FORMAT is the format to pass to gotestsum. If not set,
+# the default value of "dots-v2" will be used. If CI is set, the default
+# value is "pkgname". If 'TEST_FLAGS' contains '-v', the default value
+# is "standard-verbose".
+TEST_OUTPUT_FORMAT="${TEST_OUTPUT_FORMAT:-}"
+
 if [[ -n $CI ]]; then
   GOFLAGS+=(-mod=readonly)
   WITH_COVERAGE="true"
@@ -131,13 +137,16 @@ fi
 if [[ "$(git ls-files '*_test.go' | wc -l | tr -d ' ')" -gt 0 ]]; then
   info "Running go test (${TEST_TAGS[*]})"
 
-  # If TEST_OUTPUT_FORMAT is set, we use it instead of the default value
-  # of "dots-v2"
-  format="${TEST_OUTPUT_FORMAT:-"dots-v2"}"
+  format="dots-v2"
   if [[ -n $CI ]]; then
     # When in CI, always use the pkgname format because it's easier to
     # read.
     format="pkgname"
+  fi
+
+  # If TEST_OUTPUT_FORMAT is set, we use it instead of the default value.
+  if [[ -n $TEST_OUTPUT_FORMAT ]]; then
+    format="$TEST_OUTPUT_FORMAT"
   fi
 
   for flag in "${TEST_FLAGS[@]}"; do

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@ grpcui: 1.3.1
 jsonnetfmt: 0.19.1
 goimports: 0.5.0
 delve: 1.20.1
-gotestsum: 1.9.0
+gotestsum: 1.10.1
 lintroller: 1.16.0
 clerkgenproto: 1.28.1
 goveralls: 0.0.11


### PR DESCRIPTION
Changed `test.sh` to fully document all environment variables in use.
Changed `_FLAG` and `_TAG` environment variables to use bash arrays to
ensure consistent space handling behaviour, while keeping space
splitting for pre-specified environment variables for compatability.

When passing `-v` to `TEST_FLAGS` (and in turn to `go test`) we now set
the `gotestsum` output format to be `standard-verbose` which is
equivalent to `go test -v`[1] output. Before, this was silently ignored
and frustrating to work with.

Updated the `shared/setup_docker` step to use a newer version of Docker
as the older version had issues with apt package installs (somehow?)

[1]: https://github.com/gotestyourself/gotestsum#:~:text=standard%2Dverbose%20%2D%20the%20standard%20go%20test%20%2Dv%20format.
