### PR TITLE
fix: Upgrade Go 1.19.11

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@
 # you are reducing compatibility guarantees.
 ## <<Stencil::Block(toolverOverride)>>
 ## <</Stencil::Block>>
-golang 1.19.8
+golang 1.19.11
 terraform 1.4.4
 protoc 21.5
 nodejs 18.14.1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,16 +38,27 @@
         // Maps the go module cache on the host to the persistent volume used by devspaces.
         // See the value of `go env GOMODCACHE` on the host and devspace.
         {
-          "from": "${env:HOME}/.asdf/installs/golang/1.19.8/packages/pkg/mod",
+          "from": "${env:HOME}/.asdf/installs/golang/1.19.11/packages/pkg/mod",
           "to": "/tmp/cache/go/mod/"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.
           // This enables debugging standard library code.
-          "from": "${env:HOME}/.asdf/installs/golang/1.19.8/go/src",
-          "to": "/home/dev/.asdf/installs/golang/1.19.8/go/src"
+          "from": "${env:HOME}/.asdf/installs/golang/1.19.11/go/src",
+          "to": "/home/dev/.asdf/installs/golang/1.19.11/go/src"
         }
       ]
+    },
+    {
+      "name": "Attach to dev container (in binary mode)",
+      "type": "go",
+      "debugAdapter": "dlv-dap",
+      "request": "attach",
+      "mode": "remote",
+      // <<Stencil::Block(vscodeRemoteDebugDevspaceBinary)>>
+      "host": "127.0.0.1",
+      "port": 42097
+      // <</Stencil::Block>>
     }
     // <<Stencil::Block(vscodeLaunchConfigs)>>
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/getoutreach/devbase/v2
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.70.5
+	github.com/getoutreach/gobox v1.71.0
 	github.com/getoutreach/localizer v1.14.5
 	github.com/google/go-github/v47 v47.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/getoutreach/gobox v1.70.5 h1:lRYCnnjf72aE79jtHbRBHFGcqvPvwoBBiU2/MoaupUE=
-github.com/getoutreach/gobox v1.70.5/go.mod h1:OUNenxrlCtCy3aWyRfWz78lcXQZU2gvTHWrMjyGS2eU=
+github.com/getoutreach/gobox v1.71.0 h1:5T3G94y6aG7lqnfzXzMhuR/hw0VnNGwU7VQLml+Lwsw=
+github.com/getoutreach/gobox v1.71.0/go.mod h1:NMFEug44bFUQnpGTS9vov/WsZK36fnQFLDl+3p/yeas=
 github.com/getoutreach/localizer v1.14.5 h1:YrVCdQ+mmFjLB8FR/rAIPKUjP4Vu/J40meVT1PjxpsQ=
 github.com/getoutreach/localizer v1.14.5/go.mod h1:hDN4ku3XiaDCED9sLxzg3Fagw4MySdmbRtrHQDHGZSg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,4 +1,4 @@
-version: v1.35.0
+version: v1.36.0
 modules:
     - name: github.com/getoutreach/devbase
       url: file://./
@@ -11,7 +11,7 @@ modules:
       version: v1.10.0
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
-      version: v1.12.0
+      version: v1.13.2
 files:
     - name: .circleci/config.yml
       template: .circleci/config.yml.tpl


### PR DESCRIPTION
Upgrades Go to 1.19.11 through `stencil`. Also includes a `gobox`
upgrade.
