### PR TITLE
fix(yq): use local gojq if installed

### DIFF
--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -31,7 +31,11 @@ else
 fi
 
 if [[ $use_gojq == "true" ]]; then
-  "$DIR"/gobin.sh github.com/itchyny/gojq/cmd/gojq@"$GOJQ_VERSION" --yaml-input "$@"
+  if command -v gojq >/dev/null 2>&1; then
+    gojq --yaml-input "$@"
+  else
+    "$DIR"/gobin.sh github.com/itchyny/gojq/cmd/gojq@"$GOJQ_VERSION" --yaml-input "$@"
+  fi
 else
   yq "$@"
 fi

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ lintroller: 1.18.1
 goveralls: 0.0.11
 getoutreach/ci: v1.3.0
 getoutreach/logfmt: v1.1.0
-gojq: v0.12.14
+gojq: v0.12.16
 
 # protobuf formatters/plugins/tools/etc
 buf: 1.8.0 # formatter


### PR DESCRIPTION
## What this PR does / why we need it

This should make running `yq.sh` when `yq` isn't installed much faster and not dependent on `gobin` / `go` installed correctly.

Also, update the `gobin` version of `gojq`.