### PR TITLE
fix(asdf): use LIB_DIR instead of DIR to avoid clashing

### DIFF
--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Utilities for working with asdf
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# LIB_DIR is the directory that shell script libraries live in.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=./shell.sh
-source "${DIR}/shell.sh"
+source "${LIB_DIR}/shell.sh"
 
 ensure_bash_5_or_greater
 


### PR DESCRIPTION
`DIR` is a common pattern used in devbase to determine the current
running directory. Unfortunately, some of our libraries have _also_
started to use it. This ends up in secenarios where `DIR` can be
overwritten by an imported script. To avoid this, we've used `LIB_DIR`
inside the libraries to prevent clashes from causing an issue.

In reality, we shouldn't be using Bash which would help... for now this
fixes it by changing the newly added `DIR` to be `LIB_DIR`.
