### PR TITLE
fix(prettier): ensure installed if defined in `mise.toml`

### DIFF
--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -190,7 +190,7 @@ mise_install_if_needed() {
   local installed versions
 
   versions="$(mise ls --local --json "$tool_name")"
-  if [[ "$versions" == "[]" ]]; then
+  if [[ $versions == "[]" ]]; then
     fatal "mise: $tool_name is not declared in mise.toml"
   fi
   installed="$(echo "$versions" | gojq --raw-output '.[] | select(.installed and .active)')"
@@ -198,7 +198,5 @@ mise_install_if_needed() {
   if [[ -z $installed ]]; then
     info "mise: installing $tool_name"
     mise install --yes "$tool_name"
-  else
-    info "mise: $tool_name is already installed"
   fi
 }

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -182,3 +182,23 @@ find_tool() {
     "$mise_path" which "$tool_name"
   fi
 }
+
+mise_install_if_needed() {
+  ensure_mise_installed
+
+  local tool_name="$1"
+  local installed versions
+
+  versions="$(mise ls --local --json "$tool_name")"
+  if [[ "$versions" == "[]" ]]; then
+    fatal "mise: $tool_name is not declared in mise.toml"
+  fi
+  installed="$(echo "$versions" | gojq --raw-output '.[] | select(.installed and .active)')"
+
+  if [[ -z $installed ]]; then
+    info "mise: installing $tool_name"
+    mise install --yes "$tool_name"
+  else
+    info "mise: $tool_name is already installed"
+  fi
+}

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -12,7 +12,7 @@ source "$DIR/lib/mise.sh"
 # shellcheck disable=SC2034
 extensions=(yaml yml json md ts)
 
-find_prettier() {
+find_and_install_prettier_if_needed() {
   PRETTIER="node_modules/.bin/prettier"
   if [[ ! -f $PRETTIER && (! -f package.json || "$(gojq --raw-output .devDependencies.prettier package.json)" == "null") ]]; then
     mise_install_if_needed npm:prettier
@@ -21,6 +21,10 @@ find_prettier() {
     if [[ -z $PRETTIER ]]; then
       fatal "prettier not found in repo, make sure 'npm:prettier' is defined in 'mise.toml' and you have run 'mise install'"
     fi
+  fi
+
+  if [[ $PRETTIER =~ ^node_modules/ ]]; then
+    yarn_install_if_needed >/dev/null
   fi
 }
 
@@ -33,11 +37,7 @@ prettier_log_level_flag() {
 }
 
 prettier_linter() {
-  find_prettier
-
-  if [[ $PRETTIER =~ ^node_modules/ ]]; then
-    yarn_install_if_needed >/dev/null
-  fi
+  find_and_install_prettier_if_needed
 
   local log_level_flag
   log_level_flag="$(prettier_log_level_flag)"
@@ -47,9 +47,7 @@ prettier_linter() {
 }
 
 prettier_formatter() {
-  yarn_install_if_needed >/dev/null
-
-  find_prettier
+  find_and_install_prettier_if_needed
 
   local log_level_flag
   log_level_flag="$(prettier_log_level_flag)"

--- a/shell/linters/prettier.sh
+++ b/shell/linters/prettier.sh
@@ -5,6 +5,9 @@
 # shellcheck source=../languages/nodejs.sh
 source "$DIR/languages/nodejs.sh"
 
+# shellcheck source=../lib/mise.sh
+source "$DIR/lib/mise.sh"
+
 # Why: Used by the script that calls us
 # shellcheck disable=SC2034
 extensions=(yaml yml json md ts)
@@ -12,6 +15,7 @@ extensions=(yaml yml json md ts)
 find_prettier() {
   PRETTIER="node_modules/.bin/prettier"
   if [[ ! -f $PRETTIER && (! -f package.json || "$(gojq --raw-output .devDependencies.prettier package.json)" == "null") ]]; then
+    mise_install_if_needed npm:prettier
     # Try to find prettier installed via mise
     PRETTIER="$(mise which prettier)"
     if [[ -z $PRETTIER ]]; then
@@ -29,9 +33,11 @@ prettier_log_level_flag() {
 }
 
 prettier_linter() {
-  yarn_install_if_needed >/dev/null
-
   find_prettier
+
+  if [[ $PRETTIER =~ ^node_modules/ ]]; then
+    yarn_install_if_needed >/dev/null
+  fi
 
   local log_level_flag
   log_level_flag="$(prettier_log_level_flag)"


### PR DESCRIPTION
## What this PR does / why we need it

With the current behavior, `prettier` was `yarn install`'d if it wasn't already installed. Now we need to check to see if it's in `package.json`, and if it's not, check to see if it's in `mise.toml`, and if it is but not installed, install it.

## Jira ID

[DT-4816]