### PR TITLE
fix: disable dual publishing of gRPC clients

### DIFF
--- a/shell/ci/release/release.sh
+++ b/shell/ci/release/release.sh
@@ -60,23 +60,4 @@ fi
 # and run the unstable-release code.
 if [[ $UPDATED == "false" ]]; then
   exec "$DIR/unstable-release.sh"
-elif [[ $UPDATED == "true" ]]; then
-  # Special logic to publish a Node.js client to GitHub packages while
-  # we're dual writing. This will be removed soonish.
-  if [[ -e $nodeClientDir && "$(is_service)" == "true" ]] && has_grpc_client "node"; then
-    info "Publishing Node.js client to GitHub Packages"
-
-    info_sub "pointing package.json to GitHub Packages"
-    pjson="$nodeClientDir/package.json"
-    originalName="$(jq -r '.name' "$pjson")"
-    newName="${originalName//@outreach/@getoutreach}"
-
-    newpjson="$(jq ". + {\"name\":\"$newName\",\"publishConfig\":{\"registry\":\"https://npm.pkg.github.com/\"}}" "$pjson")"
-    echo "$newpjson" >"$pjson"
-
-    pushd "$nodeClientDir" >/dev/null || exit 1
-    info_sub "pushing to GitHub packages"
-    npm publish || send_failure_notification
-    popd >/dev/null || exit 1
-  fi
 fi


### PR DESCRIPTION
Disables dual publishing for the gRPC client to both npm and Github
Packages. This, instead, only publishes to whatever the configured
registry is for that scope.

For Outreach, this results in Github Packages only (for the scope of
`@getoutreach`)

[DT-4053]
