### PR TITLE
fix(orbs/shared): update machine executor image

### DIFF
--- a/orbs/shared/executors/testbed-machine.yml
+++ b/orbs/shared/executors/testbed-machine.yml
@@ -1,6 +1,6 @@
 description: Standard executor for machine runtimes
 machine:
-  image: ubuntu-2204:2023.04.2
+  image: ubuntu-2204:2023.10.1
   docker_layer_caching: true
 environment:
   TEST_RESULTS: /tmp/test-results


### PR DESCRIPTION
Updates to the newest snapshot of the `ubuntu22.04` image.
