### PR TITLE
fix: support @getoutreach npm packages

### DIFF
--- a/shell/ci/auth/github_packages.sh
+++ b/shell/ci/auth/github_packages.sh
@@ -55,5 +55,6 @@ if command -v npm >/dev/null 2>&1; then
   cat >>"$HOME/.npmrc" <<EOF
 
 //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
+@getoutreach:registry=https://npm.pkg.github.com
 EOF
 fi

--- a/shell/ci/auth/github_packages.sh
+++ b/shell/ci/auth/github_packages.sh
@@ -55,6 +55,6 @@ if command -v npm >/dev/null 2>&1; then
   cat >>"$HOME/.npmrc" <<EOF
 
 //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
-@getoutreach:registry=https://npm.pkg.github.com
+@$ORG:registry=https://npm.pkg.github.com
 EOF
 fi

--- a/shell/ci/auth/packagecloud.sh
+++ b/shell/ci/auth/packagecloud.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Sets up authentication for pushing up a RubyGem
-# DEPRECATED: This is no longer supported and will be replaced
-# by Github Packages very soon.
-if [[ -z $PACKAGECLOUD_TOKEN ]]; then
-  echo "Skipped: PACKAGECLOUD_TOKEN is not set"
-fi

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -17,7 +17,6 @@ authn=(
   "vault"
   "aws"
   "github"
-  "packagecloud"
   "github_packages"
 )
 


### PR DESCRIPTION
Updates `@getoutreach` scope to always use Github Packages. This is set
globally as our templates rely on Outreach packages. Users that wish to
have their own custom scopes should use a per-repo `.npmrc` instead.

Removes `packagecloud` since it hasn't been supported for a long time
(it also doesn't do anything).

[DT-4053]

[DT-4053]: https://outreach-io.atlassian.net/browse/DT-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ