### PR TITLE
fix(delibird): use stable version of delibird

### DIFF
--- a/shell/ci/testing/delibird.sh
+++ b/shell/ci/testing/delibird.sh
@@ -32,9 +32,7 @@ export VAULT_ADDR
 
 # install_delibird installs the delibird log uploader.
 install_delibird() {
-  # We enable pre-releases for now because we rely on the latest
-  # unstable version of delibird to function.
-  install_latest_github_release getoutreach/orc true delibird
+  install_latest_github_release getoutreach/orc false delibird
 
   # tokenPath is the path that the delibird token should be written to.
   local tokenPath="$HOME/.outreach/.delibird/token"


### PR DESCRIPTION
## What this PR does / why we need it

There hasn't been any new development on the `delibird` client in a while, so it should be safe to assume that we can use the stable version instead of the unstable version.