### PR TITLE
fix(setup-devenv): missing library import

### DIFF
--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -6,6 +6,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=../../lib/logging.sh
 source "$DIR/../../lib/logging.sh"
+# shellcheck source=../../lib/github.sh
+source "$DIR/../../lib/github.sh"
 
 # Arguments
 PROVISION="${PROVISION:-"false"}"


### PR DESCRIPTION
Previous change forgot to add an import for `github.sh` (which provides
`install_latest_github_release`). This adds it.

Wish that Bash had an easier way to catch this statically...
