### PR TITLE
fix(box): abort early if the box repo can't be cloned correctly

### DIFF
--- a/shell/lib/box.sh
+++ b/shell/lib/box.sh
@@ -42,7 +42,7 @@ download_box() {
   local newBox=$(yq . "${BOXPATH}" |
     jq --slurpfile boxconf \
       <(yq -r . "${tempDir}/box.yaml") '. * {config: $boxconf[0] }' |
-    yq . --yaml-output)
+    yq --yaml-output .)
   echo "${newBox}" >"${BOXPATH}"
 }
 

--- a/shell/lib/box.sh
+++ b/shell/lib/box.sh
@@ -31,6 +31,11 @@ download_box() {
 
   git clone -q "${boxGitRepo}" "${tempDir}" --depth 1
 
+  if [[ ! -f "${tempDir}/box.yaml" ]]; then
+    echo "Cloning failed, cannot find box.yaml" >&2
+    return 1
+  fi
+
   # Stub for the below yq command if it doesn't exist
   mkdir -p "$(dirname "$BOXPATH")"
   if [[ ! -e $BOXPATH ]]; then

--- a/shell/lib/box.sh
+++ b/shell/lib/box.sh
@@ -27,7 +27,7 @@ download_box() {
   # Why: OK with assigning without checking exit code.
   # shellcheck disable=SC2155
   local tempDir="$(mktemp -d)"
-  trap 'rm -rf "${TMPDIR}"' EXIT
+  trap 'rm -rf "${tempDir}"' EXIT
 
   git clone -q "${boxGitRepo}" "${tempDir}" --depth 1
 

--- a/shell/lib/box_test.bats
+++ b/shell/lib/box_test.bats
@@ -51,3 +51,11 @@ teardown() {
   run get_box_yaml
   assert_output "$(cat "$BOXPATH")"
 }
+
+@test "get_box_yaml should fail if cloning the box repo fails" {
+  BOX_REPOSITORY_URL="https://github.com/getoutreach/notaboxrepo"
+
+  BOXPATH=/foo/bar/nonexistent run get_box_yaml
+  assert_failure
+  assert_line "Cloning failed, cannot find box.yaml"
+}

--- a/shell/lib/box_test.bats
+++ b/shell/lib/box_test.bats
@@ -53,9 +53,9 @@ teardown() {
 }
 
 @test "get_box_yaml should fail if cloning the box repo fails" {
-  BOX_REPOSITORY_URL="https://github.com/getoutreach/notaboxrepo"
-
-  BOXPATH=/foo/bar/nonexistent run get_box_yaml
+  BOX_REPOSITORY_URL="https://github.com/getoutreach/notaboxrepo" \
+    BOXPATH=/foo/bar/nonexistent \
+    run get_box_yaml
   assert_failure
   assert_line "Cloning failed, cannot find box.yaml"
 }


### PR DESCRIPTION
## What this PR does / why we need it

In addition to what it says on the tin, the PR fixes the following:

* Delete the generated temporary directory instead of the entire system `TMPDIR` on `EXIT` signal captured
* Put `yq` flag in the correct position

## Jira ID

[DT-4111]

[DT-4111]: https://outreach-io.atlassian.net/browse/DT-4111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ