### PR TITLE
fix: remove most of the remaining hardcoded GCR references

### DIFF
--- a/orbs/shared/jobs/merge.yaml
+++ b/orbs/shared/jobs/merge.yaml
@@ -1,11 +1,4 @@
 description: Merges the base (to merge into) branch into the head (current) branch and pushes the result
-executor:
-  name: testbed-docker
-docker:
-  - image: gcr.io/outreach-docker/bootstrap/ci-slim:stable
-    auth:
-      username: _json_key
-      password: $GCLOUD_SERVICE_ACCOUNT
 parameters:
   head:
     description: The current branch, this will have base merged into it. This is only supplied to ensure we're on the correct branch when merging.
@@ -17,6 +10,22 @@ parameters:
     description: Whether to push the to the remote the results of the merge
     type: boolean
     default: true
+  docker_image:
+    description: The docker image to use for running the test
+    type: string
+  docker_tag:
+    description: The docker image tag to use for running the test
+    type: string
+    default: stable
+  executor_name:
+    description: The executor to use for the job
+    type: enum
+    enum: [testbed-docker, testbed-docker-aws]
+    default: "testbed-docker"
+executor:
+  name: << parameters.executor_name >>
+  docker_image: << parameters.docker_image >>
+  docker_tag: << parameters.docker_tag >>
 steps:
   - setup_environment
   - run:

--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -22,7 +22,6 @@ parameters:
   docker_image:
     description: The docker image to use for running the test
     type: string
-    default: gcr.io/outreach-docker/bootstrap/ci-slim
   docker_tag:
     description: The docker image tag to use for running the test
     type: string

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -26,7 +26,6 @@ parameters:
   docker_image:
     description: The docker image to use for running the test
     type: string
-    default: gcr.io/outreach-docker/bootstrap/ci-slim
   docker_tag:
     description: The docker image tag to use for running the test
     type: string

--- a/root/Makefile
+++ b/root/Makefile
@@ -58,7 +58,6 @@ E2E_ENVIRONMENT     ?= development
 OSS                 ?= false
 
 # Docker build
-BASE_IMAGE          ?= gcr.io/outreach-docker/$(APP)
 DOCKERFILE          ?= deployments/$(APP)/Dockerfile
 
 .PHONY: default

--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -5,6 +5,9 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/bootstrap.sh
 source "$SCRIPTS_DIR/lib/bootstrap.sh"
 
+# shellcheck source=./lib/docker.sh
+source "$SCRIPTS_DIR/lib/docker.sh"
+
 # shellcheck source=./lib/logging.sh
 source "$SCRIPTS_DIR/lib/logging.sh"
 
@@ -18,7 +21,7 @@ version="${DEVENV_DEPLOY_VERSION:-"latest"}"
 environment="${DEVENV_DEPLOY_ENVIRONMENT:-"development"}"
 host="${DEVENV_DEPLOY_HOST:-"bento1a.outreach-dev.com"}"
 email="${DEV_EMAIL:-$(git config user.email)}"
-appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"gcr.io/outreach-docker"}"
+appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"$(get_docker_pull_registry)"}"
 
 kubecfg \
   --jurl http://k8s-clusters.outreach.cloud/ \


### PR DESCRIPTION
## What this PR does / why we need it

* Replaces the hardcoded default in `shell/build-jsonnet.sh` with fetching the box value
* Removes the default image value from a bunch of jobs. (All Outreach CircleCI configs should be specifying the docker image URL via Stencil anyway.)
* Removes an unused `Makefile` variable
* Adds an executor config to a job which I'm pretty sure is unused, but I don't want to remove just yet. I'm changing it because I don't want others to think it *needs* to be changed just because it had a hardcoded reference in it.

## Jira ID

[DT-4466]

## Notes for your reviewers

Replaces / closes #879.

The remaining references are either for GCR authentication, or a default in the `shared/testbed-docker` executor which is fine to keep as a default. If they need to use some non-AWS registry, that's the executor to use and they can just specify `docker_image` appropriately in their CircleCI config. If they need to use an AWS (ECR) registry, they can't use that executor anyway (that's what `shared/testbed-docker-aws` is for).

[DT-4466]: https://outreach-io.atlassian.net/browse/DT-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ