### PR TITLE
fix: always run mise install

### DIFF
--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -18,6 +18,7 @@ repo="$(get_repo_directory)"
 if [[ -f "$repo"/mise.toml ]]; then
   info_sub "🧑‍🍳 installing tool versions via mise"
   if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
+    info_sub "🧑‍🍳 ignoring .tool-versions"
     MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="none" mise install --cd "$repo" --yes
   else
     mise install --cd "$repo" --yes

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -9,7 +9,9 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/bootstrap.sh
 source "${LIB_DIR}/bootstrap.sh"
 
+repo="$(get_repo_directory)"
+
 # TODO(malept): feature parity with asdf.sh in the same folder.
-if [[ -f "$REPODIR"/mise.toml ]]; then
-  mise install --yes
+if [[ -f "$repo"/mise.toml ]]; then
+  mise install --cd "$repo" --yes
 fi

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -16,6 +16,9 @@ repo="$(get_repo_directory)"
 
 # TODO(malept): feature parity with asdf.sh in the same folder.
 if [[ -f "$repo"/mise.toml ]]; then
+  if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
+    export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="none"
+  fi
   info_sub "🧑‍🍳 installing tool versions via mise"
   mise install --cd "$repo" --yes
 fi

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -17,7 +17,7 @@ repo="$(get_repo_directory)"
 # TODO(malept): feature parity with asdf.sh in the same folder.
 if [[ -f "$repo"/mise.toml ]]; then
   info_sub "🧑‍🍳 installing tool versions via mise"
-  if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
+  if [[ -z $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
     info_sub "🧑‍🍳 ignoring .tool-versions"
     MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="none" mise install --cd "$repo" --yes
   else

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -3,5 +3,13 @@
 # or other CI platforms with that notion.
 set -e
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+LIB_DIR="${DIR}/../../lib"
+
+# shellcheck source=../../lib/bootstrap.sh
+source "${LIB_DIR}/bootstrap.sh"
+
 # TODO(malept): feature parity with asdf.sh in the same folder.
-mise install --yes
+if [[ -f "$REPODIR"/mise.toml ]]; then
+  mise install --yes
+fi

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -9,9 +9,13 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/bootstrap.sh
 source "${LIB_DIR}/bootstrap.sh"
 
+# shellcheck source=../../lib/logging.sh
+source "${LIB_DIR}/logging.sh"
+
 repo="$(get_repo_directory)"
 
 # TODO(malept): feature parity with asdf.sh in the same folder.
 if [[ -f "$repo"/mise.toml ]]; then
+  info_sub "🧑‍🍳 installing tool versions via mise"
   mise install --cd "$repo" --yes
 fi

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -16,9 +16,10 @@ repo="$(get_repo_directory)"
 
 # TODO(malept): feature parity with asdf.sh in the same folder.
 if [[ -f "$repo"/mise.toml ]]; then
-  if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
-    export MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="none"
-  fi
   info_sub "🧑‍🍳 installing tool versions via mise"
-  mise install --cd "$repo" --yes
+  if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
+    MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="none" mise install --cd "$repo" --yes
+  else
+    mise install --cd "$repo" --yes
+  fi
 fi

--- a/shell/ci/env/mise.sh
+++ b/shell/ci/env/mise.sh
@@ -21,6 +21,7 @@ if [[ -f "$repo"/mise.toml ]]; then
     info_sub "🧑‍🍳 ignoring .tool-versions"
     MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="none" mise install --cd "$repo" --yes
   else
+    info_sub "🧑‍🍳 allowing mise to manage .tool-versions"
     mise install --cd "$repo" --yes
   fi
 fi

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -24,10 +24,8 @@ fi
 info "🔨 Setting up mise 🧑‍🍳"
 ensure_mise_installed
 
-if [[ -n $ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS ]]; then
-  info_sub "🧑‍🍳 installing tool versions via mise"
-  "$CI_DIR/env/mise.sh"
-fi
+info_sub "🧑‍🍳 installing tool versions via mise"
+"$CI_DIR/env/mise.sh"
 
 authn=(
   "npm"

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -24,7 +24,6 @@ fi
 info "🔨 Setting up mise 🧑‍🍳"
 ensure_mise_installed
 
-info_sub "🧑‍🍳 installing tool versions via mise"
 "$CI_DIR/env/mise.sh"
 
 authn=(

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -24,7 +24,7 @@ fi
 info "🔨 Setting up mise 🧑‍🍳"
 ensure_mise_installed
 
-"$CI_DIR/env/mise.sh"
+ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS="$ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS" "$CI_DIR/env/mise.sh"
 
 authn=(
   "npm"

--- a/shell/circleci/setup.sh
+++ b/shell/circleci/setup.sh
@@ -24,7 +24,7 @@ fi
 info "🔨 Setting up mise 🧑‍🍳"
 ensure_mise_installed
 
-ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS="$ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS" "$CI_DIR/env/mise.sh"
+"$CI_DIR/env/mise.sh"
 
 authn=(
   "npm"


### PR DESCRIPTION
## What this PR does / why we need it

`mise install` needs to be run in the repo so that `prettier` can be run correctly.

## Jira ID

[DT-4813]

[DT-4813]: https://outreach-io.atlassian.net/browse/DT-4813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ