### PR TITLE
fix: ensure asdf utilities are run with bash 5 or greater

### DIFF
--- a/shell/ci/testing/delibird.sh
+++ b/shell/ci/testing/delibird.sh
@@ -7,15 +7,18 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="$DIR/../../lib"
+
+echo "LIB DIR: $LIB_DIR"
 
 # shellcheck source=../../lib/bootstrap.sh
-source "$DIR/../../lib/bootstrap.sh"
+source "$LIB_DIR/bootstrap.sh"
 # shellcheck source=../../lib/logging.sh
-source "$DIR/../../lib/logging.sh"
+source "$LIB_DIR/logging.sh"
 # shellcheck source=../../lib/github.sh
-source "$DIR/../../lib/github.sh"
+source "$LIB_DIR/github.sh"
 # shellcheck source=../../lib/box.sh
-source "$DIR/../../lib/box.sh"
+source "$LIB_DIR/box.sh"
 
 # DELIBIRD_ENABLED denotes if the delibird log uploader should be
 # enabled or not. If the value is "true", then the delibird log uploader

--- a/shell/ci/testing/delibird.sh
+++ b/shell/ci/testing/delibird.sh
@@ -9,8 +9,6 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 LIB_DIR="$DIR/../../lib"
 
-echo "LIB DIR: $LIB_DIR"
-
 # shellcheck source=../../lib/bootstrap.sh
 source "$LIB_DIR/bootstrap.sh"
 # shellcheck source=../../lib/logging.sh

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 # Utilities for working with asdf
 
+if ((BASH_VERSINFO[0] < 5)); then
+  echo "Requires Bash 5 or greater" >&2
+  case "$(uname -s)" in # kernel name
+  "Darwin")
+    echo "Install the latest version of bash (brew install bash) and open a new terminal to try again" >&2
+    ;;
+  "Linux")
+    echo "Upgrade to the latest version of your Linux distro" >&2
+    ;;
+  *)
+    echo "Unsupported OS"
+    ;;
+  esac
+  exit 1
+fi
+
 # asdf_plugins_list stores a list of all asdf plugins
 # this is done to speed up the plugin install
 asdf_plugins_list=""

--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -1,21 +1,12 @@
 #!/usr/bin/env bash
 # Utilities for working with asdf
 
-if ((BASH_VERSINFO[0] < 5)); then
-  echo "Requires Bash 5 or greater" >&2
-  case "$(uname -s)" in # kernel name
-  "Darwin")
-    echo "Install the latest version of bash (brew install bash) and open a new terminal to try again" >&2
-    ;;
-  "Linux")
-    echo "Upgrade to the latest version of your Linux distro" >&2
-    ;;
-  *)
-    echo "Unsupported OS"
-    ;;
-  esac
-  exit 1
-fi
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=./shell.sh
+source "${DIR}/shell.sh"
+
+ensure_bash_5_or_greater
 
 # asdf_plugins_list stores a list of all asdf plugins
 # this is done to speed up the plugin install

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -3,6 +3,26 @@
 
 DEVBASE_CACHED_BINARY_STORAGE_PATH="$HOME/.outreach/.cache/devbase"
 
+# Exits with code 1 if the running shell is not bash or
+# the version is < 5.
+ensure_bash_5_or_greater() {
+  if ((BASH_VERSINFO[0] < 5)); then
+    echo "Requires Bash 5 or greater" >&2
+    case "$(uname -s)" in # kernel name
+    "Darwin")
+      echo "Install the latest version of bash (brew install bash) and open a new terminal to try again" >&2
+      ;;
+    "Linux")
+      echo "Upgrade to the latest version of your Linux distro" >&2
+      ;;
+    *)
+      echo "Unsupported OS"
+      ;;
+    esac
+    exit 1
+  fi
+}
+
 # retry calls a given command (must be wrapped in quotes)
 # syntax: retry <interval> <maxRetries> <command> [args...]
 retry() {


### PR DESCRIPTION
## What this PR does / why we need it

the `asdf` utilities file uses `readarray`, which is not implemented in the version of bash that comes with macOS (which is 3.2). So, check the bash version array's major version at the beginning of the file.

Tested on macOS (thanks @jaredallard) and Linux with both Bash 3.2 and Bash 5.x.

## Jira ID

[DT-4123]

[DT-4123]: https://outreach-io.atlassian.net/browse/DT-4123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ