### PR TITLE
fix(lib/github): import required dependencies on load

### DIFF
--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # Contains various helper functions for interacting with Github.
-#
-# Requires:
-# - asdf.sh
-# - logging.sh
+
+# LIB_DIR is the directory that shell script libraries live in.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=asdf.sh
+source "$LIB_DIR/asdf.sh"
+# shellcheck source=logging.sh
+source "$LIB_DIR/logging.sh"
 
 # install_latest_github_release downloads the latest version of a tool
 # from Github. Requires the 'gh' cli to be installed.

--- a/shell/lib/github_test.bats
+++ b/shell/lib/github_test.bats
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 
 load github.sh
-load asdf.sh
-load logging.sh
 
 bats_load_library "bats-support/load.bash"
 bats_load_library "bats-assert/load.bash"


### PR DESCRIPTION
While it's not the most performant for us to load dependencies on every
load of the library (since shell functions aren't namespaced), it's more
complicated/problematic to try to make consuming shell scripts aware of
the libary's dependencies. So, we have `lib/github` now import it's own
dependencies.

This could cause some issues with libraries that do initial state
setting (e.g., `asdf`) but most of those libraries should be designed to
only initialize their state once (which `asdf`, the example, does for
this reason)
