### PR TITLE
refactor(vault): fetch address from box config

### DIFF
--- a/shell/ci/auth/vault.sh
+++ b/shell/ci/auth/vault.sh
@@ -2,9 +2,14 @@
 # Sets up vault authn
 set -e
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEVBASE_LIB_DIR="$DIR/../../lib"
+
+# shellcheck source=../../lib/box.sh
+source "$DEVBASE_LIB_DIR/box.sh"
+
 if [[ -n $VAULT_ROLE_ID ]] && [[ -n $VAULT_SECRET_ID ]]; then
-  # TODO(jaredallard): Put in box configuration. Need to build support for that.
-  VAULT_ADDR=https://vault-dev.outreach.cloud vault write auth/approle/login \
+  VAULT_ADDR="$(get_box_field devenv.vault.addressCI)" vault write auth/approle/login \
     role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID" -format=json |
     jq .auth.client_token -r >"$HOME/.vault-token"
 else

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -27,7 +27,6 @@ authn=(
   "aws"
   "github"
   "github_packages"
-  "vault"
 )
 
 for authName in "${authn[@]}"; do
@@ -47,7 +46,7 @@ if [[ -n $PRE_SETUP_SCRIPT ]]; then
   "${PRE_SETUP_SCRIPT}"
 fi
 
-# Setup a box stub
+# Set up a box stub
 boxPath="$HOME/.outreach/.config/box/box.yaml"
 mkdir -p "$(dirname "$boxPath")"
 cat >"$boxPath" <<EOF
@@ -66,6 +65,12 @@ source "${LIB_DIR}/box.sh"
 
 # Ensure we have the latest box config
 download_box
+
+# Authenticate with Vault now that we have the box config
+info "🔒 Setting up Vault access"
+
+# shellcheck source=../ci/auth/vault.sh
+"$CI_DIR/auth/vault.sh"
 
 # Setup a cache-version.txt file that can be used to invalidate cache via env vars in CircleCI
 echo "$CACHE_VERSION" >cache-version.txt

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -24,10 +24,10 @@ ensure_mise_installed
 authn=(
   "npm"
   "ssh"
-  "vault"
   "aws"
   "github"
   "github_packages"
+  "vault"
 )
 
 for authName in "${authn[@]}"; do


### PR DESCRIPTION
## What this PR does / why we need it

Reduces the amount of hardcoded items from devbase.

## Notes for your reviewers

As far as I can tell from a GitHub search, moving the Vault authentication after the pre-setup script and box setup code will not affect any repositories.