### PR TITLE
fix: make devspace glibc error

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -183,7 +183,7 @@ devspace-watch:
 .PHONY: devspace
 devspace:
 	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=0 SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 $(MAGE_CMD) gobuild
-	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" $(MAGE_CMD) e2etestbuild
+	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=0 $(MAGE_CMD) e2etestbuild
 	@echo "Use 'devenv apps run --sync-binaries .' to sync binaries to devspace pod"
 
 ## dev:       run the service

--- a/root/Makefile
+++ b/root/Makefile
@@ -177,12 +177,12 @@ run:: pre-run build
 ## devspace-watch:         watch source files and build them for linux. To be used with devspace using `devenv apps run --sync-binaries .`
 .PHONY: devspace-watch
 devspace-watch:
-	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 $(AIR)
+	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=0 SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 $(AIR)
 
 ## devspace:               build sources for linux with debugging symbols. To be used with devspace using `devenv apps run --sync-binaries .`
 .PHONY: devspace
 devspace:
-	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 $(MAGE_CMD) gobuild
+	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=0 SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 $(MAGE_CMD) gobuild
 	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" $(MAGE_CMD) e2etestbuild
 	@echo "Use 'devenv apps run --sync-binaries .' to sync binaries to devspace pod"
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
- fixes error when glibc version on CircleCI VM (ubuntu latest) does not match with glibc in dev-slim container
- fix is based on disabling [CGO](https://pkg.go.dev/cmd/cgo#:~:text=You%20can%20override%20the%20default,cgo%22%20if%20cgo%20is%20enabled.) which should help with cross-compiling that we do in binary sync (build on macos or ubuntu latest in CircleCI, run in dev-slim container on debian bullseye)
- verified [here](https://app.circleci.com/pipelines/github/getoutreach/devenvtestapp/118/workflows/1ef682dd-04a3-4cd9-aeba-2cc70cb03ea5/jobs/319) that it works


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QF-936]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[QF-936]: https://outreach-io.atlassian.net/browse/QF-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ