### PR TITLE
fix(orb): replace reference to unused image

### DIFF
--- a/orbs/shared/jobs/merge.yaml
+++ b/orbs/shared/jobs/merge.yaml
@@ -2,7 +2,7 @@ description: Merges the base (to merge into) branch into the head (current) bran
 executor:
   name: testbed-docker
 docker:
-  - image: gcr.io/outreach-docker/bootstrap/ci:stable
+  - image: gcr.io/outreach-docker/bootstrap/ci-slim:stable
     auth:
       username: _json_key
       password: $GCLOUD_SERVICE_ACCOUNT


### PR DESCRIPTION
## What this PR does / why we need it

Replace `bootstrap/ci` with `bootstrap/ci-slim`