### PR TITLE
fix(makefile): adjust shell quoting for cgo-enabled script

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -28,7 +28,7 @@ TAGS                :=
 BINDIR              := $(CURDIR)/bin
 BIN_NAME            := $(APP)
 PKGDIR              := github.com/$(ORG)/$(APP)
-CGO_ENABLED         ?= $(shell "$(CURDIR)/scripts/shell-wrapper.sh cgo-enabled.sh")
+CGO_ENABLED         ?= $(shell "$(CURDIR)/scripts/shell-wrapper.sh" cgo-enabled.sh)
 TOOL_DEPS           := ${GO}
 
 # formatters / misc


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.