### PR TITLE
fix(confluence): don't append logs to markdown output

### DIFF
--- a/shell/ci/release/confluence-publish.sh
+++ b/shell/ci/release/confluence-publish.sh
@@ -51,7 +51,7 @@ while read -r file; do
     "$GOBIN" "github.com/getoutreach/markdowntools/cmd/visualizemd@$(get_application_version "getoutreach/markdowntools/visualizemd")" \
       -umlusername internal_access_user -umlpassword "${UML_PASSWORD}" -umlserver https://rolling.mi.outreach-dev.com/api/internal/plantuml \
       -mermaidusername internal_access_user -mermaidpassword "${UML_PASSWORD}" -mermaidserver https://rolling.mi.outreach-dev.com/api/internal/mermaid \
-      -u "${CONFLUENCE_USERNAME}" -p "${CONFLUENCE_API_TOKEN}" -no-add-parent -f "${fileBaseName}" >"${updatedName}"
+      -u "${CONFLUENCE_USERNAME}" -p "${CONFLUENCE_API_TOKEN}" -no-add-parent -f "${fileBaseName}" -o "${updatedName}"
 
     # Add caveat to the end of the updated file.
     {


### PR DESCRIPTION
## What this PR does / why we need it

Avoids redirecting `stdout` of `visualizemd` to create the markdown file, and instead uses the existing `-o` flag.

## Jira ID

[DT-3756]

[DT-3756]: https://outreach-io.atlassian.net/browse/DT-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ