### PR TITLE
fix(ci): use ghaccesstoken via mise instead of gobin

### DIFF
--- a/shell/ci/auth/github.sh
+++ b/shell/ci/auth/github.sh
@@ -2,15 +2,20 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SHELL_DIR="$DIR/../.."
 LIB_DIR="${DIR}/../../lib"
 
 # shellcheck source=../../lib/bootstrap.sh
 source "${LIB_DIR}/bootstrap.sh"
 
+# shellcheck source=../../lib/mise.sh
+source "$LIB_DIR/mise.sh"
+
 # Fetch the token from ghaccesstoken if not set.
 if [[ -z $GITHUB_TOKEN ]]; then
-  GITHUB_TOKEN=$("$SHELL_DIR/gobin.sh" "github.com/getoutreach/ci/cmd/ghaccesstoken@$(get_tool_version "getoutreach/ci")" --skip-update token)
+  ghaccesstoken_version="$(get_tool_version getoutreach/ci)"
+  mise_tool_config_set ubi:getoutreach/ci version "$ghaccesstoken_version" exe ghaccesstoken
+  install_tool_with_mise ubi:getoutreach/ci "$ghaccesstoken_version"
+  GITHUB_TOKEN="$(ghaccesstoken --skip-update token)"
 fi
 
 # Configure the gh CLI, and tools that depend on it

--- a/shell/ci/auth/github.sh
+++ b/shell/ci/auth/github.sh
@@ -18,7 +18,7 @@ if [[ -z $GITHUB_TOKEN ]]; then
   ghaccesstoken_version="$(get_tool_version getoutreach/ci)"
   mise_tool_config_set ubi:getoutreach/ci version "$ghaccesstoken_version" exe ghaccesstoken
   install_tool_with_mise ubi:getoutreach/ci "$ghaccesstoken_version"
-  GITHUB_TOKEN="$(ghaccesstoken --skip-update token)"
+  GITHUB_TOKEN="$("$(mise which ghaccesstoken)" --skip-update token)"
 fi
 
 # Configure the gh CLI, and tools that depend on it

--- a/shell/ci/auth/github.sh
+++ b/shell/ci/auth/github.sh
@@ -7,6 +7,9 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/bootstrap.sh
 source "${LIB_DIR}/bootstrap.sh"
 
+# shellcheck source=../../lib/logging.sh
+source "$LIB_DIR/logging.sh"
+
 # shellcheck source=../../lib/mise.sh
 source "$LIB_DIR/mise.sh"
 


### PR DESCRIPTION
## What this PR does / why we need it

This allows repos to use this authentication method without needing Go installed.

## Jira ID

[DT-4638]

[DT-4638]: https://outreach-io.atlassian.net/browse/DT-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ