### PR TITLE
fix(docker-build): use get_box_array to fetch push registries from box

### DIFF
--- a/shell/docker-build.sh
+++ b/shell/docker-build.sh
@@ -26,7 +26,7 @@ warn "If you run into credential issues, ensure that your key is in your SSH age
 
 tags=()
 
-imageRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_box_field 'docker.imagePushRegistries')}"
+imageRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_box_array 'docker.imagePushRegistries')}"
 if [[ -z $imageRegistries ]]; then
   # Fall back to the old box field
   imageRegistries="$(get_box_field 'devenv.imageRegistry')"


### PR DESCRIPTION
## What this PR does / why we need it

This should fix the tagging issues when running `make e2e`.

## Jira ID

[DT-4504]

[DT-4504]: https://outreach-io.atlassian.net/browse/DT-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ