### PR TITLE
feat: add catalog sync script, used when catalog manifest isn't a template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP := devbase
 OSS := true
-_ := $(shell ./scripts/devbase.sh)
+_ := $(shell ./scripts/devbase.sh) 
 
 include .bootstrap/root/Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP := devbase
 OSS := true
-_ := $(shell ./scripts/devbase.sh) 
+_ := $(shell ./scripts/devbase.sh)
 
 include .bootstrap/root/Makefile
 
@@ -40,4 +40,5 @@ publish-orb: validate-orb
 post-stencil::
 	$(SED_I) "s/dev:first/$(STABLE_ORB_VERSION)/" .circleci/config.yml
 	yarn add --dev @getoutreach/semantic-release-circleci-orb
+	./scripts/shell-wrapper.sh catalog-sync.sh
 ## <</Stencil::Block>>

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Syncs the service catalog manifest for the given repository with
+# the metadata present in the repository.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=./lib/logging.sh
+source "$DIR/lib/logging.sh"
+# shellcheck source=./lib/yaml.sh
+source "$DIR/lib/yaml.sh"
+
+sed_replace() {
+  local pattern=$1
+  local replacement=$2
+  local file=$3
+  local SED
+  case "$OSTYPE" in
+  darwin*)
+    SED="sed -i ''"
+    ;;
+  linux*)
+    SED="sed -i"
+    ;;
+  esac
+  $SED "s|$pattern|$replacement|g" "$file"
+}
+
+sync_cortex() {
+  info "Syncing cortex.yaml"
+  local golang_version lintroller reporting_team stencil_version
+  golang_version="$(grep -w ^golang .tool-versions | awk '{print $2}')"
+  lintroller="$(yaml_get_field .arguments.lintroller service.yaml)"
+  reporting_team="$(yaml_get_field .arguments.reportingTeam service.yaml)"
+  stencil_version="$(yaml_get_field .version stencil.lock)"
+  sed_replace '\(golang_version:\) .\+' "\1 $golang_version" cortex.yaml
+  sed_replace '\(lintroller:\) .\+' "\1 $lintroller" cortex.yaml
+  sed_replace '\(reporting_team:\) .\+' "\1 $reporting_team" cortex.yaml
+  sed_replace '\(stencil_version:\) .\+' "\1 $stencil_version" cortex.yaml
+}
+
+if [[ -f cortex.yaml ]]; then
+  sync_cortex
+fi


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin. This script only updates some basic fields, it's not exhaustive. An exhaustive updater would effectively require a Go-based script. It currently only supports Cortex but can be extended to other service catalogs' manifests.

## Jira ID

[DT-4324]

[DT-4324]: https://outreach-io.atlassian.net/browse/DT-4324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ