### PR TITLE
fix(orb): release job sometimes needs a machine executor

### DIFF
--- a/orbs/shared/jobs/release.yaml
+++ b/orbs/shared/jobs/release.yaml
@@ -20,11 +20,10 @@ parameters:
     description: The slack channel to notify if the release fails
     type: string
     default: ""
-  executor_name:
+  executor:
     description: The executor to use for the job
-    type: enum
-    enum: [testbed-docker, testbed-docker-aws]
-    default: "testbed-docker-aws"
+    type: executor
+    default: testbed-docker-aws
   docker_image:
     description: The docker image to use for running the test
     type: string
@@ -38,10 +37,7 @@ parameters:
     type: string
     default: 10m
 resource_class: << parameters.resource_class >>
-executor:
-  name: << parameters.executor_name >>
-  docker_image: << parameters.docker_image >>
-  docker_tag: << parameters.docker_tag >>
+executor: << parameters.executor >>
 steps:
   - setup_environment:
       machine: << parameters.machine >>


### PR DESCRIPTION
## What this PR does / why we need it

This is a regression introduced in the latest RC. As an example, the `actions` repository needs this functionality.

## Jira ID

[DT-4707]