### PR TITLE
fix(orb): add restore and provision timeout parameters to E2E job

### DIFF
--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -27,7 +27,7 @@ parameters:
   provision_timeout:
     description: The timeout for completing a devenv provision, post-snapshot restore.
     type: string
-    default: 30m
+    default: 20m
   snapshot_restore_timeout:
     description: The timeout for restoring a devenv snapshot.
     type: string

--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -24,6 +24,14 @@ parameters:
     description: Maps to gotest -timeout parameter.
     type: string
     default: ""
+  provision_timeout:
+    description: The timeout for completing a devenv provision, post-snapshot restore.
+    type: string
+    default: 30m
+  snapshot_restore_timeout:
+    description: The timeout for restoring a devenv snapshot.
+    type: string
+    default: 30m
   use_devspace:
     description: Use devspace to run e2e tests inside of k8s cluster. No devconfig or localizer needed.
     type: boolean
@@ -39,6 +47,8 @@ environment:
   DEVENV_PRE_RELEASE: << parameters.devenv_pre_release >>
   GO_TEST_TIMEOUT: << parameters.go_test_timeout >>
   PROVISION_TARGET: << parameters.provision_target >>
+  PROVISION_TIMEOUT: << parameters.provision_timeout >>
+  RESTORE_TIMEOUT: << parameters.snapshot_restore_timeout >>
   USE_DEVSPACE: << parameters.use_devspace >>
   TEST_FLAGS: << parameters.test_flags >>
 resource_class: << parameters.resource_class >>


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

## Jira ID

[DT-4759]

[DT-4759]: https://outreach-io.atlassian.net/browse/DT-4759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ