### PR TITLE
fix: re-run stencil and update deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.19.2
-  queue: eddiewebb/queue@1.8.4
+  shared: getoutreach/shared@2.21.0
+  queue: eddiewebb/queue@2.2.1
 
 parameters:
   rebuild_cache:
@@ -13,7 +13,6 @@ parameters:
 # Extra contexts to expose to all jobs below
 contexts: &contexts
   - aws-credentials
-  - prismacloud-credentials
   - vault-dev
   - confluence
   - circleci-credentials

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ insert_final_newline = true
 [*.go,Makefile]
 indent_style = tab
 
-[*.{bash,rb,sh,slim,yml,yaml,bats}]
+[*.{bash,rb,sh,slim,yml,yaml}]
 indent_style = space
 indent_size  = 2
 
@@ -19,6 +19,11 @@ indent_style = tab
 indent_size  = 2
 
 [*.{bash,rb,sh,slim,yml,yaml}.tpl]
+indent_style = space
+indent_size  = 2
+
+# Bats tests
+[*.bats]
 indent_style = space
 indent_size  = 2
 ## <</Stencil::Block>>

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # See https://help.github.com/articles/about-codeowners/
-* @getoutreach/fnd-dt @getoutreach/qf
+* @getoutreach/fnd-dt
 
 ## <<Stencil::Block(customCodeowners)>>
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
+      - dependency-name: github.com/getoutreach/stencil-golang/pkg
 
   # Ignore semantic-release, this code is only executed in CI.
   - package-ecosystem: "npm"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,15 @@
 <!--
   !!!! README !!!! Please fill this out.
 
-  Please follow the PR naming conventions: 
-  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
+  Please follow conventional commit naming conventions:
+
+  https://www.conventionalcommits.org/en/v1.0.0/#summary
 -->
 
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!
 
 <!-- A short description of what your PR does and what it solves. -->
 ## What this PR does / why we need it
-
 
 
 <!-- <<Stencil::Block(jiraPrefix)>> -->
@@ -21,8 +22,6 @@
 
 <!-- Notes that may be helpful for anyone reviewing this PR -->
 ## Notes for your reviewers
-
-
 
 <!-- <<Stencil::Block(custom)>> -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ Pulumi.*.yaml
 # Documentation output
 /apidocs
 
+# Terraform lock files
+.terraform.lock.hcl
+
 ### Start ignores inserted by other modules
 ### End ignores inserted by other modules
 

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -20,7 +20,7 @@ plugins:
   # Build the orb
   - - "@semantic-release/exec"
     - prepareCmd: make
-  - - "@outreach/semantic-release-circleci-orb"
+  - - "@getoutreach/semantic-release-circleci-orb"
     - orbName: "getoutreach/shared"
       orbPath: "orb.yml"
   ## <</Stencil::Block>>

--- a/.tool-versions
+++ b/.tool-versions
@@ -18,4 +18,5 @@ golangci-lint 1.54.1
 shellcheck 0.9.0
 shfmt 3.7.0
 goreleaser 1.20.0
+terraform 1.4.4
 ## <</Stencil::Block>>

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,10 +4,9 @@
 # you are reducing compatibility guarantees.
 ## <<Stencil::Block(toolverOverride)>>
 ## <</Stencil::Block>>
-terraform 1.4.4
+nodejs 18.17.1
 protoc 21.5
-nodejs 18.14.1
-golang 1.20.7
+golang 1.20.8
 # Note: Versions in this block do not override the default versions above
 # but sometimes you have to declare additional versions of the same tool
 # while leaving the 'default' version intact for the infra.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,16 +36,16 @@
           "to": "/home/dev/app"
         },
         // Maps the go module cache on the host to the persistent volume used by devspaces.
-        // See the value of `go env GOMODCACHE` on the host and devspace.
+        // These should be the respective values of `go env GOMODCACHE`.
         {
-          "from": "${env:HOME}/.asdf/installs/golang/1.20.7/packages/pkg/mod",
-          "to": "/tmp/cache/go/mod/"
+          "from": "${env:HOME}/.asdf/installs/golang/1.20.8/packages/pkg/mod",
+          "to": "/home/dev/.asdf/installs/golang/1.20.8/packages/pkg/mod"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.
           // This enables debugging standard library code.
-          "from": "${env:HOME}/.asdf/installs/golang/1.20.7/go/src",
-          "to": "/home/dev/.asdf/installs/golang/1.20.7/go/src"
+          "from": "${env:HOME}/.asdf/installs/golang/1.20.8/go/src",
+          "to": "/home/dev/.asdf/installs/golang/1.20.8/go/src"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "UNLICENSED",
   "devDependencies": {
-    "@outreach/semantic-release-circleci-orb": "^1.1.9",
+    "@getoutreach/semantic-release-circleci-orb": "^1.1.9",
     "@semantic-release/commit-analyzer": "^10.0.1",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,14 +1,14 @@
-version: v1.36.0
+version: v1.37.0
 modules:
     - name: github.com/getoutreach/devbase
       url: file://./
       version: local
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
-      version: v0.12.0
+      version: v0.14.0
     - name: github.com/getoutreach/stencil-circleci
       url: https://github.com/getoutreach/stencil-circleci
-      version: v1.10.0
+      version: v1.11.1
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
       version: unstable
@@ -58,18 +58,12 @@ files:
     - name: .vscode/settings.json
       template: .vscode/settings.json.tpl
       module: github.com/getoutreach/stencil-golang
-    - name: CONTRIBUTING.md
-      template: CONTRIBUTING.md.tpl
-      module: github.com/getoutreach/stencil-base
     - name: LICENSE
       template: LICENSE.tpl
       module: github.com/getoutreach/stencil-base
     - name: Makefile
       template: Makefile.tpl
       module: github.com/getoutreach/stencil-golang
-    - name: README.md
-      template: README.md.tpl
-      module: github.com/getoutreach/stencil-base
     - name: devenv.yaml
       template: devenv.yaml.tpl
       module: github.com/getoutreach/stencil-golang

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,15 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@getoutreach/semantic-release-circleci-orb@^1.1.9":
+  version "1.1.9"
+  resolved "https://npm.pkg.github.com/download/@getoutreach/semantic-release-circleci-orb/1.1.9/7049c6130416c39b0cefa9d1be0c06ce0caeb3bd#7049c6130416c39b0cefa9d1be0c06ce0caeb3bd"
+  integrity sha512-bS9yALtUshWP4rZ+zcxIOsIuvtZINmKcz44i0UXjIvqnXSH2b7I2ZccFH28iMuKbwkaUimNv6R3Y0YivNcyexQ==
+  dependencies:
+    "@semantic-release/error" "^3.0.0"
+    aggregate-error "^3.1.0"
+    execa "^5.1.0"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -391,15 +400,6 @@
   integrity sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
-
-"@outreach/semantic-release-circleci-orb@^1.1.9":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@outreach/semantic-release-circleci-orb/-/semantic-release-circleci-orb-1.1.9.tgz#187f9d71599f7e3f6b88cefa3b180d788e9be6cd"
-  integrity sha512-j3eFWSXa9kD3GIoDEpIlovCajxvUugt4mBROcB+a5X8kPMBFuDEqlNTNVA98AuvCtWsdzg7KokvGIVWJDTjHXQ==
-  dependencies:
-    "@semantic-release/error" "^3.0.0"
-    aggregate-error "^3.1.0"
-    execa "^5.1.0"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
Re-runs stencil and updates the npm dependencies. This is to test if the
newer semantic-release versions work so we can upgrade them globally.

Also moves to use the `@getoutreach`-scoped
semantic-release-circleci-orb package.
