### PR TITLE
fix(circleci): better logging, better ECR compatibility

### DIFF
--- a/shell/ci/auth/aws-ecr.sh
+++ b/shell/ci/auth/aws-ecr.sh
@@ -13,9 +13,10 @@ if [[ ! -f "$HOME/.aws/credentials" ]]; then
 fi
 
 for registry in $DOCKER_PUSH_REGISTRIES; do
-  if [[ $registry =~ amazonaws.com$ ]]; then
+  if [[ $registry =~ amazonaws.com($|/) ]]; then
     # Format: $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
     region="$(echo "$registry" | cut -d. -f4)"
+    echo " -> Authenticating with AWS ECR in $registry"
     # See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token
     aws ecr get-login-password --region "$region" | docker login --username AWS --password-stdin "$registry"
   fi

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -61,6 +61,7 @@ download_box
 echo "$CACHE_VERSION" >cache-version.txt
 
 # Authenticate with AWS ECR now that we have the box config
+echo "🔒 Setting up AWS ECR access"
 DOCKER_PUSH_REGISTRIES="$(get_box_array 'docker.imagePushRegistries')"
 # shellcheck source=../ci/auth/aws-ecr.sh
 source "$CI_DIR/auth/aws-ecr.sh"


### PR DESCRIPTION
## What this PR does / why we need it

Make it more obvious in the CI logs that we're logging into AWS ECR.

Also add support for `foo.amazonaws.com/bar` registries.

## Jira ID

[DT-4464]

## Notes for reviewers

This is what it looks like in the terminal:

```shell
❯ DOCKER_PUSH_REGISTRIES=accountid.dkr.ecr.region.amazonaws.com/somepath shell/ci/auth/aws-ecr.sh 
 -> Authenticating with AWS ECR in accountid.dkr.ecr.region.amazonaws.com/somepath
WARNING! Your password will be stored unencrypted in $HOME/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credential-stores

Login Succeeded
```

[DT-4464]: https://outreach-io.atlassian.net/browse/DT-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ