### PR TITLE
fix(asdf): when finding .tool-versions, ignore .asdf within containers

### DIFF
--- a/shell/lib/asdf.sh
+++ b/shell/lib/asdf.sh
@@ -24,10 +24,11 @@ if [[ -z $asdf_plugins_list ]]; then
 fi
 
 # read_all_asdf_tool_versions combines all .tool-versions found in this directory
-# and the child directories minus node_modules and vendor.
+# and the child directories minus node_modules and vendor, and in some cases
+# `.asdf` (when run within a Docker container).
 # This prints the plugin, then the version, each separated by a newline.
 read_all_asdf_tool_versions() {
-  find . -type d \( -path ./.git -o -path ./vendor -o -path ./node_modules \) -prune -o \
+  find . -type d \( -path ./.git -o -path ./vendor -o -path ./node_modules -o -path "*/.asdf" \) -prune -o \
     -name .tool-versions -exec cat {} \; |
     grep -Ev "^#|^$" | sort | uniq | awk '{ print $1 } { print $2 }'
 }


### PR DESCRIPTION
## What this PR does / why we need it

When running `asdf` initialization within a Docker container, ignore the `~/.asdf` folder as it will install unnecessary runtimes.

## Jira ID

[DT-4507]

[DT-4507]: https://outreach-io.atlassian.net/browse/DT-4507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ