### PR TITLE
fix(circleci): only set DOCKER_PUSH_REGISTRIES from box if it's unset

### DIFF
--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -62,6 +62,8 @@ echo "$CACHE_VERSION" >cache-version.txt
 
 # Authenticate with AWS ECR now that we have the box config
 echo "🔒 Setting up AWS ECR access"
-DOCKER_PUSH_REGISTRIES="$(get_box_array 'docker.imagePushRegistries')"
+if [[ -z $DOCKER_PUSH_REGISTRIES ]]; then
+  DOCKER_PUSH_REGISTRIES="$(get_box_array 'docker.imagePushRegistries')"
+fi
 # shellcheck source=../ci/auth/aws-ecr.sh
-source "$CI_DIR/auth/aws-ecr.sh"
+"$CI_DIR/auth/aws-ecr.sh"


### PR DESCRIPTION
## What this PR does / why we need it

* Don't override the env var
* Possible subtle bash bug by using `source` vs. calling the script directly


## Jira ID

[DT-4464]

[DT-4464]: https://outreach-io.atlassian.net/browse/DT-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ