### PR TITLE
fix: Upgrading goreleaser to 1.20.0 to fix releases

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -89,7 +89,7 @@ release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 >/dev/null || true
 	@git tag "$(APP_VERSION)" >&2
-	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.6.2 release --skip-announce --skip-publish --skip-validate --rm-dist
+	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ./scripts/shell-wrapper.sh gobin.sh github.com/goreleaser/goreleaser@v1.20.0 release --skip-announce --skip-publish --skip-validate --rm-dist
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 


### PR DESCRIPTION
Older versions of goreleaser have a bug that detects go v1.20 incorrectly and stops releasing darwin/arm64.  We have to upgrade to fix it. https://github.com/goreleaser/goreleaser/issues/3835
