### PR TITLE
fix(lintroller): upgrade to 1.17

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@ jsonnetfmt: 0.19.1
 goimports: 0.5.0
 delve: 1.20.1
 gotestsum: 1.10.1
-lintroller: 1.16.0
+lintroller: 1.17.0
 clerkgenproto: 1.28.1
 goveralls: 0.0.11
 getoutreach/ci: v1.3.0


### PR DESCRIPTION
Upgrades `lintroller` to 1.17 to (hopefully) fix some issues with it on
Go 1.20.
