### PR TITLE
fix: find prettier via mise even if package.json exists

### DIFF
--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -10,7 +10,7 @@ source "$DIR/languages/nodejs.sh"
 extensions=(yaml yml json md ts)
 
 PRETTIER="node_modules/.bin/prettier"
-if [[ ! -f $PRETTIER ]] && [[ ! -f package.json ]]; then
+if [[ ! -f $PRETTIER ]] && ([[ ! -f package.json ]] || ! grep -qw prettier package.json); then
   # Try to find prettier installed via mise
   PRETTIER="$(mise which prettier)"
   if [[ -z $PRETTIER ]]; then

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -10,7 +10,7 @@ source "$DIR/languages/nodejs.sh"
 extensions=(yaml yml json md ts)
 
 PRETTIER="node_modules/.bin/prettier"
-if [[ ! -f $PRETTIER ]] && ([[ ! -f package.json ]] || ! grep -qw prettier package.json); then
+if [[ ! -f $PRETTIER ]] && ([[ ! -f package.json ]] || [[ "$(gojq --raw-output .devDependencies.prettier package.json)" == "null" ]]); then
   # Try to find prettier installed via mise
   PRETTIER="$(mise which prettier)"
   if [[ -z $PRETTIER ]]; then

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -10,7 +10,7 @@ source "$DIR/languages/nodejs.sh"
 extensions=(yaml yml json md ts)
 
 PRETTIER="node_modules/.bin/prettier"
-if [[ ! -f $PRETTIER ]] && ([[ ! -f package.json ]] || [[ "$(gojq --raw-output .devDependencies.prettier package.json)" == "null" ]]); then
+if [[ ! -f $PRETTIER && (! -f package.json || "$(gojq --raw-output .devDependencies.prettier package.json)" == "null") ]]; then
   # Try to find prettier installed via mise
   PRETTIER="$(mise which prettier)"
   if [[ -z $PRETTIER ]]; then


### PR DESCRIPTION
## What this PR does / why we need it

Even if we migrate `prettier` to `mise`, we'll still need `semantic-release` to be in `package.json`. So, check that prettier doesn't exist in `package.json` before checking via `mise`.

## Jira ID

[DT-4799]

[DT-4799]: https://outreach-io.atlassian.net/browse/DT-4799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ