### PR TITLE
fix(golangci-lint): upgrade to v1.54.1, fail on invalid version pairs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -15,7 +15,7 @@ golang 1.20.7
 ## <<Stencil::Block(toolver)>>
 # The below tools are used by all repositories when using devbase
 mage 1.14.0
-golangci-lint 1.53.3
+golangci-lint 1.54.1
 shellcheck 0.9.0
 shfmt 3.7.0
 goreleaser 1.20.0

--- a/root/Makefile
+++ b/root/Makefile
@@ -92,7 +92,8 @@ release:: pre-release
 	@# Create a tag for our version
 	@git tag -d "$(APP_VERSION)" >&2 >/dev/null || true
 	@git tag "$(APP_VERSION)" >&2
-	@GORELEASER_CURRENT_TAG=$(APP_VERSION) goreleaser release --skip-announce --skip-publish --skip-validate --rm-dist
+	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ASDF_GORELEASER_VERSION=$(shell cat "$(BOOTSTRAP_DIR)/.tool-versions" | grep goreleaser | awk '{ print $$2 }') \
+		goreleaser release --skip-announce --skip-publish --skip-validate --rm-dist
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -23,37 +23,53 @@ GOLANGCILINT_VERSION=$(asdf_devbase_run golangci-lint --version | awk '{print $4
 GO_MINOR_VERSION_INT=${GO_MINOR_VERSION//./}
 GOLANGCI_LINT_VERSION_INT=${GOLANGCILINT_VERSION//./}
 
-# Go 1.20 requires >= golangci-lint 1.52.0
-if [[ $GO_MINOR_VERSION_INT == 120 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1520 ]]; then
-  echo "Error: Go 1.20 requires golangci-lint 1.52.0 or newer (detected $GOLANGCILINT_VERSION)" >&2
-  exit 1
-fi
-
-# Go 1.21 requires >= golangci-lint 1.54.1
-if [[ $GO_MINOR_VERSION_INT == 121 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1541 ]]; then
-  echo "Error: Go 1.21 requires golangci-lint 1.54.1 or newer (detected $GOLANGCILINT_VERSION)" >&2
-  exit 1
-fi
-
-# If we're on a system with free, set GOMEMLIMIT to a value that's less
-# than the max amount of RAM on the system. This helps ensure that we
-# don't go over the memory limit and get OOM killed. This is mostly
-# important for CI systems.
-if (command -v free || command -v sysctl) &>/dev/null; then
-  if command -v free &>/dev/null; then
-    mem="$(free -m | awk '/^Mem:/{print $2}')"
-  elif command -v sysctl &>/dev/null; then
-    mem=$((($(sysctl -n hw.memsize) / 1024) / 1024))
+# Check version compatibility for golangci-lint/go 1.X.
+if [[ ${GO_MINOR_VERSION_INT:0:1} -lt 2 ]] && [[ ${GOLANGCI_LINT_VERSION_INT:0:1} -lt 2 ]]; then
+  # Go 1.20 requires >= golangci-lint 1.52.0
+  if [[ $GO_MINOR_VERSION_INT == 120 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1520 ]]; then
+    echo "Error: Go 1.20 requires golangci-lint 1.52.0 or newer (detected $GOLANGCILINT_VERSION)" >&2
+    exit 1
   fi
 
-  if [[ $mem -lt 1024 ]] || [[ -z $mem ]]; then
-    # Failed to determine GOMEMLIMIT somehow. Fallback to GOGC.
-    echo "Warning: Failed to determine system memory or under threshold. " \
-      "Falling back to GOGC" >&2
-    export GOGC=20
-  else
-    # Use mem as the memory target and ensure that we have 1GB of room.
-    export GOMEMLIMIT="$((mem - 1024))MiB"
+  # Go 1.21 requires >= golangci-lint 1.54.1
+  if [[ $GO_MINOR_VERSION_INT == 121 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1541 ]]; then
+    echo "Error: Go 1.21 requires golangci-lint 1.54.1 or newer (detected $GOLANGCILINT_VERSION)" >&2
+    exit 1
+  fi
+fi
+
+# If GOGC or GOMEMLIMIT aren't set, we attempt to set them to better
+# manage memory usage by the golangci-linter in CI.
+if [[ -z $GOGC ]] && [[ -z $GOMEMLIMIT ]]; then
+
+  # RESERVED_MEMORY_IN_MIB is the amount of memory we want to reserve for
+  # other processes or overheads. This will not be used by the linter.
+  RESERVED_MEMORY_IN_MIB=2048
+
+  # If we're on a system with free or sysctl, set GOMEMLIMIT to a value
+  # that's less than the max amount of RAM on the system. This helps
+  # ensure that we don't go over the memory limit and get OOM killed.
+  # This is mostly important for CI systems or other container
+  # environments.
+  if (command -v free || command -v sysctl) &>/dev/null; then
+    if command -v free &>/dev/null; then
+      mem="$(free -m | awk '/^Mem:/{print $2}')"
+    elif command -v sysctl &>/dev/null; then
+      mem=$((($(sysctl -n hw.memsize) / 1024) / 1024))
+    fi
+
+    # If we don't have enough memory to hit the reserve or we failed to
+    # determine how much memory we have, fall back to setting GOGC --
+    # which is relative to the amount of memory we have.
+    if [[ $mem -lt $RESERVED_MEMORY_IN_MIB ]] || [[ -z $mem ]]; then
+      # Failed to determine GOMEMLIMIT somehow. Fallback to GOGC.
+      echo "Warning: Failed to determine system memory or under threshold. " \
+        "Falling back to GOGC" >&2
+      export GOGC=20
+    else
+      # Use mem as the memory target and ensure that we have 1GB of room.
+      export GOMEMLIMIT="$((mem - RESERVED_MEMORY_IN_MIB))MiB"
+    fi
   fi
 fi
 

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -17,8 +17,45 @@ fi
 # Enable only fast linters, and always use the correct config.
 args=("--config=${workspaceFolder}/scripts/golangci.yml" "$@" "--fast" "--allow-parallel-runners")
 
-# trade memory for CPU when running the linters
-export GOGC=20
+# Determine the version of go and golangci-lint to calculate compatibility.
+GO_MINOR_VERSION=$(go version | awk '{print $3}' | sed 's/go//' | cut -d'.' -f1,2)
+GOLANGCILINT_VERSION=$(asdf_devbase_run golangci-lint --version | awk '{print $4}')
+GO_MINOR_VERSION_INT=${GO_MINOR_VERSION//./}
+GOLANGCI_LINT_VERSION_INT=${GOLANGCILINT_VERSION//./}
+
+# Go 1.20 requires >= golangci-lint 1.52.0
+if [[ $GO_MINOR_VERSION_INT == 120 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1520 ]]; then
+  echo "Error: Go 1.20 requires golangci-lint 1.52.0 or newer (detected $GOLANGCILINT_VERSION)" >&2
+  exit 1
+fi
+
+# Go 1.21 requires >= golangci-lint 1.54.1
+if [[ $GO_MINOR_VERSION_INT == 121 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1541 ]]; then
+  echo "Error: Go 1.21 requires golangci-lint 1.54.1 or newer (detected $GOLANGCILINT_VERSION)" >&2
+  exit 1
+fi
+
+# If we're on a system with free, set GOMEMLIMIT to a value that's less
+# than the max amount of RAM on the system. This helps ensure that we
+# don't go over the memory limit and get OOM killed. This is mostly
+# important for CI systems.
+if (command -v free || command -v sysctl) &>/dev/null; then
+  if command -v free &>/dev/null; then
+    mem="$(free -m | awk '/^Mem:/{print $2}')"
+  elif command -v sysctl &>/dev/null; then
+    mem=$((($(sysctl -n hw.memsize) / 1024) / 1024))
+  fi
+
+  if [[ $mem -lt 1024 ]] || [[ -z $mem ]]; then
+    # Failed to determine GOMEMLIMIT somehow. Fallback to GOGC.
+    echo "Warning: Failed to determine system memory or under threshold. " \
+      "Falling back to GOGC" >&2
+    export GOGC=20
+  else
+    # Use mem as the memory target and ensure that we have 1GB of room.
+    export GOMEMLIMIT="$((mem - 1024))MiB"
+  fi
+fi
 
 # Use individual directories for golangci-lint cache as opposed to a mono-directory.
 # This helps with the "too many open files" error.

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -41,26 +41,41 @@ asdf_get_version_from_devbase() {
   grep -E "^$tool_name " "$devbase_dir/.tool-versions" | head -n1 | awk '{print $2}'
 }
 
-# asdf_devbase_exec executes a command with the versions from the devbase
+# asdf_devbase_exec runs asdf_devbase_run but execs the command instead
+# of running it as a subprocess.
+asdf_devbase_exec() {
+  asdf_tool_env_var "$1"
+  exec "$@"
+}
+
+# asdf_devbase_run executes a command with the versions from the devbase
 # .tool-versions file. This will fail if the tool isn't installed, so callers
 # should invoke asdf_devbase_ensure first.
-asdf_devbase_exec() {
+asdf_devbase_run() {
+  asdf_tool_env_var "$1"
+  "$@"
+}
+
+# asdf_tool_env_var exports an environment variable to have the provided
+# tool version be used in asdf. This mutates the current shell's
+# environment variables by exporting the variable.
+#
+# See: https://asdf-vm.com/manage/versions.html#set-current-version
+asdf_tool_env_var() {
   local tool="$1"
   # Why: We're OK with this being the way it is.
   # shellcheck disable=SC2155
-  local tool_env_var="$(echo "$tool" | tr '[:lower:]-' '[:upper:]_')"
+  local tool_env_var="$(tr '[:lower:]-' '[:upper:]_' <<<"$tool")"
 
   # Why: We're OK with this being the way it is.
   # shellcheck disable=SC2155
   local version="$(asdf_get_version_from_devbase "$tool")"
   if [[ -z $version ]]; then
     echo "No version found for $tool in devbase .tool-versions file"
-    exit 1
+    return 1
   fi
 
   export "ASDF_${tool_env_var}_VERSION"="${version}"
-
-  exec "$@"
 }
 
 # asdf_devbase_ensure ensures that all versions of tools are installed from

--- a/shell/linters.sh
+++ b/shell/linters.sh
@@ -62,7 +62,7 @@ for linterScript in "${linters[@]}"; do
 
     # Set by the language file
     if ! linter; then
-      error "Linter failed to run, run 'make fmt' to fix"
+      error "linter failed to run. Please check the logs, 'make fmt' may help in some cases."
       exit 1
     fi
   )


### PR DESCRIPTION
Upgrades golangci-lint to v1.54.1 to support Go 1.21. Adds a small
framework in `golangci-lint.sh` to explode if versions of Go and
golangci-lint are not compatible. Adds checks just for 1.21 and 1.20.
This is important because, most notably for 1.20, it can explode in CI
by consuming all the RAM and not be clear why that is happening.

Changes `GOGC` to no longer be set in favor of using total memory
calculation to pass to `GOMEMLIMIT`. Fallsback to `GOGC` if required.
It's important to note that this doesn't disable GC, just makes it less
important until we get close to total memory (or are otherwise unable to
free any).

Also updated `linter.sh`'s error to not blindly suggest `make fmt`.
Instead, it recommends it based on the output.
