### PR TITLE
feat: add `no_output_timeout` param

### DIFF
--- a/orbs/shared/jobs/release.yaml
+++ b/orbs/shared/jobs/release.yaml
@@ -24,6 +24,10 @@ parameters:
     description: The executor to use for the release
     type: executor
     default: "testbed-docker"
+  dryrun_timeout:
+    description: The timeout that gets applied when CircleCI receives no output during the dryrun
+    type: string
+    default: 10m
 resource_class: << parameters.resource_class >>
 executor: << parameters.executor >>
 steps:
@@ -42,6 +46,7 @@ steps:
         - run:
             name: Release (Dry-run)
             command: ./scripts/shell-wrapper.sh ci/release/dryrun.sh
+            no_output_timeout: << parameters.dryrun_timeout >>
   - unless:
       condition: << parameters.dryrun >>
       steps:

--- a/orbs/shared/jobs/release.yaml
+++ b/orbs/shared/jobs/release.yaml
@@ -24,8 +24,8 @@ parameters:
     description: The executor to use for the release
     type: executor
     default: "testbed-docker"
-  dryrun_timeout:
-    description: The timeout that gets applied when CircleCI receives no output during the dryrun
+  no_output_timeout:
+    description: The timeout that gets applied when CircleCI receives no output during the release
     type: string
     default: 10m
 resource_class: << parameters.resource_class >>
@@ -46,7 +46,7 @@ steps:
         - run:
             name: Release (Dry-run)
             command: ./scripts/shell-wrapper.sh ci/release/dryrun.sh
-            no_output_timeout: << parameters.dryrun_timeout >>
+            no_output_timeout: << parameters.no_output_timeout >>
   - unless:
       condition: << parameters.dryrun >>
       steps:
@@ -55,3 +55,4 @@ steps:
             environment:
               RELEASE_FAILURE_SLACK_CHANNEL: << parameters.release_failure_slack_channel >>
             command: ./scripts/shell-wrapper.sh ci/release/release.sh
+            no_output_timeout: << parameters.no_output_timeout >>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds a `no_output_timeout` param that maps to `no_output_timeout` on the release, with a default of `10m`. [Related issue](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1705408681156669)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-4165]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-4165]: https://outreach-io.atlassian.net/browse/DT-4165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ