### PR TITLE
fix(orb): revert unnecessary asdf install step

### DIFF
--- a/orbs/shared/commands/with_node_client_cache.yml
+++ b/orbs/shared/commands/with_node_client_cache.yml
@@ -12,10 +12,6 @@ steps:
         - v1-node-client-cache-{{ checksum "cache-version.txt" }}-{{ checksum "api/clients/node/package.json" }}
         - v1-node-client-cache-{{ checksum "cache-version.txt" }}
   - run:
-      name: Ensure Node.js version is installed
-      working_directory: api/clients/node
-      command: asdf install
-  - run:
       name: Install Node.js Client Dependencies
       working_directory: api/clients/node
       command: yarn --frozen-lockfile


### PR DESCRIPTION
## What this PR does / why we need it

Rebuilding the CI cache via the [`rebuild_cache` parameter](https://github.com/getoutreach/devbase/blob/e253dce5053f7d33f8e1a98adc23d4fc1b9aae17/.circleci/config.yml#L8-L11) is sufficient to fix the bug described in #650.