### PR TITLE
fix(yq): add support for finding gojq/yq via mise

### DIFF
--- a/shell/ci/env/asdf.sh
+++ b/shell/ci/env/asdf.sh
@@ -44,12 +44,21 @@ init_asdf() {
 }
 
 set_default_packages() {
+  local protoc_go_version protoc_doc_version
+  protoc_go_version="$(get_tool_version protoc-gen-go)"
+  protoc_doc_version="$(get_tool_version protoc-gen-doc)"
+  if [[ -z $protoc_go_version ]]; then
+    fatal "protoc-gen-go version not found"
+  fi
+  if [[ -z $protoc_doc_version ]]; then
+    fatal "protoc-gen-doc version not found"
+  fi
   # language specifics
   echo -e "yarn" >"$HOME/.default-npm-packages"
   echo -e "bundler 2.2.17" >"$HOME/.default-gems"
   cat >"$HOME/.default-golang-pkgs" <<EOF
-github.com/golang/protobuf/protoc-gen-go@v$(get_tool_version protoc-gen-go)
-github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v$(get_tool_version protoc-gen-doc)
+github.com/golang/protobuf/protoc-gen-go@v$protoc_go_version
+github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v$protoc_doc_version
 EOF
 }
 

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -25,6 +25,11 @@ install_tool_with_mise uv
 mise config set settings.pipx.uvx true
 install_tool_with_mise pipx:yq
 
+# Install gojq as that's preferred over yq
+if ! command -v gojq >/dev/null 2>&1; then
+  install_tool_with_mise gojq "$(grep ^gojq: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
+fi
+
 if ! command -v vault >/dev/null 2>&1; then
   install_tool_with_mise vault
   sudo rm -rf /opt/vault

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -107,3 +107,16 @@ mise_tool_config_set() {
     mise config set --file="$config_file" "$config_key" "$value"
   done
 }
+
+# find_mise returns the path to the mise binary if it is installed.
+find_mise() {
+  if command -v mise >/dev/null 2>&1; then
+    command -v mise
+  elif [[ -x $HOME/.local/bin/mise ]]; then
+    echo "$HOME/.local/bin/mise"
+  elif [[ -x /usr/local/bin/mise ]]; then
+    echo "/usr/local/bin/mise"
+  else
+    return 1
+  fi
+}

--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -16,12 +16,14 @@ source "${LIB_DIR}/mise.sh"
 
 find_bin() {
   local bin_name="$1"
-  local mise_path
   if command -v "$bin_name" >/dev/null 2>&1; then
     command -v "$bin_name"
   else
+    local mise_path
     mise_path="$(find_mise)"
-    "$mise_path" which "$bin_name"
+    if "$mise_path" which "$bin_name" >/dev/null 2>&1; then
+      "$mise_path" which "$bin_name"
+    fi
   fi
 }
 

--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -6,8 +6,18 @@
 
 set -euo pipefail
 
-if command -v gojq >/dev/null 2>&1; then
-  gojq --yaml-input "$@"
+find_gojq() {
+  local
+  if command -v gojq >/dev/null 2>&1; then
+    command -v gojq
+  else
+    mise which gojq
+  fi
+}
+
+gojq_path="$(find_gojq)"
+if [[ -n $gojq_path ]]; then
+  "$gojq_path" --yaml-input "$@"
 else
   yq "$@"
 fi

--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -6,18 +6,28 @@
 
 set -euo pipefail
 
-find_gojq() {
-  local
-  if command -v gojq >/dev/null 2>&1; then
-    command -v gojq
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="${DIR}/lib"
+
+# shellcheck source=./lib/logging.sh
+source "${LIB_DIR}/logging.sh"
+# shellcheck source=./lib/mise.sh
+source "${LIB_DIR}/mise.sh"
+
+find_bin() {
+  local bin_name="$1"
+  local mise_path
+  if command -v "$bin_name" >/dev/null 2>&1; then
+    command -v "$bin_name"
   else
-    mise which gojq
+    mise_path="$(find_mise)"
+    "$mise_path" which "$bin_name"
   fi
 }
 
-gojq_path="$(find_gojq)"
+gojq_path="$(find_bin gojq)"
 if [[ -n $gojq_path ]]; then
   "$gojq_path" --yaml-input "$@"
 else
-  yq "$@"
+  "$(find_bin yq)" "$@"
 fi

--- a/shell/yq.sh
+++ b/shell/yq.sh
@@ -14,6 +14,8 @@ source "${LIB_DIR}/logging.sh"
 # shellcheck source=./lib/mise.sh
 source "${LIB_DIR}/mise.sh"
 
+# find_bin looks for a binary in the PATH or in the mise environment.
+# If found, returns the path to the binary.
 find_bin() {
   local bin_name="$1"
   if command -v "$bin_name" >/dev/null 2>&1; then

--- a/templates/scripts/devbase.sh.tpl
+++ b/templates/scripts/devbase.sh.tpl
@@ -7,7 +7,7 @@ libDir="$DIR/../.bootstrap"
 lockfile="$DIR/../stencil.lock"
 serviceYaml="$DIR/../service.yaml"
 {{- /* This needs to be synced with versions.yaml since the template can't read that file. */}}
-gojqVersion="v0.12.16"
+gojqVersion="v0.12.17"
 
 # get_absolute_path returns the absolute path of a file
 get_absolute_path() {

--- a/versions.yaml
+++ b/versions.yaml
@@ -9,7 +9,7 @@ getoutreach/ci: v1.3.0
 getoutreach/logfmt: v1.1.0
 gh: 2.62.0
 ## Sync with templates/scripts/devbase.sh.tpl
-gojq: v0.12.16
+gojq: v0.12.17
 
 # protobuf formatters/plugins/tools/etc
 buf: 1.8.0 # formatter


### PR DESCRIPTION
## What this PR does / why we need it

When running `circleci/machine.sh` in a `Dockerfile`, make sure that other devbase scripts that are called can find `mise`, `gojq` and/or `yq`, regardless of how they're installed.

Also, upgrade `gojq` to the latest version.

## Notes for your reviewers

The `ci/env/asdf.sh` change is to have CI break if it can't find the protoc versions from `versions.yaml` for whatever reason.