### PR TITLE
feat(circleci): add support for macOS executors

### DIFF
--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -13,7 +13,7 @@ source "$LIB_DIR"/logging.sh
 # shellcheck source=../lib/mise.sh
 source "$LIB_DIR"/mise.sh
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ $OSTYPE == "darwin"* ]]; then
   brew install bash docker gnupg
   # Rosetta is required for awscli installed by mise
   softwareupdate --install-rosetta --agree-to-license

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -14,7 +14,7 @@ source "$LIB_DIR"/logging.sh
 source "$LIB_DIR"/mise.sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  brew install bash gnupg
+  brew install bash docker gnupg
 fi
 
 install_tool_with_mise github-cli "$(grep ^gh: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -15,6 +15,8 @@ source "$LIB_DIR"/mise.sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   brew install bash docker gnupg
+  # Rosetta is required for awscli installed by mise
+  softwareupdate --install-rosetta --agree-to-license
 fi
 
 install_tool_with_mise github-cli "$(grep ^gh: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -13,6 +13,10 @@ source "$LIB_DIR"/logging.sh
 # shellcheck source=../lib/mise.sh
 source "$LIB_DIR"/mise.sh
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  brew install gnupg
+fi
+
 install_tool_with_mise github-cli "$(grep ^gh: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"
 
 info "Installing yq (Python)"

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -14,7 +14,7 @@ source "$LIB_DIR"/logging.sh
 source "$LIB_DIR"/mise.sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  brew install gnupg
+  brew install bash gnupg
 fi
 
 install_tool_with_mise github-cli "$(grep ^gh: "$ROOT_DIR"/versions.yaml | awk '{print $2}')"

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -24,7 +24,7 @@ ensure_mise_installed() {
     fi
 
     # Install mise
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0x7413A06D
+    gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x24853ec9f655ce80b48e6c3a8b81c9d17413a06d
     curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt >/tmp/mise-install.sh
     # ensure the above is signed with the mise release key
     sh /tmp/mise-install.sh


### PR DESCRIPTION
## What this PR does / why we need it

Allow the `shared/setup_environment` command to run on macOS executors in CircleCI.

## Notes for reviewers

Adjusted the mise install script to use a different PGP key server (and made the key ID explicitly longer) as there was a "no route to host" issue on the macOS executor.