### PR TITLE
feat: add script to sync the CircleCI orb version when stencil-circleci isn't used

### DIFF
--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -8,24 +8,10 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/logging.sh
 source "$DIR/lib/logging.sh"
+# shellcheck source=./lib/sed.sh
+source "$DIR/lib/sed.sh"
 # shellcheck source=./lib/yaml.sh
 source "$DIR/lib/yaml.sh"
-
-sed_replace() {
-  local pattern=$1
-  local replacement=$2
-  local file=$3
-  local SED
-  case "$OSTYPE" in
-  darwin*)
-    SED="sed -i ''"
-    ;;
-  linux*)
-    SED="sed -i"
-    ;;
-  esac
-  $SED "s|$pattern|$replacement|g" "$file"
-}
 
 sync_cortex() {
   info "Syncing cortex.yaml"

--- a/shell/circleci-orb-sync.sh
+++ b/shell/circleci-orb-sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Syncs the CircleCI orb definition with the version of devbase in the
+# stencil.lock file.  This is only necessary for repositories which do
+# not use stencil-circleci to manage the CircleCI config.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEVBASE_LIB_DIR="$DIR/lib"
+
+# shellcheck source=lib/box.sh
+source "$DEVBASE_LIB_DIR"/box.sh
+
+# shellcheck source=lib/sed.sh
+source "$DEVBASE_LIB_DIR"/sed.sh
+
+# stencil_module_version parses the version of the given module
+# from stencil.lock.
+stencil_module_version() {
+  local module_name="$1"
+  "$DIR/yq.sh" --raw-output ".modules[] | select(.name == \"$module_name\").version" stencil.lock
+}
+
+stencilCircleCIVersion="$(stencil_module_version github.com/getoutreach/stencil-circleci)"
+if [[ -n $stencilCircleCIVersion ]]; then
+  echo "stencil-circleci is in use, skipping CircleCI orb sync"
+  exit 0
+fi
+
+devbaseVersion="$(stencil_module_version github.com/getoutreach/devbase)"
+
+if [[ $devbaseVersion =~ -rc ]]; then
+  replaceVersion="dev:${devbaseVersion:1}"
+elif [[ $devbaseVersion == local ]]; then
+  replaceVersion="dev:first"
+else
+  replaceVersion="${devbaseVersion:1}"
+fi
+
+org="$(get_box_field org)"
+for config in .circleci/config.yml "$@"; do
+  sed_replace "$org/shared@.\+" "$org/shared@$replaceVersion" "$config"
+  circleci config validate --org-slug="github/$org" "$config"
+done

--- a/shell/lib/sed.sh
+++ b/shell/lib/sed.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Sed helper functions.
+
+# sed_in_place is a wrapper around sed -i that works on both Linux
+# and macOS.
+sed_in_place() {
+  local SED
+  case "$OSTYPE" in
+  darwin*)
+    SED="sed -i ''"
+    ;;
+  linux*)
+    SED="sed -i"
+    ;;
+  esac
+
+  $SED "$@"
+}
+
+# sed_replace is a wrapper around in-place sed replace that works on
+# both Linux and macOS.
+sed_replace() {
+  local pattern=$1
+  local replacement=$2
+  local file=$3
+  sed_in_place "s|$pattern|$replacement|g" "$file"
+}

--- a/shell/protoc.sh
+++ b/shell/protoc.sh
@@ -13,6 +13,8 @@ source "$SCRIPTS_DIR/lib/logging.sh"
 source "$SCRIPTS_DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/yaml.sh
 source "$SCRIPTS_DIR/lib/yaml.sh"
+# shellcheck source=./lib/sed.sh
+source "$SCRIPTS_DIR/lib/sed.sh"
 
 # SUBDIR is the directory to run protoc in relative to the current root
 # (normally /api). If not set, defaults to "" (no sub directory).
@@ -172,7 +174,7 @@ if has_feature "validation"; then
 fi
 
 delete_validate() {
-  sed -i '' '/validate_pb/d' "$1" 2>/dev/null || sed -i '/validate_pb/d' "$1"
+  sed_in_place '/validate_pb/d' "$1"
 }
 
 # Make docs output directory if it doesn't exist.

--- a/shell/ruby/build.sh
+++ b/shell/ruby/build.sh
@@ -10,6 +10,8 @@ LIB_DIR="$SCRIPTS_DIR/lib"
 source "$LIB_DIR/bootstrap.sh"
 # shellcheck source=../lib/logging.sh
 source "$LIB_DIR/logging.sh"
+# shellcheck source=../lib/sed.sh
+source "$LIB_DIR/sed.sh"
 
 appName="$(get_app_name)"
 clientDir="$(get_repo_directory)/api/clients/ruby"
@@ -17,14 +19,13 @@ versionFile="$clientDir/lib/${appName}_client/version.rb"
 
 newVersion="$1"
 if [[ -z $newVersion ]]; then
-  echo "Error: Must pass in version" >&2
-  exit 1
+  fatal "Must pass in version"
 fi
 
-echo "Setting package version to $newVersion" >&2
-sed -i.bak "/VERSION /s/=.*/= \"$newVersion\"/" "$versionFile" && rm "$versionFile.bak"
+info "Setting package version to $newVersion"
+sed_in_place "/VERSION /s/=.*/= \"$newVersion\"/" "$versionFile"
 
-echo "Building ruby package"
+info "Building ruby package"
 pushd "$clientDir" >/dev/null || exit 1
 bundle install
 bundle exec rake build


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

Also extracted `sed_replace` into a couple of reusable functions.