### PR TITLE
fix(get_app_version): work as intended, add tests

### DIFF
--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -39,7 +39,7 @@ get_app_name() {
 # get_app_version returns the version of the application
 # from git.
 get_app_version() {
-  git describe --match='v[0-9]+' --tags --always HEAD 2>/dev/null || echo "0.0.0-dev"
+  git describe --match='v[0-9]*' --tags HEAD 2>/dev/null || echo "v0.0.0-dev"
 }
 
 # get_tool_version reads a version from .bootstrap/versions.yaml

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -11,7 +11,7 @@ setup() {
   REPOPATH=$(mktemp -p "$TMPDIR" -d devbase.bootstrapXXXXXXXXXX)
 
   git init --initial-branch=main "$REPOPATH"
-  cd "$REPOPATH"
+  cd "$REPOPATH" || exit 1
   git commit --allow-empty --message "Initial commit"
   git commit --allow-empty --message "Second commit"
   git switch --create username/feat/feature-branch

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -12,6 +12,7 @@ setup() {
 
   git init --initial-branch=main "$REPOPATH"
   cd "$REPOPATH" || exit 1
+  git config user.email "bootstrap@devbase.test"
   git commit --allow-empty --message "Initial commit"
   git commit --allow-empty --message "Second commit"
   git switch --create username/feat/feature-branch

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+bats_load_library "bats-support/load.bash"
+bats_load_library "bats-assert/load.bash"
+
+load bootstrap.sh
+
+setup() {
+  # This points us to use a temp file for a git repo to operate on, as
+  # opposed to the real one.
+  REPOPATH=$(mktemp -p "$TMPDIR" -d devbase.bootstrapXXXXXXXXXX)
+
+  git init --initial-branch=main "$REPOPATH"
+  cd "$REPOPATH"
+  git commit --allow-empty --message "Initial commit"
+  git commit --allow-empty --message "Second commit"
+  git switch --create username/feat/feature-branch
+  git commit --allow-empty --message "feat: empty branch commit"
+}
+
+teardown() {
+  rm -rf "$REPOPATH"
+}
+
+@test "get_app_version without a version tag in git returns the fallback version" {
+  run get_app_version
+  assert_output "v0.0.0-dev"
+}
+
+@test "get_app_version returns the latest version tag" {
+  git switch main
+  git tag v1.0.0
+  run get_app_version
+  assert_output "v1.0.0"
+
+  git commit --allow-empty --message "Third commit"
+  git tag v1.1.0
+  run get_app_version
+  assert_output "v1.1.0"
+}

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -12,6 +12,7 @@ setup() {
 
   git init --initial-branch=main "$REPOPATH"
   cd "$REPOPATH" || exit 1
+  git config user.name "Test User"
   git config user.email "bootstrap@devbase.test"
   git commit --allow-empty --message "Initial commit"
   git commit --allow-empty --message "Second commit"


### PR DESCRIPTION
## What this PR does / why we need it

Porting over the Magefile version of `get_app_version` did not work as intended, and it's unclear why.

* Removed `--always` from `git describe` so that a repo without any tags actually uses the fallback.
* Updated the value passed to `--match` to be a glob instead of a regex, per the docs.
* Minor change: prefix fallback version with `v` for consistency

Also adds tests to show what it's supposed to do.

## Jira ID

[DT-4561]

## Notes for your reviewers

`--always` documentation from `git describe --help`:

```
       --always
           Show uniquely abbreviated commit object as fallback.
```

[DT-4561]: https://outreach-io.atlassian.net/browse/DT-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ