### PR TITLE
feat: Add gopls.sh

### DIFF
--- a/shell/gopls.sh
+++ b/shell/gopls.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Parses the embedding project's `.tool-versions` file to find which is the
+# currently active version of gopls, then invokes it explicitly through `asdf`.
+#
+# The idea here is that `some_project/.bootstrap/shell/gopls.sh` will will
+# always point to the "right" go for that particular `some_project`.
+#
+# If this doesn't work right away, try:
+# go install golang.org/x/tools/gopls@latest
+# asdf reshim
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+exec "$SCRIPTS_DIR/asdf-exec.sh" go run golang.org/x/tools/gopls@v0.14.2
+
+gopls "$@"


### PR DESCRIPTION
Adds a `gopls.sh` script that provides a `asdf`-aware way to start a
`gopls` LSP server.  This script helps my Emacs load and run the right
`gopls` for any given project.

To my fellow Emacs users, I offer these configs as an example:
```
(defun find-stencil-root ()
  "Finds the directory that contains stencil.lock"
  ()
  (message "evaluating find-stencil-root")
  (locate-dominating-file "." "stencil.lock"))

(defun stencil-go-setup ()
  "A go-mode hook for Outreach stencil projects"
  ()
  (let
      ((stencil-root (find-stencil-root)))
    (if stencil-root
        (progn
          (setq-local go-command (concat stencil-root ".bootstrap/shell/go.sh"))
          (setq-local gofmt-command (concat stencil-root ".bootstrap/shell/gofmt.sh"))
          (setq-local godoc-command (concat stencil-root ".bootstrap/shell/go.sh doc"))
          (setq-local go-test-command (concat stencil-root ".bootstrap/shell/go.sh test -ldflags '-X github.com/getoutreach/go-outreach/v2/pkg/app.Version=testing -X github.com/getoutreach/gobox/pkg/app.Version=testing' -tags=or_test"))

          (setq-local lsp-go-gopls-server-path (concat stencil-root ".bootstrap/shell/gopls.sh"))
          (setq-local lsp-go-env '((GOFLAGS . "-tags=or_test,or_e2e")))

          (setq-local flycheck-go-test-executable (concat stencil-root ".bootstrap/shell/go.sh") )
          (setq-local flycheck-go-vet-executable (concat stencil-root ".bootstrap/shell/go.sh") )
          (setq-local flycheck-go-gofmt-executable (concat stencil-root ".bootstrap/shell/gofmt.sh") )
          (setq-local flycheck-go-build-executable (concat stencil-root ".bootstrap/shell/go.sh") )
          )
          ()
          )
      )
    )

(add-hook 'go-mode-hook 'stencil-go-setup)
```
(Note the `gopls.sh` references in the middle there.)

Folks using a different editor might not benefit from this specific
advice, but I'm hoping the `gopls.sh` script will be of some use to
them, too.