### PR TITLE
feat: replace gcr.io links with ecr link

### DIFF
--- a/orbs/shared/executors/testbed-docker.yml
+++ b/orbs/shared/executors/testbed-docker.yml
@@ -5,7 +5,7 @@ parameters:
     default: stable
   docker_image:
     type: string
-    default: gcr.io/outreach-docker/bootstrap/ci-slim
+    default: 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/bootstrap/ci-slim
 docker:
   - image: << parameters.docker_image >>:<< parameters.docker_tag >>
     auth:

--- a/orbs/shared/jobs/merge.yaml
+++ b/orbs/shared/jobs/merge.yaml
@@ -2,7 +2,7 @@ description: Merges the base (to merge into) branch into the head (current) bran
 executor:
   name: testbed-docker
 docker:
-  - image: gcr.io/outreach-docker/bootstrap/ci-slim:stable
+  - image: 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/bootstrap/ci-slim:stable
     auth:
       username: _json_key
       password: $GCLOUD_SERVICE_ACCOUNT

--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -22,7 +22,7 @@ parameters:
   docker_image:
     description: The docker image to use for running the test
     type: string
-    default: gcr.io/outreach-docker/bootstrap/ci-slim
+    default: 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/bootstrap/ci-slim
   docker_tag:
     description: The docker image tag to use for running the test
     type: string

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -26,7 +26,7 @@ parameters:
   docker_image:
     description: The docker image to use for running the test
     type: string
-    default: gcr.io/outreach-docker/bootstrap/ci-slim
+    default: 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/bootstrap/ci-slim
   docker_tag:
     description: The docker image tag to use for running the test
     type: string

--- a/root/Makefile
+++ b/root/Makefile
@@ -58,7 +58,7 @@ E2E_ENVIRONMENT     ?= development
 OSS                 ?= false
 
 # Docker build
-BASE_IMAGE          ?= gcr.io/outreach-docker/$(APP)
+BASE_IMAGE          ?= 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/$(APP)
 DOCKERFILE          ?= deployments/$(APP)/Dockerfile
 
 .PHONY: default

--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -18,7 +18,7 @@ version="${DEVENV_DEPLOY_VERSION:-"latest"}"
 environment="${DEVENV_DEPLOY_ENVIRONMENT:-"development"}"
 host="${DEVENV_DEPLOY_HOST:-"bento1a.outreach-dev.com"}"
 email="${DEV_EMAIL:-$(git config user.email)}"
-appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"gcr.io/outreach-docker"}"
+appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker"}"
 
 kubecfg \
   --jurl http://k8s-clusters.outreach.cloud/ \


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Giraffe deployment [is not working](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1742239257335989). I believe this is because the devbase local deployment scripts are using `gcr.io` as the image registry. Giraffe (and likely other services have already switched to use ecr so the images are not available on ecr.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
