### PR TITLE
fix: use mise to install gh/gojq for docker jobs

### DIFF
--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -11,7 +11,6 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 AUTH_DIR="${DIR}/../auth"
-CIRCLECI_DIR="${DIR}/../../circleci"
 LIB_DIR="${DIR}/../../lib"
 DOCKER_AUTH_DIR="${LIB_DIR}/docker/authn"
 ROOT_DIR="${DIR}/../../.."
@@ -19,13 +18,17 @@ ROOT_DIR="${DIR}/../../.."
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+source "${LIB_DIR}/mise.sh"
+
+tool_version() {
+  local tool="$1"
+  grep "^$tool:" "$ROOT_DIR"/versions.yaml | awk '{print $2}'
+}
+
 info "Ensuring that 'gh' is installed"
 
-# shellcheck source=../../circleci/install_gh.sh
-source "${CIRCLECI_DIR}/install_gh.sh"
-
-gojq_version="$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
-mise use --global "gojq@$gojq_version"
+install_tool_with_mise gh "$(tool_version gh)"
+install_tool_with_mise gojq "$(tool_version gojq)"
 
 info "🔓 Authenticating to GitHub"
 

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -21,8 +21,8 @@ source "${LIB_DIR}/logging.sh"
 
 info "Ensuring that 'gh' is installed"
 
-# shellcheck source=../../circleci/setup-docker-authn.sh
-source "${CIRCLECI_DIR}/setup-docker-authn.sh"
+# shellcheck source=../../circleci/install_gh.sh
+source "${CIRCLECI_DIR}/install_gh.sh"
 
 gojq_version="$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
 mise install --global "gojq@$gojq_version"

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -27,6 +27,8 @@ source "${CIRCLECI_DIR}/install_gh.sh"
 gojq_version="$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
 mise use --global "gojq@$gojq_version"
 
+mise reshim
+
 info "🔓 Authenticating to GitHub"
 
 # In order to get the box config, we need to authenticate with GitHub

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -14,14 +14,18 @@ AUTH_DIR="${DIR}/../auth"
 CIRCLECI_DIR="${DIR}/../../circleci"
 LIB_DIR="${DIR}/../../lib"
 DOCKER_AUTH_DIR="${LIB_DIR}/docker/authn"
+ROOT_DIR="${DIR}/../../.."
 
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
 info "Ensuring that 'gh' is installed"
 
-# shellcheck source=../../circleci/install_gh.sh
-source "${CIRCLECI_DIR}/install_gh.sh"
+# shellcheck source=../../circleci/setup-docker-authn.sh
+source "${CIRCLECI_DIR}/setup-docker-authn.sh"
+
+gojq_version="$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
+mise install --global "gojq@$gojq_version"
 
 info "🔓 Authenticating to GitHub"
 

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -25,7 +25,7 @@ info "Ensuring that 'gh' is installed"
 source "${CIRCLECI_DIR}/install_gh.sh"
 
 gojq_version="$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
-mise install --global "gojq@$gojq_version"
+mise use --global "gojq@$gojq_version"
 
 info "🔓 Authenticating to GitHub"
 

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -27,8 +27,6 @@ source "${CIRCLECI_DIR}/install_gh.sh"
 gojq_version="$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
 mise use --global "gojq@$gojq_version"
 
-mise reshim
-
 info "🔓 Authenticating to GitHub"
 
 # In order to get the box config, we need to authenticate with GitHub

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -18,6 +18,7 @@ ROOT_DIR="${DIR}/../../.."
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+# shellcheck source=../../lib/mise.sh
 source "${LIB_DIR}/mise.sh"
 
 tool_version() {

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -18,8 +18,13 @@ if ! command -v mise >/dev/null; then
   export PATH="$PATH:$HOME/.local/bin"
 
   # shellcheck disable=SC2016
-  # Why: Appending a shell command to BASH_ENV
-  echo 'eval "$(mise activate bash --shims)"' >>"$BASH_ENV"
+  # Why: Appending a PATH to BASH_ENV
+  {
+    echo 'export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none'
+    echo 'export PATH="$PATH:$HOME/.local/bin"'
+    echo 'eval "$(mise activate bash --shims)"'
+  } >>"$BASH_ENV"
+
   eval "$(mise activate bash --shims)"
 fi
 

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -4,28 +4,15 @@
 
 set -e
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="${DIR}/../lib"
+
 # GH_VERSION is the version of gh to install.
 export GH_VERSION=2.62.0
 
-if ! command -v mise >/dev/null; then
-  # Install mise
-  gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0x7413A06D
-  curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt >/tmp/mise-install.sh
-  # ensure the above is signed with the mise release key
-  sh /tmp/mise-install.sh
+# shellcheck source=../lib/mise.sh
+source "$LIB_DIR/mise.sh"
 
-  export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none
-  export PATH="$PATH:$HOME/.local/bin"
-
-  # shellcheck disable=SC2016
-  # Why: Appending a PATH to BASH_ENV
-  {
-    echo 'export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none'
-    echo 'export PATH="$PATH:$HOME/.local/bin"'
-    echo 'eval "$(mise activate bash --shims)"'
-  } >>"$BASH_ENV"
-
-  eval "$(mise activate bash --shims)"
-fi
+ensure_mise_installed
 
 mise use --global "gh@$GH_VERSION"

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -20,7 +20,7 @@ GH_VERSION="$(grep ^gh: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
 if ! command -v gh >/dev/null; then
   echo "Installing gh"
 
-  wget -O gh.deb https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb
+  wget -O gh.deb "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb"
   sudo apt-get install --assume-yes --fix-broken ./gh.deb
   rm ./gh.deb
 fi

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -14,6 +14,8 @@ if ! command -v mise >/dev/null; then
   # ensure the above is signed with the mise release key
   sh /tmp/mise-install.sh
 
+  export PATH="$PATH:$HOME/.local/bin"
+
   # shellcheck disable=SC2016
   # Why: Appending a shell command to .bashrc
   echo 'eval "$(mise activate bash)"' >>~/.bashrc

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -4,15 +4,23 @@
 
 set -e
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-LIB_DIR="${DIR}/../lib"
+ROOT_DIR="$DIR/../.."
+
+# ARCH is the current architecture of the machine. Valid values are:
+#   - amd64
+#   - arm64
+ARCH="amd64"
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  ARCH="arm64"
+fi
 
 # GH_VERSION is the version of gh to install.
-export GH_VERSION=2.62.0
+GH_VERSION="$(grep ^gh: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
 
-# shellcheck source=../lib/mise.sh
-source "$LIB_DIR/mise.sh"
+if ! command -v gh >/dev/null; then
+  echo "Installing gh"
 
-ensure_mise_installed
-
-mise use --global "gh@$GH_VERSION"
+  wget -O gh.deb https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb
+  sudo apt-get install --assume-yes --fix-broken ./gh.deb
+  rm ./gh.deb
+fi

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -19,8 +19,8 @@ if ! command -v mise >/dev/null; then
 
   # shellcheck disable=SC2016
   # Why: Appending a shell command to .bashrc
-  echo 'eval "$(mise activate bash)"' >>~/.bashrc
-  eval "$(mise activate bash)"
+  echo 'eval "$(mise activate bash --shims)"' >>~/.bashrc
+  eval "$(mise activate bash --shims)"
 fi
 
 mise use --global "gh@$GH_VERSION"

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -18,8 +18,8 @@ if ! command -v mise >/dev/null; then
   export PATH="$PATH:$HOME/.local/bin"
 
   # shellcheck disable=SC2016
-  # Why: Appending a shell command to .bashrc
-  echo 'eval "$(mise activate bash --shims)"' >>~/.bashrc
+  # Why: Appending a shell command to BASH_ENV
+  echo 'eval "$(mise activate bash --shims)"' >>"$BASH_ENV"
   eval "$(mise activate bash --shims)"
 fi
 

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -14,6 +14,7 @@ if ! command -v mise >/dev/null; then
   # ensure the above is signed with the mise release key
   sh /tmp/mise-install.sh
 
+  export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none
   export PATH="$PATH:$HOME/.local/bin"
 
   # shellcheck disable=SC2016

--- a/shell/circleci/install_gh.sh
+++ b/shell/circleci/install_gh.sh
@@ -4,21 +4,20 @@
 
 set -e
 
-# ARCH is the current architecture of the machine. Valid values are:
-#   - amd64
-#   - arm64
-ARCH="amd64"
-if [[ "$(uname -m)" == "aarch64" ]]; then
-  ARCH="arm64"
-fi
-
 # GH_VERSION is the version of gh to install.
 export GH_VERSION=2.62.0
 
-if ! command -v gh >/dev/null; then
-  echo "Installing gh"
+if ! command -v mise >/dev/null; then
+  # Install mise
+  gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0x7413A06D
+  curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt >/tmp/mise-install.sh
+  # ensure the above is signed with the mise release key
+  sh /tmp/mise-install.sh
 
-  wget -O gh.deb https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb
-  sudo apt-get install --assume-yes --fix-broken ./gh.deb
-  rm ./gh.deb
+  # shellcheck disable=SC2016
+  # Why: Appending a shell command to .bashrc
+  echo 'eval "$(mise activate bash)"' >>~/.bashrc
+  eval "$(mise activate bash)"
 fi
+
+mise use --global "gh@$GH_VERSION"

--- a/shell/gobin.sh
+++ b/shell/gobin.sh
@@ -3,7 +3,7 @@
 # Run a golang binary using gobin
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-GOBIN_VERSION=1.11.5
+GOBIN_VERSION=1.11.12
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 

--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -9,6 +9,23 @@ source "$LIB_DIR/asdf.sh"
 # shellcheck source=logging.sh
 source "$LIB_DIR/logging.sh"
 
+ghCmd=""
+
+run_gh() {
+  if [[ -z $ghCmd ]]; then
+    ghCmd="$(command -v gh)"
+    if [[ -z $ghCmd ]]; then
+      if ! command -v mise >/dev/null; then
+        echo "Error: gh and mise not found (run_gh)" >&2
+        return 1
+      fi
+      ghCmd="$(mise which gh)"
+    fi
+  fi
+
+  "$ghCmd" "$@"
+}
+
 # install_latest_github_release downloads the latest version of a tool
 # from Github. Requires the 'gh' cli to be installed.
 #
@@ -30,7 +47,7 @@ install_latest_github_release() {
 
   # Ensure that the gh CLI is installed and accessible.
   if ! command -v gh &>/dev/null; then
-    echo "Error: gh cli not found (install_github_release)" >&2
+    echo "Error: gh cli not found (install_latest_github_release)" >&2
     return 1
   fi
 

--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -27,7 +27,7 @@ run_gh() {
 }
 
 # install_latest_github_release downloads the latest version of a tool
-# from Github. Requires the 'gh' cli to be installed.
+# from Github. Requires the 'gh' cli to be installed either directly or via mise.
 #
 # $1: The slug of the repo to download from. This is the same as the
 #     repo name, e.g. "github/hub".
@@ -45,20 +45,14 @@ install_latest_github_release() {
   local binary_name=${3:-$(basename "$slug")}
   local install_dir=${4:-/usr/local/bin}
 
-  # Ensure that the gh CLI is installed and accessible.
-  if ! command -v gh &>/dev/null; then
-    echo "Error: gh cli not found (install_latest_github_release)" >&2
-    return 1
-  fi
-
   if [[ $use_pre_releases == "true" ]]; then
     # shellcheck disable=SC2155 # Why: We're OK with this being
     # potentially masked.
-    local tag=$(gh release -R "$slug" list --exclude-drafts | grep Pre-release | head -n1 | awk '{ print $1 }')
+    local tag=$(run_gh release -R "$slug" list --exclude-drafts | grep Pre-release | head -n1 | awk '{ print $1 }')
   else
     # shellcheck disable=SC2155 # Why: We're OK with this being
     # potentially masked.
-    local tag=$(gh release -R "$slug" list --exclude-drafts | grep -v Pre-release | head -n1 | awk '{ print $1 }')
+    local tag=$(run_gh release -R "$slug" list --exclude-drafts | grep -v Pre-release | head -n1 | awk '{ print $1 }')
   fi
 
   # If we have an empty tag, something went wrong. Fail.
@@ -92,7 +86,7 @@ install_latest_github_release() {
   local pattern="${repoName}_*_${GOOS}_$GOARCH.tar.gz"
 
   # Download the release through the Github CLI.
-  gh release -R "$slug" download "$tag" --pattern "$pattern"
+  run_gh release -R "$slug" download "$tag" --pattern "$pattern"
 
   echo "" # Fixes issues with output being corrupted in CI
   tar xf "${repoName}"**.tar.*

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+#
+# mise related functions. Assumes logging.sh is sourced.
 
 # Installs `mise` if it isn't already found in PATH
 ensure_mise_installed() {
@@ -20,5 +22,23 @@ ensure_mise_installed() {
     } >>"$BASH_ENV"
 
     eval "$(mise activate bash --shims)"
+  fi
+}
+
+install_tool_with_mise() {
+  local tool
+  local name="$1"
+  local version="$2"
+
+  if [[ -n $version ]]; then
+    tool="$name@$version"
+  else
+    tool="$name"
+  fi
+
+  ensure_mise_installed
+
+  if ! mise use --global "$tool"; then
+    fatal "Error: failed to install $tool via mise" >&2
   fi
 }

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -7,16 +7,15 @@ ensure_mise_installed() {
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0x7413A06D
     curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt >/tmp/mise-install.sh
     # ensure the above is signed with the mise release key
-    MISE_INSTALL_PATH=/usr/local/bin/mise sh /tmp/mise-install.sh
+    sh /tmp/mise-install.sh
+    sudo mv ~/.local/bin/mise /usr/local/bin/
 
     export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none
-    export PATH="$PATH:$HOME/.local/bin"
 
     # shellcheck disable=SC2016
     # Why: Appending a PATH to BASH_ENV
     {
       echo 'export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none'
-      echo 'export PATH="$PATH:$HOME/.local/bin"'
       echo 'eval "$(mise activate bash --shims)"'
     } >>"$BASH_ENV"
 

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Installs `mise` if it isn't already found in PATH
+ensure_mise_installed() {
+  if ! command -v mise >/dev/null; then
+    # Install mise
+    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0x7413A06D
+    curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt >/tmp/mise-install.sh
+    # ensure the above is signed with the mise release key
+    MISE_INSTALL_PATH=/usr/local/bin/mise sh /tmp/mise-install.sh
+
+    export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none
+    export PATH="$PATH:$HOME/.local/bin"
+
+    # shellcheck disable=SC2016
+    # Why: Appending a PATH to BASH_ENV
+    {
+      echo 'export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none'
+      echo 'export PATH="$PATH:$HOME/.local/bin"'
+      echo 'eval "$(mise activate bash --shims)"'
+    } >>"$BASH_ENV"
+
+    eval "$(mise activate bash --shims)"
+  fi
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,6 +7,7 @@ lintroller: 1.18.1
 goveralls: 0.0.11
 getoutreach/ci: v1.3.0
 getoutreach/logfmt: v1.1.0
+gh: 2.62.0
 ## Sync with templates/scripts/devbase.sh.tpl
 gojq: v0.12.16
 


### PR DESCRIPTION
## What this PR does / why we need it

This should avoid some weirdness with using `gobin` for `gojq`.

## Jira ID

[DT-4593]


[DT-4593]: https://outreach-io.atlassian.net/browse/DT-4593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ