### PR TITLE
fix(orb): all docker auth commands require ssh keys

### DIFF
--- a/orbs/shared/commands/setup_docker_auth.yml
+++ b/orbs/shared/commands/setup_docker_auth.yml
@@ -9,6 +9,7 @@ parameters:
     description: Space-separated list of container registries to push to.
     default: ""
 steps:
+  - add_ssh_keys
   - checkout
   - run:
       name: Update submodules

--- a/orbs/shared/jobs/docker_amd64.yaml
+++ b/orbs/shared/jobs/docker_amd64.yaml
@@ -8,7 +8,6 @@ parameters:
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
-  - add_ssh_keys
   - setup_docker_auth:
       push_registries: << parameters.push_registries >>
   - build_docker_image

--- a/orbs/shared/jobs/docker_arm64.yaml
+++ b/orbs/shared/jobs/docker_arm64.yaml
@@ -8,7 +8,6 @@ parameters:
     description: Space-separated list of registries to push the Docker image to.
     default: ""
 steps:
-  - add_ssh_keys
   - setup_docker_auth:
       push_registries: << parameters.push_registries >>
   - build_docker_image:


### PR DESCRIPTION
## What this PR does / why we need it

Apparently certain repos with git submodules require that ssh keys be used in the `docker_stitch` job, so just add it to the `setup_docker_auth` command and deduplicate the step.

## Jira ID

[DT-4610]

[DT-4610]: https://outreach-io.atlassian.net/browse/DT-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ