### PR TITLE
fix: add no_output_timeout to pre-release

### DIFF
--- a/orbs/shared/jobs/pre-release.yaml
+++ b/orbs/shared/jobs/pre-release.yaml
@@ -24,6 +24,10 @@ parameters:
     description: The executor to use for the release
     type: executor
     default: "testbed-docker"
+  no_output_timeout:
+    description: The timeout that gets applied when CircleCI receives no output during the release
+    type: string
+    default: 10m
 resource_class: << parameters.resource_class >>
 executor: << parameters.executor >>
 steps:
@@ -42,6 +46,7 @@ steps:
         - run:
             name: Pre-release (dry run)
             command: ./scripts/shell-wrapper.sh ci/release/dryrun.sh
+            no_output_timeout: << parameters.no_output_timeout >>
   - unless:
       condition: << parameters.dryrun >>
       steps:
@@ -50,3 +55,4 @@ steps:
             environment:
               RELEASE_FAILURE_SLACK_CHANNEL: << parameters.release_failure_slack_channel >>
             command: ./scripts/shell-wrapper.sh ci/release/pre-release.sh
+	    no_output_timeout: << parameters.no_output_timeout >>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
we have quite regular failures of prerelease step even with powerful hardware because of default 10 minute timeout

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
