### PR TITLE
fix(orbs/save_cache): support setup_remote_docker

### DIFF
--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -35,6 +35,9 @@ parameters:
     description: If this is set to true all steps in this job will be skipped
     type: boolean
     default: false
+  setup_remote_docker:
+    type: boolean
+    default: false
 
 resource_class: << parameters.resource_class >>
 
@@ -63,6 +66,7 @@ steps:
             command: touch ~/cache-toggle && echo "true" > ~/cache-toggle
         - setup_environment:
             restore_cache: false
+            setup_remote_docker: << parameters.setup_remote_docker >>
         - run:
             name: Run tests
             command: make test


### PR DESCRIPTION
Right now, `test` supports `setup_remote_docker` but `save_cache` does
not. This leads to potential issues with tests that need a remote docker
daemon to be available for their tests (thus failing to run on
`save_cache` but _not_ the `test` job).

This, fixes that, by supporting it in `save_cache` as well.
