### PR TITLE
feat: add `mise` tasks for CircleCI orbs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,11 @@ indent_size  = 2
 indent_style = space
 indent_size  = 2
 
+# mise tasks
+[.mise/tasks/**/*]
+indent_style = space
+indent_size  = 2
+
 # Bats tests
 [*.bats]
 indent_style = space

--- a/.mise/tasks/orb/build
+++ b/.mise/tasks/orb/build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="Build the CircleCI orb."
+#MISE sources=["{{ get_env(name="CIRCLECI_ORB_PATH")}}/**/*"]
+#MISE outputs=["orb.yml"]
+
+set -euo pipefail
+
+if [[ -z ${CIRCLECI_ORB_PATH:-} ]]; then
+  echo "CIRCLECI_ORB_PATH is not set. Please set it to the name of your CircleCI orb."
+  exit 1
+fi
+
+exec circleci orb pack "$CIRCLECI_ORB_PATH" >orb.yml

--- a/.mise/tasks/orb/build
+++ b/.mise/tasks/orb/build
@@ -5,9 +5,14 @@
 
 set -euo pipefail
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="${DIR}/../../../shell/lib"
+
+# shellcheck source=../../../shell/lib/logging.sh
+source "$LIB_DIR/logging.sh"
+
 if [[ -z ${CIRCLECI_ORB_PATH:-} ]]; then
-  echo "CIRCLECI_ORB_PATH is not set. Please set it to the name of your CircleCI orb."
-  exit 1
+  fatal "CIRCLECI_ORB_PATH is not set. Please set it to the path of your CircleCI orb."
 fi
 
 exec circleci orb pack "$CIRCLECI_ORB_PATH" >orb.yml

--- a/.mise/tasks/orb/publish-dev
+++ b/.mise/tasks/orb/publish-dev
@@ -5,9 +5,14 @@
 
 set -euo pipefail
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="${DIR}/../../../shell/lib"
+
+# shellcheck source=../../../shell/lib/logging.sh
+source "$LIB_DIR/logging.sh"
+
 if [[ -z ${CIRCLECI_ORB_NAME:-} ]]; then
-  echo "CIRCLECI_ORB_NAME is not set. Please set it to the name of your CircleCI orb."
-  exit 1
+  fatal "CIRCLECI_ORB_NAME is not set. Please set it to the name of your CircleCI orb."
 fi
 
 CIRCLECI_ORB_VERSION="${1:-first}"

--- a/.mise/tasks/orb/publish-dev
+++ b/.mise/tasks/orb/publish-dev
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="Publish a dev version of the CircleCI orb to the registry."
+#MISE tools.circleci="latest"
+#MISE depends=["orb:build"]
+
+set -euo pipefail
+
+if [[ -z ${CIRCLECI_ORB_NAME:-} ]]; then
+  echo "CIRCLECI_ORB_NAME is not set. Please set it to the name of your CircleCI orb."
+  exit 1
+fi
+
+CIRCLECI_ORB_VERSION="${1:-first}"
+
+exec circleci orb publish orb.yml "$CIRCLECI_ORB_NAME"@dev:"$CIRCLECI_ORB_VERSION"

--- a/.mise/tasks/orb/validate
+++ b/.mise/tasks/orb/validate
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#MISE description="Validate the CircleCI orb."
+#MISE tools.circleci="latest"
+#MISE depends=["orb:build"]
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="${DIR}/../../../shell/lib"
+
+# shellcheck source=../../../shell/lib/box.sh
+source "$LIB_DIR/box.sh"
+
+org="$(get_box_field org)"
+
+exec circleci org validate orb.yml --org-slug "github/$org"

--- a/.mise/tasks/orb/validate
+++ b/.mise/tasks/orb/validate
@@ -13,4 +13,4 @@ source "$LIB_DIR/box.sh"
 
 org="$(get_box_field org)"
 
-exec circleci org validate orb.yml --org-slug "github/$org"
+exec circleci orb validate orb.yml --org-slug "github/$org"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[env]
+CIRCLECI_ORB_NAME = "getoutreach/shared"
+CIRCLECI_ORB_PATH = "orbs/shared"

--- a/scripts/test.include.sh
+++ b/scripts/test.include.sh
@@ -11,4 +11,4 @@ if ! command -v circleci &>/dev/null; then
   echo "Hint: brew install circleci" >&2
   exit 1
 fi
-make validate-orb || exit 1
+mise run orb:validate || exit 1

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -197,3 +197,20 @@ find_files_with_extensions() {
     # Remove deleted files from the list.
     grep -vE "^$(git ls-files --deleted | paste -sd "|" -)$"
 }
+
+# find_files_with_shebang <shebang> <path_prefixes...>
+#
+# Finds all files via `git ls-files` that start with the given shebang.
+# Useful for finding executable scripts without file extensions, of a
+# certain file type.
+find_files_with_shebang() {
+  local shebang="$1"
+  shift
+
+  # Find all files that start with the given shebang and one of the given path prefixes.
+  git ls-files --cached --others --modified --exclude-standard "$@" | while read -r file; do
+    if [[ "$(head -n 1 "$file")" == "#!$shebang" ]]; then
+      echo "$file"
+    fi
+  done
+}

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -212,5 +212,5 @@ find_files_with_shebang() {
     if [[ "$(head -n 1 "$file")" == "#!$shebang" ]]; then
       echo "$file"
     fi
-  done
+  done | sort | uniq
 }

--- a/shell/lib/shell_test.bats
+++ b/shell/lib/shell_test.bats
@@ -12,6 +12,8 @@ setup() {
   TMP_GITDIR=$(mktemp -d)
   git init --quiet "$TMP_GITDIR"
   pushd "$TMP_GITDIR" || exit 1
+  git config user.name "Test User"
+  git config user.email "test@example.com"
 
   mkdir -p .mise/tasks/foo
   echo -e "#!/usr/bin/env bash\n\necho 'Hello, World!'" >.mise/tasks/foo/bash_script

--- a/shell/lib/shell_test.bats
+++ b/shell/lib/shell_test.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Not needed for tests:
+# - SC2155: Declare and assign separately to avoid masking return values.
+# shellcheck disable=SC2155
+
+load yaml.sh
+
+bats_load_library "bats-support/load.bash"
+bats_load_library "bats-assert/load.bash"
+
+setup() {
+  TMP_GITDIR=$(mktemp -d)
+  git init --quiet "$TMP_GITDIR"
+  pushd "$TMP_GITDIR" || exit 1
+
+  mkdir -p .mise/tasks/foo
+  echo -e "#!/usr/bin/env bash\n\necho 'Hello, World!'" >.mise/tasks/foo/bash_script
+  echo -e "#!/usr/bin/env python3\n\nprint('Hello, World!')" >.mise/tasks/foo/python_script
+
+  # Add and commit the script
+  git add .mise/tasks/foo/bash_script
+  git add .mise/tasks/foo/python_script
+  git commit -m "Initial commit"
+
+  echo -e "#!/usr/bin/env bash\n\necho 'Untracked file!'" >.mise/tasks/foo/untracked_bash_script
+}
+
+teardown() {
+  popd || exit 1
+  rm -rf "$TMP_GITDIR"
+}
+
+@test "find_files_with_shebang should find extension-less bash scripts in a git repo" {
+  run find_files_with_shebang "/usr/bin/env bash" ".mise/tasks"
+  assert_success
+  assert_output ".mise/tasks/foo/bash_script\n.mise/tasks/foo/untracked_bash_script"
+}

--- a/shell/lib/shell_test.bats
+++ b/shell/lib/shell_test.bats
@@ -3,7 +3,7 @@
 # - SC2155: Declare and assign separately to avoid masking return values.
 # shellcheck disable=SC2155
 
-load yaml.sh
+load shell.sh
 
 bats_load_library "bats-support/load.bash"
 bats_load_library "bats-assert/load.bash"

--- a/shell/lib/shell_test.bats
+++ b/shell/lib/shell_test.bats
@@ -11,7 +11,7 @@ bats_load_library "bats-assert/load.bash"
 setup() {
   TMP_GITDIR=$(mktemp -d)
   git init --quiet "$TMP_GITDIR"
-  pushd "$TMP_GITDIR" || exit 1
+  pushd "$TMP_GITDIR" >/dev/null || exit 1
   git config user.name "Test User"
   git config user.email "test@example.com"
 
@@ -22,18 +22,21 @@ setup() {
   # Add and commit the script
   git add .mise/tasks/foo/bash_script
   git add .mise/tasks/foo/python_script
-  git commit -m "Initial commit"
+  git commit --quiet -m "Initial commit"
 
   echo -e "#!/usr/bin/env bash\n\necho 'Untracked file!'" >.mise/tasks/foo/untracked_bash_script
 }
 
 teardown() {
-  popd || exit 1
+  popd >/dev/null || exit 1
   rm -rf "$TMP_GITDIR"
 }
 
 @test "find_files_with_shebang should find extension-less bash scripts in a git repo" {
   run find_files_with_shebang "/usr/bin/env bash" ".mise/tasks"
   assert_success
-  assert_output ".mise/tasks/foo/bash_script\n.mise/tasks/foo/untracked_bash_script"
+  assert_output - <<EOF
+.mise/tasks/foo/bash_script
+.mise/tasks/foo/untracked_bash_script
+EOF
 }

--- a/shell/linters/bash.sh
+++ b/shell/linters/bash.sh
@@ -6,17 +6,25 @@ SHELLCHECKPATH="$DIR/shellcheck.sh"
 # Why: Used by the script that calls us
 # shellcheck disable=SC2034
 extensions=(sh bash bats)
+shebang_paths=(.mise/tasks)
+
+find_shell_files() {
+  (
+    find_files_with_extensions "${extensions[@]}"
+    find_files_with_shebang "/usr/bin/env bash" "${shebang_paths[@]}"
+  ) | sort | uniq
+}
 
 shellcheck_linter() {
-  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$SHELLCHECKPATH" -x -P SCRIPTDIR
+  find_shell_files | xargs -n40 "$SHELLCHECKPATH" -x -P SCRIPTDIR
 }
 
 shellfmt_linter() {
-  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$SHELLFMTPATH" -s -d
+  find_shell_files | xargs -n40 "$SHELLFMTPATH" -s -d
 }
 
 shellfmt_formatter() {
-  find_files_with_extensions "${extensions[@]}" | xargs -n40 "$SHELLFMTPATH" -w -l
+  find_shell_files | xargs -n40 "$SHELLFMTPATH" -w -l
 }
 
 linter() {


### PR DESCRIPTION
## What this PR does / why we need it

* Does what it says on the tin
* Adds support for linting/formatting `mise` tasks
* Adds support for using the new tasks in this repo (`mise.toml` is a hardcoded file for now, in the future it will be a Stencil-managed file)

## Jira ID

[DT-4796]