### PR TITLE
fix(linters): allow prettier to be installed via `mise` instead of `package.json`

### DIFF
--- a/shell/languages/nodejs.sh
+++ b/shell/languages/nodejs.sh
@@ -7,6 +7,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../lib/she
 yarn_install_if_needed() {
   local stateFile="node_modules/devbase.lock"
 
+  if [[ ! -e "package.json" ]]; then
+    echo "No package.json found, skipping yarn install"
+    return
+  fi
+
   if ! yarn -v >/dev/null 2>&1; then
     npm install -g yarn
   fi

--- a/shell/languages/nodejs.sh
+++ b/shell/languages/nodejs.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Helpers for node.js
 
+# shellcheck source=../lib/logging.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../lib/logging.sh"
+
 # shellcheck source=../lib/shell.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../lib/shell.sh"
 
@@ -8,7 +11,7 @@ yarn_install_if_needed() {
   local stateFile="node_modules/devbase.lock"
 
   if [[ ! -e "package.json" ]]; then
-    echo "No package.json found, skipping yarn install"
+    warn "No package.json found, skipping yarn install"
     return
   fi
 

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -10,6 +10,13 @@ source "$DIR/languages/nodejs.sh"
 extensions=(yaml yml json md ts)
 
 PRETTIER="node_modules/.bin/prettier"
+if [[ ! -f "$PRETTIER" ]]; then
+  # Try to find prettier installed via mise
+  PRETTIER="$(mise which prettier)"
+  if [[ -z $PRETTIER ]]; then
+    fatal "prettier not found in repo"
+  fi
+fi
 
 prettier_log_level_flag() {
   if [[ $("$PRETTIER" --version) =~ ^2 ]]; then

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -10,7 +10,7 @@ source "$DIR/languages/nodejs.sh"
 extensions=(yaml yml json md ts)
 
 PRETTIER="node_modules/.bin/prettier"
-if [[ ! -f "$PRETTIER" ]] && [[ ! -f package.json ]]; then
+if [[ ! -f $PRETTIER ]] && [[ ! -f package.json ]]; then
   # Try to find prettier installed via mise
   PRETTIER="$(mise which prettier)"
   if [[ -z $PRETTIER ]]; then

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -10,7 +10,7 @@ source "$DIR/languages/nodejs.sh"
 extensions=(yaml yml json md ts)
 
 PRETTIER="node_modules/.bin/prettier"
-if [[ ! -f "$PRETTIER" ]]; then
+if [[ ! -f "$PRETTIER" ]] && [[ ! -f package.json ]]; then
   # Try to find prettier installed via mise
   PRETTIER="$(mise which prettier)"
   if [[ -z $PRETTIER ]]; then


### PR DESCRIPTION
## What this PR does / why we need it

This is for internal Stenciled non-service repos which don't need to use `stencil-base` (which provides `prettier` in its templated `package.json`). Instead, it assumes that the repo has installed it via `mise`.