### PR TITLE
feat: Tweak cache

### DIFF
--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -174,7 +174,7 @@ build_and_push_image() {
   (
     if [[ $OSTYPE == "linux-gnu"* ]]; then
       docker buildx --builder devbase build "${args[@]}"
-      docker buildx prune --force
+      docker buildx prune --force --keep-storage 6GB
     else
       docker buildx build "${args[@]}"
     fi

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -174,7 +174,7 @@ build_and_push_image() {
   (
     if [[ $OSTYPE == "linux-gnu"* ]]; then
       docker buildx --builder devbase build "${args[@]}"
-      docker buildx prune
+      docker buildx prune --force
     else
       docker buildx build "${args[@]}"
     fi

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -176,6 +176,7 @@ build_and_push_image() {
       docker buildx --builder devbase build "${args[@]}"
     else
       docker buildx build "${args[@]}"
+      docker buildx prune
     fi
   )
 }

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -174,9 +174,9 @@ build_and_push_image() {
   (
     if [[ $OSTYPE == "linux-gnu"* ]]; then
       docker buildx --builder devbase build "${args[@]}"
+      docker buildx prune
     else
       docker buildx build "${args[@]}"
-      docker buildx prune
     fi
   )
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Docker cache keeps increasing with each build and will reset itself once it hits 15G in circleci, this will prune cache after each build and will keep usage under 6GB. 

Another solution could be to switch to different provider, rather then DLC in circleci. For example https://docs.docker.com/build/cache/backends/s3/

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
