### PR TITLE
fix: upgrade golangci-lint to 1.62.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -14,7 +14,7 @@ nodejs 20.16.0
 ## <<Stencil::Block(toolver)>>
 # The below tools are used by all repositories when using devbase
 mage 1.14.0
-golangci-lint 1.61.0
+golangci-lint 1.62.2
 shellcheck 0.9.0
 shfmt 3.7.0
 goreleaser 1.20.0


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.