### PR TITLE
feat: make go test timeout configurable in test job

### DIFF
--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -42,6 +42,10 @@ parameters:
   setup_remote_docker:
     type: boolean
     default: false
+  go_test_timeout:
+    description: Maps to gotest -timeout parameter.
+    type: string
+    default: ""
 
 resource_class: << parameters.resource_class >>
 
@@ -53,6 +57,7 @@ executor:
 environment:
   AWS_REGION: << parameters.aws_region >>
   PRE_SETUP_SCRIPT: << parameters.pre_setup_script >>
+  GO_TEST_TIMEOUT: << parameters.go_test_timeout >>
 steps:
   - when:
       condition:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Unfortunately, I have a test that takes longer than 10 minutes and this isn't currently configurable.

The test.sh looks for this env var and sets the timeout flag:
https://github.com/getoutreach/devbase/blob/be1b62d86f8295ea542f9adecdf7ace7990cf5bc/shell/test.sh#L103-L106

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
