### PR TITLE
fix: add missing per-project formatter for migrations

### DIFF
--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -13,7 +13,6 @@ source "$DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/shell.sh
 source "$DIR/lib/shell.sh"
 
-
 # add extra (per project) linters
 linters=("$DIR/linters"/*.sh)
 if [[ -z $workspaceFolder ]]; then

--- a/shell/fmt.sh
+++ b/shell/fmt.sh
@@ -13,11 +13,20 @@ source "$DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/shell.sh
 source "$DIR/lib/shell.sh"
 
+
+# add extra (per project) linters
+linters=("$DIR/linters"/*.sh)
+if [[ -z $workspaceFolder ]]; then
+  workspaceFolder="$(get_repo_directory)"
+fi
+if [[ -d "$workspaceFolder"/scripts/linters ]]; then
+  linters+=("$workspaceFolder/scripts/linters/"*.sh)
+fi
+
 info "Running formatters"
 
 started_at="$(get_time_ms)"
-for languageScript in "$DIR/linters"/*.sh; do
-  languageName="$(basename "${languageScript%.sh}")"
+for linterScript in "${linters[@]}"; do
 
   # We use a sub-shell to prevent inheriting
   # the changes to functions/variables to the parent
@@ -29,7 +38,7 @@ for languageScript in "$DIR/linters"/*.sh; do
 
     # Why: Dynamic
     # shellcheck disable=SC1090
-    source "$DIR/linters/$languageName.sh"
+    source "$linterScript"
 
     matched=false
     if [[ "$(find_files_with_extensions "${extensions[@]}" | wc -l | tr -d ' ')" -gt 0 ]]; then


### PR DESCRIPTION
adds per-project formatters, just like linters
