### PR TITLE
fix(orb): allow executor_name to be parameterized for shared/save_cache

### DIFF
--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -27,6 +27,11 @@ parameters:
     description: The docker image tag to use for running the test
     type: string
     default: stable
+  executor_name:
+    description: The executor to use for the job
+    type: enum
+    enum: [testbed-docker, testbed-docker-aws]
+    default: "testbed-docker"
   aws_region:
     description: AWS_REGION environment variable to set
     type: string
@@ -42,7 +47,7 @@ parameters:
 resource_class: << parameters.resource_class >>
 
 executor:
-  name: testbed-docker
+  name: << parameters.executor_name >>
   docker_image: << parameters.docker_image >>
   docker_tag: << parameters.docker_tag >>
 


### PR DESCRIPTION
## What this PR does / why we need it

This gives us consistency with the `shared/test` job.

## Jira ID

[DT-4466]

[DT-4466]: https://outreach-io.atlassian.net/browse/DT-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ