### PR TITLE
ci: use shared orb version 2.31.0-rc.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@dev:first
+  shared: getoutreach/shared@dev:2.31.0-rc.1
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 


### PR DESCRIPTION
## What this PR does / why we need it

Follow-up from https://github.com/getoutreach/devbase/pull/885#discussion_r2025822408


## Jira ID

[DT-4711]

[DT-4711]: https://outreach-io.atlassian.net/browse/DT-4711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ