### PR TITLE
fix: upgrade gobin to 1.11.5 to fix `go mod tidy` issues

### DIFF
--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -3,7 +3,7 @@
 # Run a golang binary using gobin
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-GOBIN_VERSION=1.9.0
+GOBIN_VERSION=1.11.5
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 


### PR DESCRIPTION
## What this PR does / why we need it

See https://github.com/getoutreach/gobin/pull/145 for details.

## Jira ID

[DT-4309]

[DT-4309]: https://outreach-io.atlassian.net/browse/DT-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ