### PR TITLE
fix(docker): ensure ssh is set up for private git repos

### DIFF
--- a/orbs/shared/jobs/docker_amd64.yaml
+++ b/orbs/shared/jobs/docker_amd64.yaml
@@ -8,6 +8,7 @@ parameters:
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
+  - add_ssh_keys
   - setup_docker_auth:
       push_registries: << parameters.push_registries >>
   - build_docker_image

--- a/orbs/shared/jobs/docker_arm64.yaml
+++ b/orbs/shared/jobs/docker_arm64.yaml
@@ -8,6 +8,7 @@ parameters:
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
+  - add_ssh_keys
   - setup_docker_auth:
       push_registries: << parameters.push_registries >>
   - build_docker_image:

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -28,6 +28,10 @@ info "🔓 Authenticating to GitHub"
 # In order to get the box config, we need to authenticate with GitHub
 # shellcheck source=../auth/github.sh
 source "${AUTH_DIR}/github.sh"
+# We need to set up SSH to ensure that we can access private
+# repositories when building the Docker images
+# shellcheck source=../auth/ssh.sh
+source "${AUTH_DIR}/ssh.sh"
 
 git config --global --remove-section url."ssh://git@github.com"
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git


### PR DESCRIPTION
## What this PR does / why we need it

This fixes the case where building Docker images can't access Go modules in private repositories.

## Jira ID

[DT-4558]

[DT-4558]: https://outreach-io.atlassian.net/browse/DT-4558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ