### PR TITLE
feat: support custom unstable-release post-release steps

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -11,12 +11,12 @@ There is currently no way to ignore files outside of the `.gitignore` file.
 There is currently a bash issue where the exit code is not getting detected when there is multiple commands being ran.
 The easy solution for now is to return the value 1 from the function indicating an error has occurred and terminating the `make test/lint` command that triggered it
 
-## Project specific linters ##
+## Project specific linters
 
-Projects can create additional linters to be run in addition to the built-in 
-linters. 
+Projects can create additional linters to be run in addition to the built-in
+linters.
 
 To add a linter place the linter shell script in `scripts/linters/<lintername>.sh`.
-The linter will be discovered when globbing `.sh` files run with the built-in 
+The linter will be discovered when globbing `.sh` files run with the built-in
 linters. Follow the conventions of the existing linter shell scripts when creating
 the new linter.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,7 +15,7 @@ arguments:
 
 When a PR is created to the default branch (normally `main`), it will be
 tested for an unstable release. By default, if a repo has a
-`.goreleaser.yml` file, binaries will be created an uploaded to the
+`.goreleaser.yml` file, binaries will be created and uploaded to the
 `unstable` tag on the repo once merged.
 
 ### Custom Release Logic
@@ -24,9 +24,9 @@ If a repo does not have a `.goreleaser.yml` file, nothing will happen by
 default.
 
 Optionally, a `scripts/unstable-release.include.sh` file can be created
-that will be ran instead. If a `.goreleaser.yml` file does exist, and
-the include file exists as well, it will be called after the github
-release has been created.
+that will be run instead. If both a `.goreleaser.yml` file and the
+include file exist, it will be called after the GitHub release has
+been created.
 
 A `DRYRUN` environment variable is passed to the include script to
 enable custom dry-run logic like the original release script.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,7 +10,7 @@ arguments:
   releaseOptions:
     enablePrereleases: true
     # It is idiomatic to use 'rc' here.
-    prereleasesBranch: <a-branch-other-than-the-default
+    prereleasesBranch: <a-branch-other-than-the-default>
 ```
 
 When a PR is created to the default branch (normally `main`), it will be

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,32 @@
+# Releasing
+
+## Unstable Releases
+
+Unstable releases are created if the following options are set in a
+`service.yaml`:
+
+```yaml
+arguments:
+  releaseOptions:
+    enablePrereleases: true
+    # It is idiomatic to use 'rc' here.
+    prereleasesBranch: <a-branch-other-than-the-default
+```
+
+When a PR is created to the default branch (normally `main`), it will be
+tested for an unstable release. By default, if a repo has a
+`.goreleaser.yml` file, binaries will be created an uploaded to the
+`unstable` tag on the repo once merged.
+
+### Custom Release Logic
+
+If a repo does not have a `.goreleaser.yml` file, nothing will happen by
+default.
+
+Optionally, a `scripts/unstable-release.include.sh` file can be created
+that will be ran instead. If a `.goreleaser.yml` file does exist, and
+the include file exists as well, it will be called after the github
+release has been created.
+
+A `DRYRUN` environment variable is passed to the include script to
+enable custom dry-run logic like the original release script.

--- a/scripts/unstable-release.include.sh
+++ b/scripts/unstable-release.include.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Publishes an orb whenever an unstable release is created.
+
+if ! command -v circleci &>/dev/null; then
+  echo "Error: circleci CLI not found, please install it." >&2
+  exit 1
+fi
+
+# If we're not logged in, attempt to login in CI or fail locally.
+if ! circleci info org >/dev/null; then
+  if [[ $CIRCLECI != "true" ]]; then
+    echo "Error: CircleCI not setup locally, please ensure the 'circleci'" >&2
+    echo "CLI is installed and that 'circleci setup' has been ran." >&2
+    exit 1
+  fi
+
+  # In CI, use the well-known "$CIRCLECI_API_TOKEN" env var to configure
+  # the CLI to use the correct token.
+  #
+  # Note: This comes from the circleci-credentials context.
+  circleci setup --no-prompt --host "https://circleci.com" --token "$CIRCLECI_API_TOKEN"
+fi
+
+if [[ $DRYRUN == true ]]; then
+  echo "Skipping orb publish due to --dry-run flag"
+  exit 0
+fi
+
+exec make publish-orb

--- a/scripts/update-toc.sh
+++ b/scripts/update-toc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Based off of:
+#
 # Original License:
 #
 # Copyright 2019 The Kubernetes Authors.

--- a/shell/ci/release/release.sh
+++ b/shell/ci/release/release.sh
@@ -59,7 +59,7 @@ fi
 # If we didn't update, assume we're on a prerelease branch
 # and run the unstable-release code.
 if [[ $UPDATED == "false" ]]; then
-  "$DIR/unstable-release.sh"
+  exec "$DIR/unstable-release.sh"
 elif [[ $UPDATED == "true" ]]; then
   # Special logic to publish a node client to github packages while
   # we're dual writing. This will be removed soonish.

--- a/shell/ci/release/unstable-release.sh
+++ b/shell/ci/release/unstable-release.sh
@@ -24,7 +24,7 @@ DRYRUN=false
 # been created. This is primarily meant to be used with creating other
 # artifacts post-release.
 #
-# This is also ran if there is no .gorereleaser.yml file in the
+# This is also run if there is no .gorereleaser.yml file in the
 # repository but all other conditions are satisfied. This allows those
 # repositories to do their own logic for releasing an unstable release.
 INCLUDE_SCRIPT="$(get_repo_directory)/scripts/unstable-release.include.sh"
@@ -92,7 +92,7 @@ echo "Creating unstable release ($app_version)"
 
 make release APP_VERSION="$app_version"
 
-# If we're in a dryrun, skip creating the release.
+# If we're in dry-run mode, skip creating the release.
 if [[ $DRYRUN == "true" ]]; then
   exit 0
 fi

--- a/shell/ci/release/unstable-release.sh
+++ b/shell/ci/release/unstable-release.sh
@@ -1,35 +1,88 @@
 #!/usr/bin/env bash
-# This file contains the logic for releasing
-# unstable code on CLI containing repositories
-# that have also opted to enablePrereleases _and_
-# not release from the default branch (e.g. main).
-set -e
+# This file contains the logic for releasing unstable code on CLI
+# containing repositories that have also opted to enablePrereleases
+# _and_ not release from the default branch (e.g. main).
+set -eo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
+# shellcheck source=./../../lib/yaml.sh
+source "$DIR/../../lib/yaml.sh"
 # shellcheck source=./../../lib/bootstrap.sh
 source "$DIR/../../lib/bootstrap.sh"
 
-dryRun=false
-if [[ $1 == "--dry-run" ]]; then
-  dryRun=true
-fi
+# CIRCLE_BRANCH is the current branch we're on. If we're unable to
+# determine the current branch (e.g., not running in CI) we fallback to
+# attempting to parse the current branch from git.
+CIRCLE_BRANCH="${CIRCLE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 
-# If we don't have a .goreleaser file, skip this.
-# TODO(jaredallard)[DT-2796]: This enables plugins to release from main.
-if [[ ! -e "$(get_repo_directory)/.goreleaser.yml" ]]; then
-  exit 0
+# DRYRUN is a flag that can be passed to this script to prevent it from
+# actually creating a release in Github. Defaults to false and is
+# configurable through the --dry-run CLI flag.
+DRYRUN=false
+
+# INCLUDE_SCRIPT is a script that is called after a Github release has
+# been created. This is primarily meant to be used with creating other
+# artifacts post-release.
+#
+# This is also ran if there is no .gorereleaser.yml file in the
+# repository but all other conditions are satisfied. This allows those
+# repositories to do their own logic for releasing an unstable release.
+INCLUDE_SCRIPT="$(get_repo_directory)/scripts/unstable-release.include.sh"
+
+# run_unstable_include runs the INCLUDE_SCRIPT if it exists.
+run_unstable_include() {
+  if [[ ! -e $INCLUDE_SCRIPT ]]; then
+    return 0
+  fi
+
+  # Allow users to add custom steps at the end of an unstable release
+  # being created (e.g., publish artifacts).
+  echo "Calling $(basename "$INCLUDE_SCRIPT")"
+  exec DRYRUN=$DRYRUN "$INCLUDE_SCRIPT"
+}
+
+# Set the DRYRUN flag if --dry-run is passed.
+if [[ $1 == "--dry-run" ]]; then
+  DRYRUN=true
 fi
 
 # If we don't have pre-releasing enabled, skip this.
-if [[ "$(yq -r ".arguments.releaseOptions.enablePrereleases" 2>/dev/null <"$(get_service_yaml)")" != "true" ]]; then
+if [[ "$(yaml_get_field ".arguments.releaseOptions.enablePrereleases" "$(get_service_yaml)")" != "true" ]]; then
+  echo "releaseOptions.enablePrereleases is not true, skipping unstable release"
   exit 0
 fi
 
 # If our prereleasesBranch is empty, or equal to the default branch
-# skip this.
-prereleasesBranch="$(yq -r '.arguments.releaseOptions.prereleasesBranch' <"$(get_service_yaml)")"
+# skip this. This is to enable prereleases to be created from the `main`
+# branch thereby skipping the 'unstable' release process entirely.
+prereleasesBranch="$(yaml_get_field '.arguments.releaseOptions.prereleasesBranch' "$(get_service_yaml)")"
 defaultBranch="$(git rev-parse --abbrev-ref origin/HEAD | sed 's/^origin\///')"
 if [[ -z $prereleasesBranch ]] || [[ $prereleasesBranch == "$defaultBranch" ]]; then
+  echo "releaseOptions.prereleasesBranch is empty or equal to the default branch, skipping unstable release"
+  exit 0
+fi
+
+# If we're not on the default branch, skip. This is to prevent
+# accidentally releasing from a branch that isn't mean to create
+# unstable releases that happened to fail releasing for whatever reason.
+#
+# Special case, skip this check if we're doing a dry-run since we will
+# short circuit before we actually create a release.
+if [[ $CIRCLE_BRANCH != "$defaultBranch" ]] && [[ $DRYRUN == "false" ]]; then
+  echo "\$CIRCLE_BRANCH ($CIRCLE_BRANCH) != \$defaultBranch ($defaultBranch), skipping unstable release"
+  exit 0
+fi
+
+# If there's no .goreleaser.yml file, skip the unstable release process.
+# Otherwise, the 'make release' step would fail.
+#
+# IDEA(jaredallard): We should support a more customizable release
+# process for things that don't use goreleaser.
+if [[ ! -e "$(get_repo_directory)/.goreleaser.yml" ]]; then
+  echo "No .goreleaser.yml, skipping creating unstable release"
+
+  # Run the unstable include script if it exists.
+  run_unstable_include
   exit 0
 fi
 
@@ -38,7 +91,8 @@ echo "Creating unstable release ($app_version)"
 
 make release APP_VERSION="$app_version"
 
-if [[ $dryRun == "true" ]]; then
+# If we're in a dryrun, skip creating the release.
+if [[ $DRYRUN == "true" ]]; then
   exit 0
 fi
 
@@ -49,3 +103,5 @@ git push --delete origin unstable || true
 
 # create unstable release and upload assets to it
 gh release create unstable --prerelease --generate-notes ./dist/*.tar.gz ./dist/checksums.txt
+
+run_unstable_include

--- a/shell/ci/release/unstable-release.sh
+++ b/shell/ci/release/unstable-release.sh
@@ -38,7 +38,8 @@ run_unstable_include() {
   # Allow users to add custom steps at the end of an unstable release
   # being created (e.g., publish artifacts).
   echo "Calling $(basename "$INCLUDE_SCRIPT")"
-  exec DRYRUN=$DRYRUN "$INCLUDE_SCRIPT"
+  export DRYRUN
+  exec "$INCLUDE_SCRIPT"
 }
 
 # Set the DRYRUN flag if --dry-run is passed.


### PR DESCRIPTION
Adds support for a shell script to be ran post-gh release creation of an
unstable release. Adds more comments/restructures some of the
unstable-release code to use the `yaml` library and be easier to read.
If `.goreleaser.yml` does not exist, the include script is still able to
be called to enable custom releasing functionality in that case.

Added a `unstable-release.include.sh` script for `devbase` to enable
publishing an orb on every unstable release of devbase.

Added documentation for unstable releases and the new include script
functionality.
