### PR TITLE
fix(linters): pretter 3+ log level flag compatibility

### DIFF
--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -9,15 +9,33 @@ source "$DIR/languages/nodejs.sh"
 # shellcheck disable=SC2034
 extensions=(yaml yml json md ts)
 
+PRETTIER="node_modules/.bin/prettier"
+
+prettier_log_level_flag() {
+  if [[ $("$PRETTIER" --version) =~ ^2 ]]; then
+    echo "--loglevel"
+  else
+    echo "--log-level"
+  fi
+}
+
 prettier_linter() {
   yarn_install_if_needed >/dev/null
-  find_files_with_extensions "${extensions[@]}" | xargs -n40 "node_modules/.bin/prettier" -l --log-level log
+
+  local log_level_flag
+  log_level_flag="$(prettier_log_level_flag)"
+
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$PRETTIER" --list-different "$log_level_flag" log
   return $?
 }
 
 prettier_formatter() {
   yarn_install_if_needed >/dev/null
-  find_files_with_extensions "${extensions[@]}" | xargs -n40 "node_modules/.bin/prettier" --write --log-level warn
+
+  local log_level_flag
+  log_level_flag="$(prettier_log_level_flag)"
+
+  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$PRETTIER" --write "$log_level_flag" warn
 }
 
 linter() {


### PR DESCRIPTION
## What this PR does / why we need it

Allows support for both the Prettier 2 and Prettier 3+ variants of the log level flag.