### PR TITLE
fix(orb): double the default no output timeout for E2E jobs to 20m

### DIFF
--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -19,7 +19,7 @@ parameters:
   no_output_timeout:
     description: The timeout that gets applied when CircleCI receives no output during the running of e2e tests.
     type: string
-    default: 10m
+    default: 20m
   go_test_timeout:
     description: Maps to gotest -timeout parameter.
     type: string


### PR DESCRIPTION
## What this PR does / why we need it

The default devenv snapshot currently takes about 14 minutes to restore (without any output). Double the default from 10m to 20m to have some breathing room, before we have to increase it again.