### PR TITLE
fix(goreleaser): switch from --rm-dist to --clean

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -93,7 +93,7 @@ release:: pre-release
 	@git tag -d "$(APP_VERSION)" >&2 >/dev/null || true
 	@git tag "$(APP_VERSION)" >&2
 	@GORELEASER_CURRENT_TAG=$(APP_VERSION) ASDF_GORELEASER_VERSION=$(shell cat "$(BOOTSTRAP_DIR)/.tool-versions" | grep goreleaser | awk '{ print $$2 }') \
-		goreleaser release --skip-announce --skip-publish --skip-validate --rm-dist
+		goreleaser release --skip-announce --skip-publish --skip-validate --clean
 	@# Delete the tag once we are done.
 	@git tag -d "$(APP_VERSION)" >&2
 


### PR DESCRIPTION
`--rm-dist` has been deprecated with `--clean` replacing it[1], this PR
adjusts our usage to use `--clean` instead.

[1]: https://goreleaser.com/deprecations/#-rm-dist
