### PR TITLE
fix(golangci-lint): v1.54.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -15,7 +15,7 @@ golang 1.20.7
 ## <<Stencil::Block(toolver)>>
 # The below tools are used by all repositories when using devbase
 mage 1.14.0
-golangci-lint 1.53.3
+golangci-lint 1.54.1
 shellcheck 0.9.0
 shfmt 3.7.0
 goreleaser 1.20.0

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -15,8 +15,10 @@ if [[ -z $workspaceFolder ]]; then
 fi
 
 # Enable only fast linters, and always use the correct config.
-args=("--config=${workspaceFolder}/scripts/golangci.yml" "$@" "--fast" "--allow-parallel-runners")
+args=("--config=${workspaceFolder}/scripts/golangci.yml" "$@"  "-v" "--fast" "--allow-parallel-runners")
 
+
+asdf_devbase_exec golangci-lint --version
 
 # If we're on a system with free, set GOMEMLIMIT to a value that's less
 # than the max amount of RAM on the system. This helps ensure that we

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -41,26 +41,41 @@ asdf_get_version_from_devbase() {
   grep -E "^$tool_name " "$devbase_dir/.tool-versions" | head -n1 | awk '{print $2}'
 }
 
-# asdf_devbase_exec executes a command with the versions from the devbase
+# asdf_devbase_exec runs asdf_devbase_run but execs the command instead
+# of running it as a subprocess.
+asdf_devbase_exec() {
+  asdf_tool_env_var "$1"
+  exec "$@"
+}
+
+# asdf_devbase_run executes a command with the versions from the devbase
 # .tool-versions file. This will fail if the tool isn't installed, so callers
 # should invoke asdf_devbase_ensure first.
-asdf_devbase_exec() {
+asdf_devbase_run() {
+  asdf_tool_env_var "$1"
+  "$@"
+}
+
+# asdf_tool_env_var exports an environment variable to have the provided
+# tool version be used in asdf. This mutates the current shell's
+# environment variables by exporting the variable.
+#
+# See: https://asdf-vm.com/manage/versions.html#set-current-version
+asdf_tool_env_var() {
   local tool="$1"
   # Why: We're OK with this being the way it is.
   # shellcheck disable=SC2155
-  local tool_env_var="$(echo "$tool" | tr '[:lower:]-' '[:upper:]_')"
+  local tool_env_var="$(tr '[:lower:]-' '[:upper:]_' <<<"$tool")"
 
   # Why: We're OK with this being the way it is.
   # shellcheck disable=SC2155
   local version="$(asdf_get_version_from_devbase "$tool")"
   if [[ -z $version ]]; then
     echo "No version found for $tool in devbase .tool-versions file"
-    exit 1
+    return 1
   fi
 
   export "ASDF_${tool_env_var}_VERSION"="${version}"
-
-  exec "$@"
 }
 
 # asdf_devbase_ensure ensures that all versions of tools are installed from

--- a/shell/linters.sh
+++ b/shell/linters.sh
@@ -62,7 +62,7 @@ for linterScript in "${linters[@]}"; do
 
     # Set by the language file
     if ! linter; then
-      error "Linter failed to run, run 'make fmt' to fix"
+      error "linter failed to run. Please check the logs, 'make fmt' may help in some cases."
       exit 1
     fi
   )


### PR DESCRIPTION
Upgrades golangci-lint to v1.54.1 to support Go 1.21, but also to
hopefully fix some memory issues that have ocurred in CI lately.
