### PR TITLE
feat(orb): add AWS version of testbed-docker executor

### DIFF
--- a/orbs/shared/executors/testbed-docker-aws.yml
+++ b/orbs/shared/executors/testbed-docker-aws.yml
@@ -1,0 +1,16 @@
+description: Standard executor for Docker based runtimes with AWS auth
+parameters:
+  docker_tag:
+    type: string
+    default: stable
+  docker_image:
+    type: string
+docker:
+  - image: << parameters.docker_image >>:<< parameters.docker_tag >>
+    aws_auth:
+      aws_access_key_id: $AWS_ACCESS_KEY_ID
+      aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+environment:
+  TEST_RESULTS: /tmp/test-results
+  GOPRIVATE: github.com/getoutreach/*
+  GOPROXY: https://proxy.golang.org

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -31,6 +31,11 @@ parameters:
     description: The docker image tag to use for running the test
     type: string
     default: stable
+  executor_name:
+    description: The executor to use for the job
+    type: enum
+    enum: [testbed-docker, testbed-docker-aws]
+    default: "testbed-docker"
   aws_region:
     description: AWS_REGION environment variable to set
     type: string
@@ -50,7 +55,7 @@ parameters:
 resource_class: << parameters.resource_class >>
 
 executor:
-  name: testbed-docker
+  name: << parameters.executor_name >>
   docker_image: << parameters.docker_image >>
   docker_tag: << parameters.docker_tag >>
 


### PR DESCRIPTION
## What this PR does / why we need it

Apparently you can't have an executor that works with both AWS and some other auth, practically speaking. If you try to use an executor with a docker image not in AWS, but `aws_auth` is set, it will fail trying to parse the AWS region from the ECR URL.

## Jira ID

[DT-4462]

[DT-4462]: https://outreach-io.atlassian.net/browse/DT-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ