### PR TITLE
fix(lib/github): extract tar file using repoName

### DIFF
--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -78,7 +78,7 @@ install_latest_github_release() {
   gh release -R "$slug" download "$tag" --pattern "$pattern"
 
   echo "" # Fixes issues with output being corrupted in CI
-  tar xf "${binary_name}"**.tar.*
+  tar xf "${repoName}"**.tar.*
 
   # If not writable, use sudo.
   baseArgs=()


### PR DESCRIPTION
Given we're downloading the tar file using the `repoName`, we should be
using that for the tar extraction as well. This changes the tar extract
command to do just that.

No test for this because we don't have any public repositories with
multiple CLIs in them :(
