### PR TITLE
fix(bootstrap): select modules from stencil.lock correctly

### DIFF
--- a/shell/lib/bootstrap.sh
+++ b/shell/lib/bootstrap.sh
@@ -190,7 +190,7 @@ stencil_arg() {
 # from stencil.lock.
 stencil_module_version() {
   local module_name="$1"
-  "$YQ" --raw-output ".modules | select(.name == \"$module_name\").version" "$(get_stencil_lock)"
+  "$YQ" --raw-output ".modules[] | select(.name == \"$module_name\").version" "$(get_stencil_lock)"
 }
 
 # managed_by_stencil checks if the given file is managed by stencil.

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -48,3 +48,25 @@ teardown() {
   VERSIONING_SCHEME=sha run get_app_version
   assert_output "$(git rev-parse HEAD)"
 }
+
+@test "stencil_module_version returns the version from stencil.lock" {
+  # Create a mock stencil.lock file
+  cat >"$REPOPATH"/stencil.lock <<EOF
+modules:
+  - name: example.com/module
+    version: v1.2.3
+  - name: github.com/getoutreach/devbase
+    version: v2.3.4
+EOF
+
+  run stencil_module_version example.com/module
+  assert_output "v1.2.3"
+
+  run stencil_module_version github.com/getoutreach/devbase
+  assert_output "v2.3.4"
+
+  # Test with a non-existent module
+  run stencil_module_version github.com/nonexistent/module
+  assert_failure
+  assert_output ""
+}

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -49,7 +49,7 @@ teardown() {
   assert_output "$(git rev-parse HEAD)"
 }
 
-@test "stencil_version" {
+@test "stencil_version reads the Stencil version from stencil.lock" {
   cat >"$REPOPATH"/stencil.lock <<EOF
 version: v1.66.6-rc.6
 EOF
@@ -57,7 +57,7 @@ EOF
   assert_output "v1.66.6-rc.6"
 }
 
-@test "stencil_arg" {
+@test "stencil_arg reads a nested argument from service.yaml" {
   cat >"$REPOPATH"/service.yaml <<EOF
 arguments:
   foo:

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -49,6 +49,14 @@ teardown() {
   assert_output "$(git rev-parse HEAD)"
 }
 
+@test "stencil_version" {
+  cat >"$REPOPATH"/stencil.lock <<EOF
+version: v1.66.6-rc.6
+EOF
+  run stencil_version
+  assert_output "v1.66.6-rc.6"
+}
+
 @test "stencil_module_version returns the version from stencil.lock" {
   # Create a mock stencil.lock file
   cat >"$REPOPATH"/stencil.lock <<EOF

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -67,6 +67,5 @@ EOF
 
   # Test with a non-existent module
   run stencil_module_version github.com/nonexistent/module
-  assert_failure
   assert_output ""
 }

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -57,6 +57,16 @@ EOF
   assert_output "v1.66.6-rc.6"
 }
 
+@test "stencil_arg" {
+  cat >"$REPOPATH"/service.yaml <<EOF
+arguments:
+  foo:
+    bar: baz
+EOF
+  run stencil_arg foo.bar
+  assert_output "baz"
+}
+
 @test "stencil_module_version returns the version from stencil.lock" {
   # Create a mock stencil.lock file
   cat >"$REPOPATH"/stencil.lock <<EOF

--- a/shell/lib/bootstrap_test.bats
+++ b/shell/lib/bootstrap_test.bats
@@ -69,3 +69,27 @@ EOF
   run stencil_module_version github.com/nonexistent/module
   assert_output ""
 }
+
+@test "managed_by_stencil succeeds for a file managed by stencil" {
+  # Create a mock stencil.lock file
+  cat >"$REPOPATH"/stencil.lock <<EOF
+files:
+  - name: exists.txt
+    template: exists.txt.tpl
+    module: example.com/module
+EOF
+  run managed_by_stencil exists.txt
+  assert_success
+}
+
+@test "managed_by_stencil fails for a file not managed by stencil" {
+  # Create a mock stencil.lock file
+  cat >"$REPOPATH"/stencil.lock <<EOF
+files:
+  - name: exists.txt
+    template: exists.txt.tpl
+    module: example.com/module
+EOF
+  run managed_by_stencil nonexistent.txt
+  assert_failure
+}


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

Also, add tests for some of the newer functions in `shell/lib/bootstrap.sh` to prevent this issue from happening for those.