### PR TITLE
fix: be consistent about determining push registries

### DIFF
--- a/shell/ci/release/docker-stitch.sh
+++ b/shell/ci/release/docker-stitch.sh
@@ -15,11 +15,7 @@ source "${LIB_DIR}/box.sh"
 # shellcheck source=../../lib/docker.sh
 source "${LIB_DIR}/docker.sh"
 
-imageRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_box_array 'docker.imagePushRegistries')}"
-if [[ -z $imageRegistries ]]; then
-  # Fall back to the old box field
-  imageRegistries="$(get_box_field 'devenv.imageRegistry')"
-fi
+imageRegistries="$(get_docker_push_registries)"
 
 # setup docker authentication
 if [[ $imageRegistries =~ gcr.io/ ]]; then

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -62,8 +62,12 @@ echo "$CACHE_VERSION" >cache-version.txt
 
 # Authenticate with AWS ECR now that we have the box config
 echo "🔒 Setting up AWS ECR access"
+
+# shellcheck source=../lib/docker.sh
+source "${LIB_DIR}/docker.sh"
+
 if [[ -z $DOCKER_PUSH_REGISTRIES ]]; then
-  DOCKER_PUSH_REGISTRIES="$(get_box_array 'docker.imagePushRegistries')"
+  DOCKER_PUSH_REGISTRIES="$(get_docker_push_registries)"
 fi
 # shellcheck source=../ci/auth/aws-ecr.sh
 "$CI_DIR/auth/aws-ecr.sh"

--- a/shell/lib/docker.sh
+++ b/shell/lib/docker.sh
@@ -13,6 +13,9 @@ source "${DIR}/bootstrap.sh"
 # shellcheck source=./yaml.sh
 source "${DIR}/yaml.sh"
 
+# shellcheck source=./box.sh
+source "${DIR}/box.sh"
+
 # get_image_field is a helper to return a field from the manifest
 # for a given image. It will return an empty string if the field
 # is not set.
@@ -48,9 +51,18 @@ get_image_field() {
 }
 
 # Returns a space-separated list of image registries to push to.
+# `BOX_DOCKER_PUSH_IMAGE_REGISTRIES` is the environment variable that
+# takes preference over every other method of determining the registries.
+# `DOCKER_PUSH_REGISTRIES` is the environment variable that can be set
+# by the CircleCI job via the `push_registries` parameter. If none of
+# these are set, the box field `docker.imagePushRegistries`` is used.
 get_docker_push_registries() {
   local imageRegistries
-  imageRegistries="${BOX_DOCKER_PUSH_IMAGE_REGISTRIES:-$(get_box_array 'docker.imagePushRegistries')}"
+  if [[ -n $BOX_DOCKER_PUSH_IMAGE_REGISTRIES ]]; then
+    imageRegistries="$BOX_DOCKER_PUSH_IMAGE_REGISTRIES"
+  else
+    imageRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_box_array 'docker.imagePushRegistries')}"
+  fi
 
   if [[ -z $imageRegistries ]]; then
     # Fall back to the old box field


### PR DESCRIPTION
## What this PR does / why we need it

This should allow someone to set `BOX_DOCKER_PUSH_IMAGE_REGISTRIES` in the CI environment variables, to test a particular service to push to custom registries.

Also fixes a bug where `docker.sh` didn't include `box.sh` explicitly, even though functions from that library were used.

## Jira ID

[DT-4462]

[DT-4462]: https://outreach-io.atlassian.net/browse/DT-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ