### PR TITLE
fix: pin version of mise

### DIFF
--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -29,7 +29,7 @@ ensure_mise_installed() {
     retry 5 5 gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x24853ec9f655ce80b48e6c3a8b81c9d17413a06d
     retry 5 5 curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt >/tmp/mise-install.sh
     # ensure the above is signed with the mise release key
-    retry 5 5 sh /tmp/mise-install.sh
+    retry 5 5 sh -c "MISE_VERSION=\"2025.7.12\" /tmp/mise-install.sh"
 
     unset MISE_INSTALL_PATH
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Mitigates issue with mise not being installed because upstream references non-existing version in install script.

See https://outreach-hq.slack.com/archives/CN9MU7GLW/p1752833948556079

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
