### PR TITLE
fix(docker): add tags for all push registries to built containers

### DIFF
--- a/shell/lib/docker.sh
+++ b/shell/lib/docker.sh
@@ -157,10 +157,12 @@ docker_buildx_args() {
     tags+=("$image")
     if [[ -n $arch ]]; then
       local remoteImageName
-      local pullRegistry
-      pullRegistry="$(get_docker_pull_registry)"
-      remoteImageName="$(determine_remote_image_name "$appName" "$pullRegistry" "$image")"
-      tags+=("$remoteImageName:latest-$arch" "$remoteImageName:$version-$arch")
+      local pushRegistries
+      pushRegistries="$(get_docker_push_registries)"
+      for pushRegistry in $pushRegistries; do
+        remoteImageName="$(determine_remote_image_name "$appName" "$pushRegistry" "$image")"
+        tags+=("$remoteImageName:latest-$arch" "$remoteImageName:$CIRCLE_TAG-$arch")
+      done
     fi
   fi
   for tag in "${tags[@]}"; do


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

## Jira ID

[DT-4580]

[DT-4580]: https://outreach-io.atlassian.net/browse/DT-4580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ