### PR TITLE
fix(orb): ensure yarn is installed for test_node_client job

### DIFF
--- a/orbs/shared/commands/with_node_client_cache.yml
+++ b/orbs/shared/commands/with_node_client_cache.yml
@@ -12,9 +12,11 @@ steps:
         - v1-node-client-cache-{{ checksum "cache-version.txt" }}-{{ checksum "api/clients/node/package.json" }}
         - v1-node-client-cache-{{ checksum "cache-version.txt" }}
   - run:
-      name: Ensure Node.js version is installed
+      name: Ensure the correct Node.js version and yarn is installed
       working_directory: api/clients/node
-      command: asdf install
+      command: |
+        asdf install
+        npm install -g yarn
   - run:
       name: Install Node.js Client Dependencies
       working_directory: api/clients/node


### PR DESCRIPTION
## What this PR does / why we need it

We've determined that the correct Node.js version is installed via #650, now we ensure that yarn is installed.