### PR TITLE
fix(gojq): normalize arm64 arch name

### DIFF
--- a/scripts/devbase.sh
+++ b/scripts/devbase.sh
@@ -26,9 +26,14 @@ gojq() {
     mkdir -p "$gjDir"
     platform="$(uname -s | awk '{print tolower($0)}')"
     arch="$(uname -m)"
-    if [[ $arch == x86_64 ]]; then
+    case $arch in
+    x86_64)
       arch=amd64
-    fi
+      ;;
+    aarch64)
+      arch=arm64
+      ;;
+    esac
     local basename="gojq_${gojqVersion}_${platform}_${arch}"
     local ext
     if [[ $platform == linux ]]; then

--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -27,9 +27,14 @@ gojq() {
     mkdir -p "$gjDir"
     platform="$(uname -s | awk '{print tolower($0)}')"
     arch="$(uname -m)"
-    if [[ $arch == x86_64 ]]; then
+    case $arch in
+    x86_64)
       arch=amd64
-    fi
+      ;;
+    aarch64)
+      arch=arm64
+      ;;
+    esac
     local basename="gojq_${gojqVersion}_${platform}_${arch}"
     local ext
     if [[ $platform == linux ]]; then


### PR DESCRIPTION
## What this PR does / why we need it

This fixes the bug where docker images on arm64 couldn't be created.

CC: @nissim-natanov-outreach