### PR TITLE
fix(docker): slim down jobs, ensure auth happens

### DIFF
--- a/orbs/shared/commands/setup_docker_auth.yml
+++ b/orbs/shared/commands/setup_docker_auth.yml
@@ -1,16 +1,18 @@
 description: Authenticate Docker for pushing/pulling images.
 parameters:
-  container_registries:
+  pull_registry:
     type: string
-    description: Space-separated list of container registries.
+    description: Container registry URL to pull from.
+    default: ""
+  push_registries:
+    type: string
+    description: Space-separated list of container registries to push to.
     default: ""
 steps:
   - checkout
   - run:
-      name: Authenticate Docker with GCR
+      name: Authenticate to Docker registries
       command: ./scripts/shell-wrapper.sh ci/auth/gcr.sh
-  - run:
-      name: Authenticate Docker with ECR
-      command: ./scripts/shell-wrapper.sh ci/auth/aws-ecr.sh
       environment:
-        DOCKER_PUSH_REGISTRIES: << parameters.container_registries >>
+        DOCKER_PULL_REGISTRY: << parameters.pull_registry >>
+        DOCKER_PUSH_REGISTRIES: << parameters.push_registries >>

--- a/orbs/shared/commands/setup_docker_auth.yml
+++ b/orbs/shared/commands/setup_docker_auth.yml
@@ -1,8 +1,8 @@
 description: Authenticate Docker for pushing/pulling images.
 parameters:
-  push_registries:
+  container_registries:
     type: string
-    description: Space-separated list of registries to push the Docker image to.
+    description: Space-separated list of container registries.
     default: ""
 steps:
   - checkout
@@ -13,4 +13,4 @@ steps:
       name: Authenticate Docker with ECR
       command: ./scripts/shell-wrapper.sh ci/auth/aws-ecr.sh
       environment:
-        DOCKER_PUSH_REGISTRIES: << parameters.push_registries >>
+        DOCKER_PUSH_REGISTRIES: << parameters.container_registries >>

--- a/orbs/shared/commands/setup_docker_auth.yml
+++ b/orbs/shared/commands/setup_docker_auth.yml
@@ -1,0 +1,16 @@
+description: Authenticate Docker for pushing/pulling images.
+parameters:
+  push_registries:
+    type: string
+    description: Space-separated list of registries to push the Docker image to.
+    default: ""
+steps:
+  - checkout
+  - run:
+      name: Authenticate Docker with GCR
+      command: ./scripts/shell-wrapper.sh ci/auth/gcr.sh
+  - run:
+      name: Authenticate Docker with ECR
+      command: ./scripts/shell-wrapper.sh ci/auth/aws-ecr.sh
+      environment:
+        DOCKER_PUSH_REGISTRIES: << parameters.push_registries >>

--- a/orbs/shared/commands/setup_docker_auth.yml
+++ b/orbs/shared/commands/setup_docker_auth.yml
@@ -12,7 +12,7 @@ steps:
   - checkout
   - run:
       name: Authenticate to Docker registries
-      command: ./scripts/shell-wrapper.sh ci/auth/gcr.sh
+      command: ./scripts/shell-wrapper.sh ci/release/docker-authn.sh
       environment:
         DOCKER_PULL_REGISTRY: << parameters.pull_registry >>
         DOCKER_PUSH_REGISTRIES: << parameters.push_registries >>

--- a/orbs/shared/jobs/docker_amd64.yaml
+++ b/orbs/shared/jobs/docker_amd64.yaml
@@ -3,6 +3,5 @@ executor:
   name: testbed-machine
 resource_class: xlarge
 steps:
-  - setup_environment:
-      machine: true
+  - setup_docker_auth
   - build_docker_image

--- a/orbs/shared/jobs/docker_amd64.yaml
+++ b/orbs/shared/jobs/docker_amd64.yaml
@@ -2,6 +2,12 @@ description: Build an AMD64 Docker image.
 executor:
   name: testbed-machine
 resource_class: xlarge
+parameters:
+  container_registries:
+    type: string
+    description: Space-separated list of registries to push the Docker image to.
+    default: ""
 steps:
-  - setup_docker_auth
+  - setup_docker_auth:
+      container_registries: << parameters.container_registries >>
   - build_docker_image

--- a/orbs/shared/jobs/docker_amd64.yaml
+++ b/orbs/shared/jobs/docker_amd64.yaml
@@ -3,11 +3,11 @@ executor:
   name: testbed-machine
 resource_class: xlarge
 parameters:
-  container_registries:
+  push_registries:
     type: string
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
   - setup_docker_auth:
-      container_registries: << parameters.container_registries >>
+      push_registries: << parameters.push_registries >>
   - build_docker_image

--- a/orbs/shared/jobs/docker_arm64.yaml
+++ b/orbs/shared/jobs/docker_arm64.yaml
@@ -2,7 +2,13 @@ description: Build an ARM64 Docker image.
 executor:
   name: testbed-machine
 resource_class: arm.xlarge
+parameters:
+  container_registries:
+    type: string
+    description: Space-separated list of registries to push the Docker image to.
+    default: ""
 steps:
-  - setup_docker_auth
+  - setup_docker_auth:
+      container_registries: << parameters.container_registries >>
   - build_docker_image:
       arch: arm64

--- a/orbs/shared/jobs/docker_arm64.yaml
+++ b/orbs/shared/jobs/docker_arm64.yaml
@@ -3,7 +3,6 @@ executor:
   name: testbed-machine
 resource_class: arm.xlarge
 steps:
-  - setup_environment:
-      machine: true
+  - setup_docker_auth
   - build_docker_image:
       arch: arm64

--- a/orbs/shared/jobs/docker_arm64.yaml
+++ b/orbs/shared/jobs/docker_arm64.yaml
@@ -3,12 +3,12 @@ executor:
   name: testbed-machine
 resource_class: arm.xlarge
 parameters:
-  container_registries:
+  push_registries:
     type: string
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
   - setup_docker_auth:
-      container_registries: << parameters.container_registries >>
+      push_registries: << parameters.push_registries >>
   - build_docker_image:
       arch: arm64

--- a/orbs/shared/jobs/docker_stitch.yaml
+++ b/orbs/shared/jobs/docker_stitch.yaml
@@ -8,8 +8,7 @@ parameters:
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
-  - setup_environment:
-      machine: true
+  - setup_docker_auth:
       push_registries: << parameters.push_registries >>
   - stitch_docker_image:
       push_registries: << parameters.push_registries >>

--- a/orbs/shared/jobs/docker_stitch.yaml
+++ b/orbs/shared/jobs/docker_stitch.yaml
@@ -9,6 +9,6 @@ parameters:
     default: ""
 steps:
   - setup_docker_auth:
-      container_registries: << parameters.push_registries >>
+      push_registries: << parameters.push_registries >>
   - stitch_docker_image:
       push_registries: << parameters.push_registries >>

--- a/orbs/shared/jobs/docker_stitch.yaml
+++ b/orbs/shared/jobs/docker_stitch.yaml
@@ -9,6 +9,6 @@ parameters:
     default: ""
 steps:
   - setup_docker_auth:
-      push_registries: << parameters.push_registries >>
+      container_registries: << parameters.push_registries >>
   - stitch_docker_image:
       push_registries: << parameters.push_registries >>

--- a/shell/ci/auth/aws-ecr.sh
+++ b/shell/ci/auth/aws-ecr.sh
@@ -6,7 +6,11 @@
 set -eo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-AUTHN_DIR="${DIR}/../../lib/docker/authn"
+LIB_DIR="${DIR}/../../lib"
+AUTHN_DIR="${LIB_DIR}/docker/authn"
+
+# shellcheck source=../../lib/logging.sh
+source "${LIB_DIR}/logging.sh"
 
 # shellcheck source=../../lib/docker/authn/aws-ecr.sh
 source "${AUTHN_DIR}/aws-ecr.sh"

--- a/shell/ci/auth/aws-ecr.sh
+++ b/shell/ci/auth/aws-ecr.sh
@@ -6,6 +6,10 @@
 set -eo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+AUTHN_DIR="${DIR}/../../lib/docker/authn"
+
+# shellcheck source=../../lib/docker/authn/aws-ecr.sh
+source "${AUTHN_DIR}/aws-ecr.sh"
 
 if [[ ! -f "$HOME/.aws/credentials" ]]; then
   # shellcheck source=./aws.sh
@@ -14,10 +18,6 @@ fi
 
 for registry in $DOCKER_PUSH_REGISTRIES; do
   if [[ $registry =~ amazonaws.com($|/) ]]; then
-    # Format: $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
-    region="$(echo "$registry" | cut -d. -f4)"
-    echo " -> Authenticating with AWS ECR in $registry"
-    # See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token
-    aws ecr get-login-password --region "$region" | docker login --username AWS --password-stdin "$registry"
+    ecr_auth "$registry"
   fi
 done

--- a/shell/ci/auth/gcr.sh
+++ b/shell/ci/auth/gcr.sh
@@ -2,12 +2,15 @@
 # Configures CircleCI docker authentication for Google Cloud Registry (GCR).
 set -e
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+AUTHN_DIR="${DIR}/../../lib/docker/authn"
+
+# shellcheck source=../../lib/docker/authn/gcr.sh
+source "${AUTHN_DIR}/gcr.sh"
+
 if [[ -z $GCLOUD_SERVICE_ACCOUNT ]]; then
   echo "Skipped: GCLOUD_SERVICE_ACCOUNT is not set."
   exit 0
 fi
 
-docker login \
-  -u _json_key \
-  --password-stdin \
-  https://gcr.io <<<"${GCLOUD_SERVICE_ACCOUNT}"
+gcr_auth "$GCLOUD_SERVICE_ACCOUNT"

--- a/shell/ci/auth/gcr.sh
+++ b/shell/ci/auth/gcr.sh
@@ -3,13 +3,17 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-AUTHN_DIR="${DIR}/../../lib/docker/authn"
+LIB_DIR="${DIR}/../../lib"
+AUTHN_DIR="${LIB_DIR}/docker/authn"
+
+# shellcheck source=../../lib/logging.sh
+source "${LIB_DIR}/logging.sh"
 
 # shellcheck source=../../lib/docker/authn/gcr.sh
 source "${AUTHN_DIR}/gcr.sh"
 
 if [[ -z $GCLOUD_SERVICE_ACCOUNT ]]; then
-  echo "Skipped: GCLOUD_SERVICE_ACCOUNT is not set."
+  warn "Skipped: GCLOUD_SERVICE_ACCOUNT is not set."
   exit 0
 fi
 

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -11,10 +11,14 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 AUTH_DIR="${DIR}/../auth"
+CIRCLECI_DIR="${DIR}/../../circleci"
 LIB_DIR="${DIR}/../../lib"
 
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
+
+# shellcheck source=../../circleci/install_gh.sh
+source "${CIRCLECI_DIR}/install_gh.sh"
 
 # In order to get the box config, we need to authenticate with GitHub
 # shellcheck source=../auth/github.sh

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -20,6 +20,8 @@ source "${LIB_DIR}/logging.sh"
 # shellcheck source=../../circleci/install_gh.sh
 source "${CIRCLECI_DIR}/install_gh.sh"
 
+GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
+
 # In order to get the box config, we need to authenticate with GitHub
 # shellcheck source=../auth/github.sh
 source "${AUTH_DIR}/github.sh"

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -16,6 +16,11 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+# shellcheck source=../../lib/box.sh
+source "${LIB_DIR}/box.sh"
+
+download_box
+
 # shellcheck source=../../lib/docker.sh
 source "${LIB_DIR}/docker.sh"
 

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -16,6 +16,10 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+# In order to get the box config, we need to authenticate with GitHub
+# shellcheck source=../auth/github.sh
+source "${AUTH_DIR}/github.sh"
+
 # shellcheck source=../../lib/box.sh
 source "${LIB_DIR}/box.sh"
 

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Authenticate with supported Docker registries.
+# Resolves in the following prcedence order (empty values are ignored):
+# 1. From environment variables:
+#    a. DOCKER_PULL_REGISTRY | DOCKER_PUSH_REGISTRIES
+#    b. gobox-defined: BOX_DOCKER_PULL_IMAGE_REGISTRY | BOX_DOCKER_PUSH_IMAGE_REGISTRIES
+# 2. From box config:
+#    a. docker.imagePullRegistry | docker.imagePushRegistries
+#    b. devenv.imageRegistry
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+AUTH_DIR="${DIR}/../auth"
+LIB_DIR="${DIR}/../../lib"
+
+# shellcheck source=../../lib/logging.sh
+source "${LIB_DIR}/logging.sh"
+
+# shellcheck source=../../lib/docker.sh
+source "${LIB_DIR}/docker.sh"
+
+pullRegistry="${DOCKER_PULL_REGISTRY:-$(get_docker_pull_registry)}"
+pushRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_docker_push_registries)}"
+
+registries=$(echo "$pullRegistry $pushRegistries" | tr ' ' '\n' | sort --unique | tr '\n' ' ')
+
+info "Authenticating with Docker registries"
+
+for crURL in $registries; do
+  case $crURL in
+  gcr.io/*)
+    info_sub "GCR"
+    # shellcheck source=../auth/gcr.sh
+    source "${AUTH_DIR}/gcr.sh"
+    ;;
+  *.amazonaws.com | *.amazonaws.com/*)
+    info_sub "AWS ECR"
+    # shellcheck source=../auth/aws-ecr.sh
+    source "${AUTH_DIR}/aws-ecr.sh"
+    ;;
+  *)
+    warn "No authentication script found for registry: $crURL"
+    ;;
+  esac
+done

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -24,6 +24,7 @@ source "${CIRCLECI_DIR}/install_gh.sh"
 # shellcheck source=../auth/github.sh
 source "${AUTH_DIR}/github.sh"
 
+git config --global --remove-section url."ssh://git@github.com"
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 
 # shellcheck source=../../lib/box.sh

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -51,6 +51,7 @@ for crURL in $registries; do
     ;;
   *.amazonaws.com | *.amazonaws.com/*)
     info_sub "AWS ECR"
+    DOCKER_PUSH_REGISTRIES="$crURL" # Set the registry for the auth script
     # shellcheck source=../auth/aws-ecr.sh
     source "${AUTH_DIR}/aws-ecr.sh"
     ;;

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -13,12 +13,17 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 AUTH_DIR="${DIR}/../auth"
 CIRCLECI_DIR="${DIR}/../../circleci"
 LIB_DIR="${DIR}/../../lib"
+DOCKER_AUTH_DIR="${LIB_DIR}/docker/authn"
 
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+info "Ensuring that 'gh' is installed"
+
 # shellcheck source=../../circleci/install_gh.sh
 source "${CIRCLECI_DIR}/install_gh.sh"
+
+info "🔓 Authenticating to GitHub"
 
 # In order to get the box config, we need to authenticate with GitHub
 # shellcheck source=../auth/github.sh
@@ -35,25 +40,27 @@ download_box
 # shellcheck source=../../lib/docker.sh
 source "${LIB_DIR}/docker.sh"
 
+# shellcheck source=../../lib/docker/authn/aws-ecr.sh
+source "${DOCKER_AUTH_DIR}/aws-ecr.sh"
+
+# shellcheck source=../../lib/docker/authn/gcr.sh
+source "${DOCKER_AUTH_DIR}/gcr.sh"
+
 pullRegistry="${DOCKER_PULL_REGISTRY:-$(get_docker_pull_registry)}"
 pushRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_docker_push_registries)}"
 
 registries=$(echo "$pullRegistry $pushRegistries" | tr ' ' '\n' | sort --unique | tr '\n' ' ')
 
-info "Authenticating with Docker registries"
+info "🔓 Authenticating to Docker registries"
 
 for crURL in $registries; do
   case $crURL in
   gcr.io/*)
-    info_sub "GCR"
-    # shellcheck source=../auth/gcr.sh
-    source "${AUTH_DIR}/gcr.sh"
+    info_sub "🔓 GCR ($crURL)"
+    gcr_auth "$GCLOUD_SERVICE_ACCOUNT"
     ;;
   *.amazonaws.com | *.amazonaws.com/*)
-    info_sub "AWS ECR"
-    DOCKER_PUSH_REGISTRIES="$crURL" # Set the registry for the auth script
-    # shellcheck source=../auth/aws-ecr.sh
-    source "${AUTH_DIR}/aws-ecr.sh"
+    ecr_auth "$crURL"
     ;;
   *)
     warn "No authentication script found for registry: $crURL"

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -20,11 +20,11 @@ source "${LIB_DIR}/logging.sh"
 # shellcheck source=../../circleci/install_gh.sh
 source "${CIRCLECI_DIR}/install_gh.sh"
 
-GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
-
 # In order to get the box config, we need to authenticate with GitHub
 # shellcheck source=../auth/github.sh
 source "${AUTH_DIR}/github.sh"
+
+GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 
 # shellcheck source=../../lib/box.sh
 source "${LIB_DIR}/box.sh"

--- a/shell/ci/release/docker-stitch.sh
+++ b/shell/ci/release/docker-stitch.sh
@@ -31,7 +31,7 @@ if [[ $imageRegistries =~ amazonaws.com/ ]]; then
 fi
 
 APPNAME="$(get_app_name)"
-VERSION="$(make --no-print-directory version)"
+VERSION="$(get_app_version)"
 MANIFEST="$(get_repo_directory)/deployments/docker.yaml"
 
 archs=(amd64 arm64)

--- a/shell/ci/release/docker-stitch.sh
+++ b/shell/ci/release/docker-stitch.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Stitch together different manifests to be pulled as one
 # (multi-arch) manifest.
+#
+# Assumes that shell/ci/release/docker-authn.sh has been run in the same job.
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-CI_AUTH_DIR="$DIR/../auth"
 LIB_DIR="${DIR}/../../lib"
 
 # shellcheck source=../../lib/bootstrap.sh
@@ -16,19 +17,6 @@ source "${LIB_DIR}/box.sh"
 source "${LIB_DIR}/docker.sh"
 
 imageRegistries="$(get_docker_push_registries)"
-
-# setup docker authentication
-if [[ $imageRegistries =~ gcr.io/ ]]; then
-  # shellcheck source=../auth/gcr.sh
-  source "$CI_AUTH_DIR/gcr.sh"
-fi
-
-if [[ $imageRegistries =~ amazonaws.com/ ]]; then
-  # The auth script uses $DOCKER_PUSH_REGISTRIES to determine which registries to authenticate.
-  DOCKER_PUSH_REGISTRIES="$imageRegistries"
-  # shellcheck source=../auth/aws-ecr.sh
-  source "$CI_AUTH_DIR/aws-ecr.sh"
-fi
 
 APPNAME="$(get_app_name)"
 VERSION="$(get_app_version)"

--- a/shell/ci/release/docker.sh
+++ b/shell/ci/release/docker.sh
@@ -13,7 +13,7 @@ source "${LIB_DIR}/bootstrap.sh"
 source "${LIB_DIR}/box.sh"
 
 APPNAME="$(get_app_name)"
-VERSION="$(make --no-print-directory version)"
+VERSION="$(get_app_version)"
 MANIFEST="$(get_repo_directory)/deployments/docker.yaml"
 
 # shellcheck source=../../lib/buildx.sh

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Installs the GitHub CLI (`gh`) if it is not already installed.
+
+set -e
+
+# ARCH is the current architecture of the machine. Valid values are:
+#   - amd64
+#   - arm64
+ARCH="amd64"
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  ARCH="arm64"
+fi
+
+# GH_VERSION is the version of gh to install.
+export GH_VERSION=2.62.0
+
+if ! command -v gh >/dev/null; then
+  echo "Installing gh"
+
+  wget -O gh.deb https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb
+  sudo apt-get install --assume-yes --fix-broken ./gh.deb
+  rm ./gh.deb
+fi

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -3,16 +3,7 @@
 # These are usually already installed in a CircleCI docker image.
 set -e
 
-# ARCH is the current architecture of the machine. Valid values are:
-#   - amd64
-#   - arm64
-ARCH="amd64"
-if [[ "$(uname -m)" == "aarch64" ]]; then
-  ARCH="arm64"
-fi
-
-# GH_VERSION is the version of gh to install.
-export GH_VERSION=2.32.1
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # should_install_vault is a helper function that checks if the vault
 # binary is already installed, if so it returns false. Otherwise, it
@@ -39,13 +30,7 @@ fi
 # Rebuild the apt list
 sudo apt-get update -y
 
-if ! command -v gh >/dev/null; then
-  echo "Installing gh"
-
-  wget -O gh.deb https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb
-  sudo apt install -yf ./gh.deb
-  rm ./gh.deb
-fi
+. "$DIR"/install_gh.sh
 
 echo "Installing yq"
 # Remove the existing yq, if it already exists

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -30,7 +30,7 @@ fi
 # Rebuild the apt list
 sudo apt-get update -y
 
-. "$DIR"/install_gh.sh
+source "$DIR"/install_gh.sh
 
 echo "Installing yq"
 # Remove the existing yq, if it already exists

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -6,8 +6,11 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 CI_DIR="$DIR/../ci"
 LIB_DIR="$DIR/../lib"
 
+# shellcheck source=../lib/logging.sh
+source "${LIB_DIR}/logging.sh"
+
 # Ensure that asdf is ready to be used
-echo "🔨 Setting up asdf"
+info "🔨 Setting up asdf"
 "$CI_DIR/env/asdf.sh"
 
 authn=(
@@ -21,7 +24,7 @@ authn=(
 )
 
 for authName in "${authn[@]}"; do
-  echo "🔒 Setting up $authName access"
+  info "🔒 Setting up $authName access"
   "$CI_DIR/auth/$authName.sh"
 done
 
@@ -30,9 +33,9 @@ if [[ -n $TEST_RESULTS ]]; then
   mkdir -p "$TEST_RESULTS"
 fi
 
-# run prescript if user specified to install packages etc. before tests
+# run pre-script if user specified to install packages etc. before tests
 if [[ -n $PRE_SETUP_SCRIPT ]]; then
-  echo "⚙️ Running setup script \"${PRE_SETUP_SCRIPT}\" (from pre_setup_script)"
+  info "⚙️ Running setup script \"${PRE_SETUP_SCRIPT}\" (from pre_setup_script)"
   # shellcheck source=/dev/null
   "${PRE_SETUP_SCRIPT}"
 fi
@@ -61,7 +64,7 @@ download_box
 echo "$CACHE_VERSION" >cache-version.txt
 
 # Authenticate with AWS ECR now that we have the box config
-echo "🔒 Setting up AWS ECR access"
+info "🔒 Setting up AWS ECR access"
 
 # shellcheck source=../lib/docker.sh
 source "${LIB_DIR}/docker.sh"

--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -36,6 +36,12 @@ get_app_name() {
   "$YQ" -r '.name' <"$(get_service_yaml)"
 }
 
+# get_app_version returns the version of the application
+# from git.
+get_app_version() {
+  git describe --match='v[0-9]+' --tags --always HEAD 2>/dev/null || echo "0.0.0-dev"
+}
+
 # get_tool_version reads a version from .bootstrap/versions.yaml
 # and returns it
 get_tool_version() {

--- a/shell/lib/docker/authn/aws-ecr.sh
+++ b/shell/lib/docker/authn/aws-ecr.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# AWS ECR authentication. Assumes that logging.sh is sourced.
+#
+
+set -eo pipefail
+
+# ecr_auth authenticates with AWS ECR.
+# Arguments:
+#   $1: The ECR registry URL.
+ecr_auth() {
+  registry="$1"
+  # Format: $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+  region="$(echo "$registry" | cut -d. -f4)"
+  info_sub "Authenticating with AWS ECR in $registry"
+  # See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token
+  aws ecr get-login-password --region "$region" | docker login --username AWS --password-stdin "$registry"
+}
+
+# ensure_ecr_repository ensures that an ECR repository exists.
+# Arguments:
+#   $1: The ECR repository URL.
+ensure_ecr_repository() {
+  imageRepository="$1"
+  # AWS ECR requires that the repository be created before pushing to it.
+  # Repo name is the part after the first / in the URL (i.e., ignores the host)
+  ecrRepoName=$(cut --delimiter=/ --fields=2- <<<"$imageRepository")
+  # Format: $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+  ecrRegion="$(echo "$imageRepository" | cut --delimiter=. --fields=4)"
+  if ! aws ecr --region "$ecrRegion" describe-repositories --repository-names "$ecrRepoName"; then
+    info_sub "Creating ECR repository: $imageRepository"
+    aws ecr --region "$ecrRegion" create-repository --repository-name "$ecrRepoName"
+  fi
+}

--- a/shell/lib/docker/authn/gcr.sh
+++ b/shell/lib/docker/authn/gcr.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# GCR authentication. Assumes that logging.sh is sourced.
+#
+
+set -eo pipefail
+
+gcr_auth() {
+  gcloudServiceAccount="$1"
+  if [[ -z $gcloudServiceAccount ]]; then
+    warn "Skipped: gcloudServiceAccount is not set."
+    return
+  fi
+
+  docker login \
+    -u _json_key \
+    --password-stdin \
+    https://gcr.io <<<"${gcloudServiceAccount}"
+}


### PR DESCRIPTION
## What this PR does / why we need it

* Reduce the amount of setup in the `shared/docker_*` jobs by replacing `setup_environment` with the bare minimum setup required to authenticate to Docker image registries (via the `shared/docker_auth` command). This saves about 1m30s in every (successful) CircleCI run. A side effect of this was to avoid running the `mage version` command, which requires installing Go.
* Use both the push and pull registry values from either the environment or the box config to determine which registries need to be authenticated.
* Make sure that the ECR repository exists before pushing to it.

## Jira ID

[DT-4462]


[DT-4462]: https://outreach-io.atlassian.net/browse/DT-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ