### PR TITLE
feat: Add gcflags to devspace for Go services

### DIFF
--- a/root/Magefile.go
+++ b/root/Magefile.go
@@ -115,6 +115,9 @@ func Gobuild(ctx context.Context) error {
 	}
 
 	args := []string{"build", "-v", "-o", binDir, "-ldflags", ldFlags}
+	if gcFlags := os.Getenv("GC_FLAGS"); gcFlags != "" {
+		args = append(args, "-gcflags", gcFlags)
+	}
 
 	// SKIP_TRIMPATH is used for devspace binary sync, where you want to have same file paths for delve to work correctly
 	if os.Getenv("SKIP_TRIMPATH") == "true" {

--- a/root/Makefile
+++ b/root/Makefile
@@ -182,7 +182,7 @@ devspace-watch:
 ## devspace:               build sources for linux with debugging symbols. To be used with devspace using `devenv apps run --sync-binaries .`
 .PHONY: devspace
 devspace:
-	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=$(CGO_ENABLED) SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 $(MAGE_CMD) gobuild
+	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=$(CGO_ENABLED) SKIP_TRIMPATH="true" SKIP_STARTING_APP="true" DLV_PORT=42097 GC_FLAGS="all=-N -l" $(MAGE_CMD) gobuild
 	@DEVBOX_LOGFMT="$(LOGFMT)" BUILD_FOR_GOOS="linux" CGO_ENABLED=$(CGO_ENABLED) $(MAGE_CMD) e2etestbuild
 	@echo "Use 'devenv apps run --sync-binaries .' to sync binaries to devspace pod"
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

When we build the binary with `make devspace`, the debug information is not there and we cannot see the variable value in VSCode debugger. The PR is to address it.

Before the change:
![Screenshot 2024-01-11 at 6 46 17 PM](https://github.com/getoutreach/devbase/assets/81997079/119b52bd-ba70-431c-a660-4265f48c43a4)

After the change:
![Screenshot 2024-01-11 at 6 48 41 PM](https://github.com/getoutreach/devbase/assets/81997079/a578a872-06c6-481b-b3e1-2c952ecc7045)


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
