### PR TITLE
feat: manage language versions with mise instead of asdf if environment variable set

### DIFF
--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Setup mise for an environment. This can be used in both Docker and Machine executors (CircleCI)
+# or other CI platforms with that notion.
+set -e
+
+# TODO(malept): feature parity with asdf.sh in the same folder.
+mise install --yes

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -15,11 +15,19 @@ source "${LIB_DIR}/mise.sh"
 # shellcheck source=../lib/shell.sh
 source "${LIB_DIR}/shell.sh"
 
-# Ensure that asdf is ready to be used
-info "🔨 Setting up asdf"
-"$CI_DIR/env/asdf.sh"
+if [[ -z $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
+  # Ensure that asdf is ready to be used
+  info "🔨 Setting up asdf"
+  "$CI_DIR/env/asdf.sh"
+fi
 
+info "🔨 Setting up mise 🧑‍🍳"
 ensure_mise_installed
+
+if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
+  info_sub "🧑‍🍳 installing tool versions via mise"
+  "$CI_DIR/env/mise.sh"
+fi
 
 authn=(
   "npm"


### PR DESCRIPTION
## What this PR does / why we need it

This is part one of many parts of the `asdf` migration - an opt-in environment variable (already used in `shell/lib/mise.sh`) to use `mise` instead of `asdf` to manage `.tool-versions`. It only works on simple Stenciled repos (that is, only the top-level `.tool-versions`).

## Jira ID

[DT-4793]

[DT-4793]: https://outreach-io.atlassian.net/browse/DT-4793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ