### PR TITLE
feat(golangci-lint): Upgrade to 1.53.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@
 # you are reducing compatibility guarantees.
 ## <<Stencil::Block(toolverOverride)>>
 ## <</Stencil::Block>>
-golang 1.19.11
+golang 1.20.7
 terraform 1.4.4
 protoc 21.5
 nodejs 18.14.1
@@ -15,7 +15,7 @@ nodejs 18.14.1
 ## <<Stencil::Block(toolver)>>
 # The below tools are used by all repositories when using devbase
 mage 1.14.0
-golangci-lint 1.50.0
+golangci-lint 1.53.3
 shellcheck 0.9.0
 shfmt 3.7.0
 ## <</Stencil::Block>>

--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -9,18 +9,42 @@ linters-settings:
   govet:
     check-shadowing: true
   revive:
-    confidence: 0
+    rules:
+      # Enable the default golint rules. We must include these because
+      # we configure a single rule, which disables the default rules.
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      # While we agree with this rule, right now it would break too many
+      # projects. So, we disable it by default.
+      - name: unused-parameter
+        disabled: true
   gocyclo:
     min-complexity: 25
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
   goconst:
     min-len: 3
     min-occurrences: 3
-  misspell:
-    locale: US
   lll:
     line-length: 140
   gocritic:
@@ -84,7 +108,6 @@ issues:
       linters:
         - gocyclo
         - errcheck
-        - dupl
         - gosec
         - funlen
         - gochecknoglobals # Globals in test files are tolerated.


### PR DESCRIPTION
Upgrades `golangci-lint` to `1.53.3` to support Go 1.20.

This likely brings in some new lint rules that _may_ fail on new
projects. Putting it in unstable to give us sometime to run into them
and adjust our rules as needed.

I didn't hit any in a few repos I tried this on.
