### PR TITLE
fix: update docker.sh statement, deduplicate logic

### DIFF
--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -167,6 +167,7 @@ build_and_push_image() {
   for arg in "${args[@]}"; do
     if [[ $arg == "--push" ]]; then
       push=true
+      break
     fi
   done
 

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -114,7 +114,7 @@ build_and_push_image() {
     return
   fi
 
-  args=(
+  local args=(
     "--ssh" "default"
     "--progress=plain" "--file" "$dockerfile"
     "--build-arg" "VERSION=${VERSION}"
@@ -125,7 +125,7 @@ build_and_push_image() {
   done
 
   # Argument format: os/arch,os/arch
-  platformArgumentString=""
+  local platformArgumentString=""
   for platform in "${platforms[@]}"; do
     if [[ -n $platformArgumentString ]]; then
       platformArgumentString+=","
@@ -138,7 +138,7 @@ build_and_push_image() {
   # we'll tag the image with that tag and latest. Otherwise, we'll just
   # build a latest image for the name "$image" (the name of the image as
   # shown in the manifest) instead.
-  tags=()
+  local tags=()
   if [[ -n $CIRCLE_TAG ]]; then
     tags+=("$remote_image_name:$CIRCLE_TAG" "$remote_image_name:latest")
 

--- a/shell/lib/buildx.sh
+++ b/shell/lib/buildx.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
-BUILDX_VERSION="v0.8.2"
-BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-amd64"
+# Installs 'docker buildx' if it doesn't already exist. On Linux,
+# creates a buildx instance and boots it.
+
+# BUILDX_VERSION is the version of 'docker buildx' we should use if not
+# already installed on the host system.
+BUILDX_VERSION="v0.11.2"
+
+# ARCH is the architecture of the host system. Matches the format,
+# loosely, of GOARCH.
+ARCH=$(uname -m)
+if [[ $ARCH == "x86_64" ]]; then
+  ARCH="amd64"
+elif [[ $ARCH == "aarch64" ]]; then
+  ARCH="arm64"
+fi
+
+# BUILDX_BINARY_URL is the URL to download the buildx binary from.
+BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-$ARCH"
 
 # only install buildx when we don't already have it
 if ! docker buildx version >/dev/null 2>&1; then
@@ -14,7 +30,7 @@ if ! docker buildx version >/dev/null 2>&1; then
   chmod a+x ~/.docker/cli-plugins/docker-buildx
 fi
 
-# On macOS we don't need to create a builder or support QEMU
+# On macOS we don't need to create a builder or support QEMU.
 if [[ $OSTYPE == "linux-gnu"* ]]; then
   # Taken from setup-qemu Github Action
   echo "💎 Installing QEMU static binaries..."


### PR DESCRIPTION
As a follow up to #605, this updates the docker.sh output to better
reflect what the docker build is doing.

I also took the time to combine the logic for the docker build _test_
logic and the docker build _release_ logic (determined by the presence
of `CIRCLE_TAG`. This brings the added benefit of us building a docker
image on all archs that we would release to on PRs.

Updated buildx to reflect what is in use on most user's machines.
