### PR TITLE
feat: add configurable grpcOptions

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,1 +1,10 @@
 name: github.com/getoutreach/devbase
+arguments:
+  disableDocGeneration:
+    description: "Disables protobuf documentation generation."
+    schema:
+      type: boolean
+  latestGoProtobufModules:
+    description: "Use non-deprecated protobuf modules for Go"
+    schema:
+      type: boolean

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Generates code from proto files for Go, gRPC, and other languages if
-# configured (currently limited to Ruby and Javascript).
+# configured (currently limited to Ruby and JavaScript/TypeScript).
 set -euo pipefail
 
 # Generates proto types and clients from proto filess
@@ -31,7 +31,7 @@ PROTO_DOCS_DIR="$(get_repo_directory)/apidocs/proto"
 PROTOC_IMPORTS_BASE_PATH="$HOME/.outreach/.protoc-imports"
 mkdir -p "$PROTOC_IMPORTS_BASE_PATH"
 
-# get_package_prefix returns the directory that a specific node package
+# get_package_prefix returns the directory that a specific Node.js package
 # lives in based on the name and version.
 get_package_prefix() {
   local package_name="$1"

--- a/versions.yaml
+++ b/versions.yaml
@@ -18,12 +18,9 @@ node-grpc-tools: 1.11.2
 ruby-grpc-tools: 1.46.3
 node-ts-grpc-tools: 5.3.2
 
-# Whenever we go to the non-deprecated version of golang protobuf generation
-# these should be uncommented as well as all of the commented out code in
-# shell/protoc.sh regarding golang prototbuf generation.
-# ---
-# protoc-gen-go: 1.28.0
-# protoc-gen-go-grpc: 1.46.0
+# latest Go protobuf modules
+protoc-gen-go-latest: 1.31.0
+protoc-gen-go-grpc: cmd/protoc-gen-go-grpc/v1.3.0
 
 # confluence publishing tools
 getoutreach/markdowntools/visualizemd: v0.0.33


### PR DESCRIPTION
Adds two new `service.yaml` driven `grpcOptions` fields:

 * `disableDocGeneration` - Disables protobuf documentation generation.
 * `latestGoProtobufModules` - Uses the latest Go protobuf modules.

Ideally each of these will become the default option later on, but for
now these must be manually enabled.
