### PR TITLE
fix(asdf/node): dont install npm again

### DIFF
--- a/shell/ci/env/asdf.sh
+++ b/shell/ci/env/asdf.sh
@@ -36,7 +36,7 @@ init_asdf() {
   git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.12.0
 
   # langauage specifics
-  echo -e "npm\nyarn" >"$HOME/.default-npm-packages"
+  echo -e "yarn" >"$HOME/.default-npm-packages"
   echo -e "bundler 2.2.17" >"$HOME/.default-gems"
   cat >"$HOME/.default-golang-pkgs" <<EOF
 github.com/golang/protobuf/protoc-gen-go@v$(get_tool_version protoc-gen-go)


### PR DESCRIPTION
Defaults to using the version of `npm` that is present with the
installed version of `node`. This prevents issues where the `npm` latest
version requires a version of node that is not in use, and in turn,
explodes the asdf node default npm packages install step silently.
