### PR TITLE
fix: cache jsonnet-libs to avoid 429 errors

### DIFF
--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -11,6 +11,19 @@ source "$SCRIPTS_DIR/lib/docker.sh"
 # shellcheck source=./lib/logging.sh
 source "$SCRIPTS_DIR/lib/logging.sh"
 
+# Cache a local copy of the `jsonnet-libs` directory on disk if it doesn't yet exist. We use the SHA
+# of the latest HEAD for invalidation; as HEAD changes with new commits, so will our cache. Do this
+# because it helps us avoid accessing jsonnet-libs via raw.githubusercontent.com, which has
+# aggressive rate limits that we can easily hit. Estimated API usage reduction is +10x since before
+# we'd make 1 request per file (15+ *sonnet files), now we clone at most once per run.
+JSONNET_LIBS_SHA="$(git ls-remote 'https://github.com/getoutreach/jsonnet-libs.git' HEAD | cut -f1)"
+JSONNET_LIBS_CACHE="$HOME/.outreach/.cache/jsonnet-libs/${JSONNET_LIBS_SHA}"
+
+mkdir -p "$(dirname "$JSONNET_LIBS_CACHE")"
+if [[ ! -f "$JSONNET_LIBS_CACHE" ]]; then
+  git clone -q --single-branch git@github.com:getoutreach/jsonnet-libs "$JSONNET_LIBS_CACHE" >/dev/null
+fi
+
 action=$1
 
 appName="${DEVENV_DEPLOY_APPNAME:-$(get_app_name)}"
@@ -24,8 +37,8 @@ email="${DEV_EMAIL:-$(git config user.email)}"
 appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"$(get_docker_pull_registry)"}"
 
 kubecfg \
+  --jpath "$JSONNET_LIBS_CACHE" \
   --jurl http://k8s-clusters.outreach.cloud/ \
-  --jurl https://raw.githubusercontent.com/getoutreach/jsonnet-libs/master \
   -n "$namespace" \
   --context "dev-environment" "$action" "$(get_repo_directory)/deployments/$appName/$appName.jsonnet" \
   -V cluster="development.us-west-2" \

--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -17,13 +17,13 @@ source "$SCRIPTS_DIR/lib/logging.sh"
 # we'd make 1 request per file (15+ *sonnet files), now we clone at most once per run.
 JSONNET_LIBS_REPO="$HOME/.outreach/.cache/jsonnet-libs"
 
-if [[ -d "$JSONNET_LIBS_REPO" ]]; then
+if [[ -d $JSONNET_LIBS_REPO ]]; then
   pushd "$JSONNET_LIBS_REPO" || fatal "Could not find jsonnet-libs cache dir"
   git pull
   popd || fatal "Could not change directory out of jsonnet-libs cache dir"
 else
-  mkdir -p "$(dirname "$JSONNET_LIBS_REPO)"
-  git clone --quiet --single-branch git@github.com:getoutreach/jsonnet-libs "$JSONNET_LIBS_CACHE" >/dev/null
+  mkdir -p "$(dirname "$JSONNET_LIBS_REPO")"
+  git clone --quiet --single-branch git@github.com:getoutreach/jsonnet-libs "$JSONNET_LIBS_REPO" >/dev/null
 fi
 
 action=$1

--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -39,7 +39,7 @@ email="${DEV_EMAIL:-$(git config user.email)}"
 appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"$(get_docker_pull_registry)"}"
 
 kubecfg \
-  --jpath "$JSONNET_LIBS_CACHE" \
+  --jpath "$JSONNET_LIBS_REPO" \
   --jurl http://k8s-clusters.outreach.cloud/ \
   -n "$namespace" \
   --context "dev-environment" "$action" "$(get_repo_directory)/deployments/$appName/$appName.jsonnet" \


### PR DESCRIPTION
## What this PR does / why we need it

Currently, we're seeing many services failing their E2E tests in CI because we include a public repo that we maintain called `jsonnet-libs` via a `raw.githubusercontent.com` URL, so jsonnet files imported by `kubecfg` are imported directly over HTTPS. This has predictably led to us getting rate-limited, as our tooling can end up making a ton of requests to that repo specifically, and Github apparently limits requests to `raw.githubusercontent.com` to ~5000/hour/ip address.

https://github.com/github/docs/issues/8031#issuecomment-880564549

To avoid making so many HTTPS request, this modification to the `build-jsonnet.sh` script clones a local copy of the `jsonnet-libs` directory to the local disk, placing that locally cached copy in the `$HOME/.outreach/.cache` folder as that's the blessed path for caching data for tooling (other scripts do the same e.g. `shell/lib/shell.sh`).

The estimated API usage reduction is +10x since before we'd make 1 request per file (there's 15+ jsonnet files in `jsonnet-libs`), now we clone at most once per run. There are still limits on clones (~5000/hour/authed user), but with our reduced usage we're unlikely to hit that limit.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

No known JIRA for this.

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
