### PR TITLE
fix: use CGO_ENABLED for make gobuild

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -161,7 +161,7 @@ gogenerate:: pre-gogenerate
 ## gobuild:         build application binary
 .PHONY: gobuild
 gobuild:
-	@$(MAGE_CMD) gobuild
+	@CGO_ENABLED=$(CGO_ENABLED) $(MAGE_CMD) gobuild
 
 ## grpcui:          run grpcui for an already locally running service
 .PHONY: grpcui


### PR DESCRIPTION
## What this PR does / why we need it

This is for consistency with the other commands which utilize `CGO_ENABLED`.