### PR TITLE
fix(circleci): stop always authenticating to GCR

### DIFF
--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -21,7 +21,6 @@ ensure_mise_installed
 authn=(
   "npm"
   "ssh"
-  "gcr"
   "vault"
   "aws"
   "github"


### PR DESCRIPTION
## What this PR does / why we need it

GCR only should be authenticated to, if there is a pull/push registry defined using GCR.