### PR TITLE
chore: remove duplicate Makefile var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ publish-orb: validate-orb
 	circleci orb publish orb.yml getoutreach/shared@dev:$(ORB_DEV_TAG)
 
 ## <<Stencil::Block(targets)>>
-ORB_DEV_TAG ?= first
 STABLE_ORB_VERSION = $(shell gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json name --jq '.[].name | ltrimstr("v")')
 
 post-stencil::


### PR DESCRIPTION
## What this PR does / why we need it

I missed this in #791.