### PR TITLE
fix(build-jsonnet): provide fallback for git config

### DIFF
--- a/shell/build-jsonnet.sh
+++ b/shell/build-jsonnet.sh
@@ -38,7 +38,7 @@ namespace="${DEVENV_DEPLOY_NAMESPACE:-$appName--$bento}"
 version="${DEVENV_DEPLOY_VERSION:-"latest"}"
 environment="${DEVENV_DEPLOY_ENVIRONMENT:-"development"}"
 host="${DEVENV_DEPLOY_HOST:-"bento1a.outreach-dev.com"}"
-email="${DEV_EMAIL:-$(git config user.email)}"
+email="${DEV_EMAIL:-$(git config user.email || echo 'devbase@outreach.io')}"
 appImageRegistry="${DEVENV_DEPLOY_IMAGE_REGISTRY:-"$(get_docker_pull_registry)"}"
 
 kubecfg \


### PR DESCRIPTION
## What this PR does / why we need it

With the addition of stricter shell execution in #911, I found an edge case in CI while testing the latest RC. In CI, `DEV_EMAIL` isn't set, nor is `git config user.email`, so the `kubecfg` linter will fail silently. Providing a fallback email address when both conditions are false fixes this.