### PR TITLE
fix(yq): hardcode gojq version in scripts/devbase.sh

### DIFF
--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
+# We don't use get_tool_version from ./lib/bootstrap.sh here because it
+# uses this script to read versions.yaml, which would cause a
+# circular dependency.
 GOJQ_VERSION="${GOJQ_VERSION:-$(grep ^gojq: "$DIR"/../versions.yaml | awk '{print $2}')}"
 
 use_gojq=false

--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -6,8 +6,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 libDir="$DIR/../.bootstrap"
 lockfile="$DIR/../stencil.lock"
 serviceYaml="$DIR/../service.yaml"
-{{- $gojqVersion := (stencil.ReadFile "versions.yaml" | fromYaml).gojq }}
-gojqVersion="{{ $gojqVersion }}"
+{{- /* This needs to be synced with versions.yaml since the template can't read that file. */}}
+gojqVersion="v0.12.14"
 
 # get_absolute_path returns the absolute path of a file
 get_absolute_path() {

--- a/templates/scripts/versions.yaml
+++ b/templates/scripts/versions.yaml
@@ -1,1 +1,0 @@
-../../versions.yaml


### PR DESCRIPTION
## What this PR does / why we need it

As it turns out, trying to use the symlink didn't work when running stencil on a different repository, but with the unstable version of devbase (it somehow worked when running stencil on devbase, which is confusing). Trying to fix stencil itself so it can work with symlinks which reference things outside of the template directory just seems like a security vulnerability waiting to happen, so I've opted to just have the duplicated version inside of the template.

Also added a comment in `shell/yq.sh` to give context as to why it doesn't use `get_tool_version` to read the gojq version from `versions.yaml`.