### PR TITLE
fix: replace awkward sed command with less awkward perl command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,6 @@ _ := $(shell ./scripts/devbase.sh)
 include .bootstrap/root/Makefile
 
 ## <<Stencil::Block(targets)>>
-ifeq ($(OS),Windows_NT)     # is Windows_NT on XP, 2000, 7, Vista, 10...
-	detectedOS := Windows
-else
-	detectedOS := $(shell uname -s)
-endif
-
-ifeq ($(detectedOS),Darwin)
-	# BSD sed
-	SED_I := sed -i ""
-else
-	# GNU sed
-	SED_I := sed -i
-endif
-
 ORB_DEV_TAG ?= first
 STABLE_ORB_VERSION = $(shell gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json name --jq '.[].name | ltrimstr("v")')
 
@@ -38,7 +24,7 @@ publish-orb: validate-orb
 	circleci orb publish orb.yml getoutreach/shared@dev:$(ORB_DEV_TAG)
 
 post-stencil::
-	$(SED_I) "s/dev:first/$(STABLE_ORB_VERSION)/" .circleci/config.yml
+	perl -p -i -e "s/dev:first/$(STABLE_ORB_VERSION)/g" .circleci/config.yml
 	yarn add --dev @getoutreach/semantic-release-circleci-orb
 	./scripts/shell-wrapper.sh catalog-sync.sh
 ## <</Stencil::Block>>


### PR DESCRIPTION
## What this PR does / why we need it

For some reason the `sed` platform-specific conditional wasn't working correctly in macOS. So replace it with a cross-platform `perl` command. We expect that `perl` is installed by default on any machine that runs `stencil` for this repository.