### PR TITLE
fix: rc prerelease before unstable release

### DIFF
--- a/shell/ci/release/pre-release.sh
+++ b/shell/ci/release/pre-release.sh
@@ -68,19 +68,6 @@ if [[ $CIRCLE_BRANCH != "$prereleasesBranch" ]] && [[ $DRYRUN == "false" ]]; the
   exit 0
 fi
 
-# If there's no .goreleaser.yml file, skip the unstable release process.
-# Otherwise, the 'make release' step would fail.
-#
-# IDEA(jaredallard): We should support a more customizable release
-# process for things that don't use goreleaser.
-if [[ ! -e "$(get_repo_directory)/.goreleaser.yml" ]]; then
-  echo "No .goreleaser.yml, skipping creating unstable release"
-
-  # Run the unstable include script if it exists.
-  run_unstable_include
-  exit 0
-fi
-
 # If we're in dry-run mode, skip creating the release.
 if [[ $DRYRUN == "true" ]]; then
   exit 0
@@ -101,6 +88,19 @@ if [[ $COMMIT_MESSAGE =~ "chore: Release" ]]; then
   # Unset NPM_TOKEN to force it to use the configured ~/.npmrc
   NPM_TOKEN='' GH_TOKEN=$GH_TOKEN \
     yarn --frozen-lockfile semantic-release
+  exit 0
+fi
+
+# If there's no .goreleaser.yml file, skip the unstable release process.
+# Otherwise, the 'make release' step would fail.
+#
+# IDEA(jaredallard): We should support a more customizable release
+# process for things that don't use goreleaser.
+if [[ ! -e "$(get_repo_directory)/.goreleaser.yml" ]]; then
+  echo "No .goreleaser.yml, skipping creating unstable release"
+
+  # Run the unstable include script if it exists.
+  run_unstable_include
   exit 0
 fi
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This PR fixes the case when a repo does not set up goreleaser. It should run RC release check first if applicable. 

Example: https://app.circleci.com/pipelines/github/getoutreach/stencil-circleci/1018/workflows/6da65a0e-50f5-4977-b766-11b8486e4f84/jobs/1856


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
