### PR TITLE
fix(release): always ensure PR metadata is omitted

### DIFF
--- a/shell/ci/release/release.sh
+++ b/shell/ci/release/release.sh
@@ -33,6 +33,14 @@ source "${LIB_DIR}/bootstrap.sh"
 # shellcheck source=../../lib/box.sh
 source "${LIB_DIR}/box.sh"
 
+# Make https://github.com/pvdlg/env-ci/blob/master/services/circleci.js
+# think we're not on a PR.
+unset CIRCLE_PR_NUMBER
+unset CIRCLE_PULL_REQUESTS
+unset CIRCLE_PULL_REQUEST
+unset CI_PULL_REQUEST
+unset CI_PULL_REQUESTS
+
 ORIGINAL_VERSION=$(git describe --match 'v[0-9]*' --tags --always HEAD)
 
 # Unset NPM_TOKEN to force it to use the configured ~/.npmrc


### PR DESCRIPTION
Right now, due to our release process, we need to open PRs to merge
commits back into the correct branches. Because of this, sometimes a
closed PR will refuse to release.

To prevent this from happening, we remove those environment variables.

This fixes the current issue, I'll have a PR to refactor the existing
logic for this out soon.
