### PR TITLE
fix(yq): prefer gojq if installed locally

### DIFF
--- a/scripts/devbase.sh
+++ b/scripts/devbase.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 libDir="$DIR/../.bootstrap"
 lockfile="$DIR/../stencil.lock"
 serviceYaml="$DIR/../service.yaml"
-gojqVersion="v0.12.14"
+gojqVersion="v0.12.16"
 
 # get_absolute_path returns the absolute path of a file
 get_absolute_path() {

--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -22,8 +22,11 @@ use_jit_gojq=false
 if [[ -n ${YQ_USE_JIT_GOJQ:-} ]]; then
   use_jit_gojq=true
 elif command -v yq >/dev/null 2>&1; then
-  # Make sure it's the correct yq. The Go yq is not compatible with jq syntax.
-  if [[ "$(yq --version)" =~ ^yq.3.* ]]; then
+  # Make sure it's the correct yq. The Go yq (github.com/mikefarah/yq) is not
+  # compatible with jq syntax.
+  # Checks for 0 in addition to 3 as the Debian package-installed version does
+  # not report the correct version (0.0.0).
+  if [[ "$(yq --version)" =~ ^yq.[03].* ]]; then
     use_jit_gojq=false
   else
     use_jit_gojq=true

--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 #
-# Wrapper around `yq` that allows use of python-yq or gojq.
-# You can force using gojq by setting the environment variable YQ_USE_GOJQ=true.
+# Wrapper around `yq` that allows use of `python-yq` or `gojq`.
+# A locally-installed `gojq` is preferred over `python-yq` if available.
+# If `gojq` is not installed locally, you can force using a `gobin`-JIT-executed
+# version of `gojq` by setting the environment variable `YQ_USE_JIT_GOJQ=true`.
 #
 
 set -euo pipefail
@@ -11,31 +13,29 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # We don't use get_tool_version from ./lib/bootstrap.sh here because it
 # uses this script to read versions.yaml, which would cause a
 # circular dependency.
-GOJQ_VERSION="${GOJQ_VERSION:-$(grep ^gojq: "$DIR"/../versions.yaml | awk '{print $2}')}"
+JIT_GOJQ_VERSION="${JIT_GOJQ_VERSION:-$(grep ^gojq: "$DIR"/../versions.yaml | awk '{print $2}')}"
 
-use_gojq=false
+use_jit_gojq=false
 
-# YQ_USE_GOJQ is meant to be set externally, hence the workaround
+# YQ_USE_JIT_GOJQ is meant to be set externally, hence the workaround
 # for the unbound variable.
-if [[ -n ${YQ_USE_GOJQ:-} ]]; then
-  use_gojq=true
+if [[ -n ${YQ_USE_JIT_GOJQ:-} ]]; then
+  use_jit_gojq=true
 elif command -v yq >/dev/null 2>&1; then
   # Make sure it's the correct yq. The Go yq is not compatible with jq syntax.
   if [[ "$(yq --version)" =~ ^yq.3.* ]]; then
-    use_gojq=false
+    use_jit_gojq=false
   else
-    use_gojq=true
+    use_jit_gojq=true
   fi
 else
-  use_gojq=true
+  use_jit_gojq=true
 fi
 
-if [[ $use_gojq == "true" ]]; then
-  if command -v gojq >/dev/null 2>&1; then
-    gojq --yaml-input "$@"
-  else
-    "$DIR"/gobin.sh github.com/itchyny/gojq/cmd/gojq@"$GOJQ_VERSION" --yaml-input "$@"
-  fi
+if command -v gojq >/dev/null 2>&1; then
+  gojq --yaml-input "$@"
+elif [[ $use_jit_gojq == "true" ]]; then
+  "$DIR"/gobin.sh github.com/itchyny/gojq/cmd/gojq@"$JIT_GOJQ_VERSION" --yaml-input "$@"
 else
   yq "$@"
 fi

--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -7,7 +7,7 @@ libDir="$DIR/../.bootstrap"
 lockfile="$DIR/../stencil.lock"
 serviceYaml="$DIR/../service.yaml"
 {{- /* This needs to be synced with versions.yaml since the template can't read that file. */}}
-gojqVersion="v0.12.14"
+gojqVersion="v0.12.16"
 
 # get_absolute_path returns the absolute path of a file
 get_absolute_path() {

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,6 +7,7 @@ lintroller: 1.18.1
 goveralls: 0.0.11
 getoutreach/ci: v1.3.0
 getoutreach/logfmt: v1.1.0
+## Sync with templates/scripts/devbase.sh.tpl
 gojq: v0.12.16
 
 # protobuf formatters/plugins/tools/etc


### PR DESCRIPTION
## What this PR does / why we need it

This avoids a chicken-and-egg problem in CI where it tries to run `gobin` before `go` is even installed, even though `gojq` and/or `yq` is installed locally. Part of this is due to the fact that the Debian/Ubuntu-installed version of `yq` doesn't report its version properly via `yq --version`.

There was also a bunch of variable renames to indicate that they are specific to the JIT-executed `gojq` and not the locally installed `gojq`.

Finally, the bootstrapped `gojq` had its version synced with the version in `versions.yaml`.