### PR TITLE
revert(docker-build): Revert "fix: use ci docker build script to buil…

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -205,7 +205,7 @@ docker-build:: pre-docker-build
 	@echo " ===> building docker image <==="
 	@ssh-add -L
 	@echo " ===> If you run into credential issues, ensure that your key is in your SSH agent (ssh-add <ssh-key-path>) <==="
-	@./scripts/shell-wrapper.sh ci/release/docker.sh
+	DOCKER_BUILDKIT=1 docker build --ssh default -t gcr.io/outreach-docker/$(APP) -f deployments/$(APP)/Dockerfile . --build-arg VERSION=${APP_VERSION}
 
 ## fmt:             run source code formatters
 .PHONY: fmt

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -142,16 +142,10 @@ build_and_push_image() {
     fi
   fi
 
-  # Build image with registry prefix for devenv
-  if [[ -n $DEVENV_DOCKER_BUILD ]]; then
-    info "Building Docker Image for devenv"
-    image="gcr.io/outreach-docker/$image"
-  else
-    # Build a quick native image and load it into docker cache for security scanning
-    # Scan reports for release images are also uploaded to OpsLevel
-    # (test image reports only available on PR runs as artifacts).
-    info "Building Docker Image (for scanning)"
-  fi
+  # Build a quick native image and load it into docker cache for security scanning
+  # Scan reports for release images are also uploaded to OpsLevel
+  # (test image reports only available on PR runs as artifacts).
+  info "Building Docker Image (for scanning)"
   (
     set -x
     docker buildx build "${args[@]}" -t "$image" --load "$buildContext"


### PR DESCRIPTION
…d docker images (#577)"

This reverts commit 2d80345a03f6833d8627edccdb5af33cca7b494d.

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Revert this change because it creates buildx instances for every build and fill up docker cache easily. It does not work well for devenv images.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers


<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
