### PR TITLE
fix: clean up post-stencil scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.32.1
+  shared: getoutreach/shared@dev:2.33.0-rc.10
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,7 @@ publish-orb: validate-orb
 	circleci orb publish orb.yml getoutreach/shared@dev:$(ORB_DEV_TAG)
 
 ## <<Stencil::Block(targets)>>
-STABLE_ORB_VERSION = $(shell gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json name --jq '.[].name | ltrimstr("v")')
-
 post-stencil::
-	perl -p -i -e "s/dev:first/$(STABLE_ORB_VERSION)/g" .circleci/config.yml
 	./scripts/shell-wrapper.sh catalog-sync.sh
+	./scripts/shell-wrapper.sh circleci-orb-sync.sh
 ## <</Stencil::Block>>

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -12,8 +12,6 @@ source "$DIR/lib/bootstrap.sh"
 source "$DIR/lib/logging.sh"
 # shellcheck source=./lib/sed.sh
 source "$DIR/lib/sed.sh"
-# shellcheck source=./lib/yaml.sh
-source "$DIR/lib/yaml.sh"
 
 sync_cortex() {
   info "Syncing cortex.yaml"

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -6,6 +6,8 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=./lib/bootstrap.sh
+source "$DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/logging.sh
 source "$DIR/lib/logging.sh"
 # shellcheck source=./lib/sed.sh
@@ -17,7 +19,7 @@ sync_cortex() {
   info "Syncing cortex.yaml"
   local golang_version lintroller reporting_team stencil_version
 
-  lintroller="$(yaml_get_field .arguments.lintroller service.yaml)"
+  lintroller="$(yaml_get_field .arguments.lintroller "$(get_service_yaml)")"
   if [[ -z $lintroller ]]; then
     fatal "lintroller field is missing in service.yaml"
   fi
@@ -34,10 +36,9 @@ sync_cortex() {
     sed_replace '\(golang_version:\) .\+' "\1 $golang_version" cortex.yaml
   fi
 
-  stencil_version="$(yaml_get_field .version stencil.lock)"
-  sed_replace '\(stencil_version:\) .\+' "\1 $stencil_version" cortex.yaml
+  sed_replace '\(stencil_version:\) .\+' "\1 $(stencil_version)" cortex.yaml
 }
 
-if [[ -f cortex.yaml ]]; then
+if ! managed_by_stencil cortex.yaml; then
   sync_cortex
 fi

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -17,15 +17,15 @@ source "$DIR/lib/yaml.sh"
 
 sync_cortex() {
   info "Syncing cortex.yaml"
-  local golang_version lintroller reporting_team stencil_version
+  local golang_version lintroller reporting_team
 
-  lintroller="$(yaml_get_field .arguments.lintroller "$(get_service_yaml)")"
+  lintroller="$(stencil_arg lintroller)"
   if [[ -z $lintroller ]]; then
     fatal "lintroller field is missing in service.yaml"
   fi
   sed_replace '\(lintroller:\) .\+' "\1 $lintroller" cortex.yaml
 
-  reporting_team="$(yaml_get_field .arguments.reportingTeam service.yaml)"
+  reporting_team="$(stencil_arg reportingTeam)"
   if [[ -z $reporting_team ]]; then
     fatal "reportingTeam field is missing in service.yaml"
   fi

--- a/shell/circleci-orb-sync.sh
+++ b/shell/circleci-orb-sync.sh
@@ -12,28 +12,38 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DEVBASE_LIB_DIR="$DIR/lib"
 
+# shellcheck source=lib/bootstrap.sh
+source "$DEVBASE_LIB_DIR"/bootstrap.sh
+
 # shellcheck source=lib/box.sh
 source "$DEVBASE_LIB_DIR"/box.sh
+
+# shellcheck source=lib/logging.sh
+source "$DEVBASE_LIB_DIR"/logging.sh
 
 # shellcheck source=lib/sed.sh
 source "$DEVBASE_LIB_DIR"/sed.sh
 
-# stencil_module_version parses the version of the given module
-# from stencil.lock.
-stencil_module_version() {
-  local module_name="$1"
-  "$DIR/yq.sh" --raw-output ".modules[] | select(.name == \"$module_name\").version" stencil.lock
-}
+repoCircleCIConfig=".circleci/config.yml"
 
-if [[ $# == 0 ]]; then
-  stencilCircleCIVersion="$(stencil_module_version github.com/getoutreach/stencil-circleci)"
-  if [[ -n $stencilCircleCIVersion ]]; then
-    echo "stencil-circleci is in use, skipping CircleCI orb sync"
-    exit 0
-  fi
+if [[ "$(get_app_name)" == "devbase" ]]; then
+  isDevbaseItself=true
+else
+  isDevbaseItself=false
 fi
 
-devbaseVersion="$(stencil_module_version github.com/getoutreach/devbase)"
+if [[ $# == 0 ]] && managed_by_stencil "$repoCircleCIConfig" && [[ $isDevbaseItself == "false" ]]; then
+  info "CircleCI config is managed by Stencil, skipping manual CircleCI orb sync" >&2
+  exit 0
+fi
+
+if [[ $isDevbaseItself == "true" ]]; then
+  # devbase itself will always use a local version of devbase, so have
+  # the CircleCI orb use the latest (pre-)release version.
+  devbaseVersion="$(get_app_version)"
+else
+  devbaseVersion="$(stencil_module_version github.com/getoutreach/devbase)"
+fi
 
 if [[ $devbaseVersion =~ -rc ]]; then
   replaceVersion="dev:${devbaseVersion:1}"
@@ -43,12 +53,13 @@ else
   replaceVersion="${devbaseVersion:1}"
 fi
 
+info "Replacing CircleCI shared orb version with $replaceVersion"
+
 org="$(get_box_field org)"
-skipValidate=
-for config in .circleci/config.yml "$@"; do
+for config in "$repoCircleCIConfig" "$@"; do
+  info_sub "Updating $config"
   sed_replace "$org/shared@.\+" "$org/shared@$replaceVersion" "$config"
-  if [[ -z $skipValidate ]]; then
+  if [[ $config == "$repoCircleCIConfig" ]]; then
     circleci config validate --org-slug="github/$org" "$config"
   fi
-  skipValidate=true
 done

--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -180,6 +180,12 @@ stencil_version() {
   "$YQ" --raw-output '.version' "$(get_stencil_lock)"
 }
 
+# stencil_arg is the shell equivalent of Stencil's `stencil.Arg` function.
+stencil_arg() {
+  local name="$1"
+  yaml_get_field ".arguments.$name" "$(get_service_yaml)"
+}
+
 # stencil_module_version parses the version of the given module
 # from stencil.lock.
 stencil_module_version() {

--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -183,7 +183,7 @@ stencil_version() {
 # stencil_arg is the shell equivalent of Stencil's `stencil.Arg` function.
 stencil_arg() {
   local name="$1"
-  yaml_get_field ".arguments.$name" "$(get_service_yaml)"
+  "$YQ" --raw-output ".arguments.$name" <"$(get_service_yaml)"
 }
 
 # stencil_module_version parses the version of the given module

--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -89,6 +89,14 @@ get_service_yaml() {
   fi
 }
 
+get_stencil_lock() {
+  if [[ -e "stencil.lock" ]]; then
+    echo "stencil.lock"
+  else
+    echo "$REPODIR/stencil.lock"
+  fi
+}
+
 has_resource() {
   local name="$1"
 
@@ -165,4 +173,25 @@ is_service() {
   else
     "$YQ" -r ".arguments.service" <"$(get_service_yaml)"
   fi
+}
+
+# stencil_version returns the version of stencil last used to generate the stencil.lock file.
+stencil_version() {
+  "$YQ" --raw-output '.version' "$(get_stencil_lock)"
+}
+
+# stencil_module_version parses the version of the given module
+# from stencil.lock.
+stencil_module_version() {
+  local module_name="$1"
+  "$YQ" --raw-output ".modules | select(.name == \"$module_name\").version" "$(get_stencil_lock)"
+}
+
+# managed_by_stencil checks if the given file is managed by stencil.
+managed_by_stencil() {
+  local file="$1"
+  if [[ $("$YQ" --raw-output ".files | map(select(.name == \"$file\")) | length" "$(get_stencil_lock)") -gt 0 ]]; then
+    return 0
+  fi
+  return 1
 }


### PR DESCRIPTION
## What this PR does / why we need it

Allow the scripts to be run even if the service doesn't need either of them run. This is in preparation for `mise`-based post-stencil tasks.

This also moves the `devbase`-specific post-stencil orb version sync code into the CircleCI orb sync code, which removes the `perl` dependency when restenciling.

## Jira ID

[DT-4791]

[DT-4791]: https://outreach-io.atlassian.net/browse/DT-4791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ