### PR TITLE
fix(ci): install awscli

### DIFF
--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -70,3 +70,14 @@ if should_install_vault; then
   sudo apt-get install -y vault
   sudo rm -rf /opt/vault
 fi
+
+# install AWS CLI
+
+if ! command -v aws >/dev/null; then
+  awscliZip="awscli-exe-linux-$(uname -m).zip"
+  echo "Installing AWS CLI"
+  wget "https://awscli.amazonaws.com/$awscliZip"
+  unzip "$awscliZip"
+  sudo ./aws/install
+  rm -rf aws "$awscliZip"
+fi


### PR DESCRIPTION
## What this PR does / why we need it

This installs the AWS CLI in environments where it's needed for ECR authentication, namely building and publishing containers.

## Jira ID

[DT-4464]

[DT-4464]: https://outreach-io.atlassian.net/browse/DT-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ