### PR TITLE
fix(orb): deprecate docker_* params in release job via docs

### DIFF
--- a/orbs/shared/jobs/release.yaml
+++ b/orbs/shared/jobs/release.yaml
@@ -25,11 +25,11 @@ parameters:
     type: executor
     default: testbed-docker-aws
   docker_image:
-    description: The docker image to use for running the test
+    description: "DEPRECATED in favor of executor. Was: The docker image to use for running the test"
     type: string
     default: $DOCKER_PULL_REGISTRY_URL/bootstrap/ci-slim
   docker_tag:
-    description: The docker image tag to use for running the test
+    description: "DEPRECATED in favor of executor. The docker image tag to use for running the test"
     type: string
     default: stable
   no_output_timeout:


### PR DESCRIPTION
## What this PR does / why we need it

They don't work anymore, but removing them would be a breaking change.