### PR TITLE
fix(ci): use Docker 24 for remote docker images

### DIFF
--- a/orbs/shared/commands/use_docker.yml
+++ b/orbs/shared/commands/use_docker.yml
@@ -2,4 +2,4 @@ description: Sets up a remote docker image with a standard version being used
 steps:
   - setup_remote_docker:
       docker_layer_caching: true
-      version: 20.10.24
+      version: docker24


### PR DESCRIPTION
## What this PR does / why we need it

Docker 20 is deprecated.

## Jira ID

[DT-4396]

[DT-4396]: https://outreach-io.atlassian.net/browse/DT-4396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ