### PR TITLE
fix: Broken golangci-lint version detection

### DIFF
--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -22,6 +22,7 @@ GO_MINOR_VERSION=$(go version | awk '{print $3}' | sed 's/go//' | cut -d'.' -f1,
 GOLANGCILINT_VERSION=$(asdf_devbase_run golangci-lint --version | awk '{print $4}')
 GO_MINOR_VERSION_INT=${GO_MINOR_VERSION//./}
 GOLANGCI_LINT_VERSION_INT=${GOLANGCILINT_VERSION//./}
+GOLANGCI_LINT_VERSION_INT=${GOLANGCI_LINT_VERSION_INT//v/}
 
 # Check version compatibility for golangci-lint/go 1.X.
 if [[ ${GO_MINOR_VERSION_INT:0:1} -lt 2 ]] && [[ ${GOLANGCI_LINT_VERSION_INT:0:1} -lt 2 ]]; then


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This change fixes how the the `golangci-lint` tool version is detected,
where a `v` prefix (e.g. `v1.XX.YY`) is not removed, causing incorrect
comparisons. The basic error is reproducible via the following short
script:

```bash
GO_MINOR_VERSION="1.20";
GOLANGCILINT_VERSION="v1.54.2";

GO_MINOR_VERSION_INT=${GO_MINOR_VERSION//./};
GOLANGCI_LINT_VERSION_INT=${GOLANGCILINT_VERSION//./};
if [[ $GO_MINOR_VERSION_INT == 120 ]] && [[ $GOLANGCI_LINT_VERSION_INT -lt 1520 ]]; then
    echo "The mistaken assumption: $GOLANGCI_LINT_VERSION_INT -lt 1520";
fi
```

To fix, this introduces a second string manipulation where the character
`v` is removed from the `GOLANGCI_LINT_VERSION_INT`.




<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

There is no JIRA for this, just fixing a bug as I found it.

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
