### PR TITLE
fix: use new apt source for kubectl

### DIFF
--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -35,8 +35,9 @@ if [[ -n $CI ]]; then
     info "Installing kubectl"
     tmpFile=$(mktemp)
     keyringLocation=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+    k8sAptSourceLocation="https://pkgs.k8s.io/core:/stable:/v1.29/deb/"
 
-    curl -fsSLo "$tmpFile" https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key
+    curl -fsSLo "$tmpFile" "${k8sAptSourceLocation}Release.key"
 
     # 2023-05-23: GCP changed their key to be armored and changed the key location. Currently
     # the file extension is incorrect. So, we handle if it is armored or not in case
@@ -50,7 +51,7 @@ if [[ -n $CI ]]; then
       # Otherwise, just copy the file
       sudo cp "$tmpFile" "$keyringLocation"
     fi
-    echo "deb [signed-by=$keyringLocation] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+    echo "deb [signed-by=$keyringLocation] ${k8sAptSourceLocation} /" | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
     sudo apt-get update -y
     sudo apt-get install -y kubectl
   fi

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -36,7 +36,7 @@ if [[ -n $CI ]]; then
     tmpFile=$(mktemp)
     keyringLocation=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
-    curl -fsSLo "$tmpFile" https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    curl -fsSLo "$tmpFile" https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key
 
     # 2023-05-23: GCP changed their key to be armored and changed the key location. Currently
     # the file extension is incorrect. So, we handle if it is armored or not in case

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -50,7 +50,7 @@ if [[ -n $CI ]]; then
       # Otherwise, just copy the file
       sudo cp "$tmpFile" "$keyringLocation"
     fi
-    echo "deb [signed-by=$keyringLocation] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+    echo "deb [signed-by=$keyringLocation] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
     sudo apt-get update -y
     sudo apt-get install -y kubectl
   fi


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

e2e tests are failing because of that:
https://outreach-hq.slack.com/archives/CN9MU7GLW/p1709544566147719

https://app.circleci.com/pipelines/github/getoutreach/gearbox/7432/workflows/c962a003-0ed0-4f3f-9d26-ec9dcb19cdfc/jobs/50980

the URL is from: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
