### PR TITLE
fix: use realpath instead of python

### DIFF
--- a/scripts/devbase.sh
+++ b/scripts/devbase.sh
@@ -10,8 +10,7 @@ gojqVersion="v0.12.17"
 
 # get_absolute_path returns the absolute path of a file
 get_absolute_path() {
-  python="$(command -v python3 || command -v python)"
-  "$python" -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+  realpath "$1" 
 }
 
 # gojq returns the path to a JIT-downloaded gojq binary.


### PR DESCRIPTION
use realpath, always available, instead of python

realpath in python
```
time python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" service.yaml
/Users/davidboon/Projects/outreach/devbase/evadnoob_fix_get-absolute-path-remove-python-dependency/service.yaml
python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" service.yaml  0.01s user 0.02s system 7% cpu 0.436 total
```

realpath from coreutils
```
time realpath service.yaml
/Users/davidboon/Projects/outreach/devbase/evadnoob_fix_get-absolute-path-remove-python-dependency/service.yaml
realpath service.yaml  0.00s user 0.00s system 15% cpu 0.013 total
```

the exec to python to noticibly slower than using realpath from
coreutils
