### PR TITLE
fix: only publish node client if releasing a service

### DIFF
--- a/shell/ci/release/release.sh
+++ b/shell/ci/release/release.sh
@@ -61,7 +61,7 @@ if [[ $UPDATED == "false" ]]; then
 elif [[ $UPDATED == "true" ]]; then
   # Special logic to publish a node client to github packages while
   # we're dual writing. This will be removed soonish.
-  if [[ -e $nodeClientDir ]]; then
+  if [[ -e $nodeClientDir && "$(is_service)" == "true" ]]; then
     info "Publishing node client to Github Packages"
 
     info_sub "pointing package.json to Github Packages"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This change prevents a publishing node clients if the repo is not a service and therefore will not have any clients to publish.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3704]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3704]: https://outreach-io.atlassian.net/browse/DT-3704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ