### PR TITLE
fix: upgrade delve to a version with Go 1.23 support

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,7 +1,7 @@
 grpcui: 1.3.1
 jsonnetfmt: 0.19.1
 goimports: 0.5.0
-delve: 1.22.1
+delve: 1.24.0
 gotestsum: 1.10.1
 lintroller: 1.18.1
 goveralls: 0.0.11


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

## Jira ID

[DT-4599]

[DT-4599]: https://outreach-io.atlassian.net/browse/DT-4599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ