### PR TITLE
fix: Upgrade delve to 1.22 to support Go 1.22

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,7 +1,7 @@
 grpcui: 1.3.1
 jsonnetfmt: 0.19.1
 goimports: 0.5.0
-delve: 1.21.2
+delve: 1.22.1
 gotestsum: 1.10.1
 lintroller: 1.18.1
 goveralls: 0.0.11


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Got the error when launching the debugger
```
Version of Delve is too old for Go version go1.22.0 (maximum supported version 1.21, suppress this error with --check-go-version=false)
```
We need to upgrade delve https://github.com/go-delve/delve/blob/master/CHANGELOG.md#1220-2023-12-29

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
