### PR TITLE
fix(orb): use pre_setup_script in save_cache job

### DIFF
--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -46,6 +46,8 @@ executor:
   docker_image: << parameters.docker_image >>
   docker_tag: << parameters.docker_tag >>
 
+environment:
+  PRE_SETUP_SCRIPT: << parameters.pre_setup_script >>
 steps:
   - when:
       condition:


### PR DESCRIPTION
## What this PR does / why we need it

Despite having the job parameter for it, it wasn't actually being used by the job.