### PR TITLE
fix(delibird): missing source/env vars

### DIFF
--- a/shell/ci/testing/delibird.sh
+++ b/shell/ci/testing/delibird.sh
@@ -6,12 +6,16 @@
 # is not already installed.
 set -euo pipefail
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
 # shellcheck source=../../lib/bootstrap.sh
 source "$DIR/../../lib/bootstrap.sh"
 # shellcheck source=../../lib/logging.sh
 source "$DIR/../../lib/logging.sh"
 # shellcheck source=../../lib/github.sh
 source "$DIR/../../lib/github.sh"
+# shellcheck source=../../lib/box.sh
+source "$DIR/../../lib/box.sh"
 
 # DELIBIRD_ENABLED denotes if the delibird log uploader should be
 # enabled or not. If the value is "true", then the delibird log uploader


### PR DESCRIPTION
There were a few missing imports/env vars in the script. This fixes
them.
