### PR TITLE
feat: migrate stencil-related tasks to mise

### DIFF
--- a/.mise/tasks/stencil/_default
+++ b/.mise/tasks/stencil/_default
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run Stencil on the current repo without updating any module versions."
+#MISE tools={"ubi:getoutreach/stencil" = "latest"}
+#MISE depends_post=["stencil:post"]
+
+exec stencil --skip-update --frozen-lockfile

--- a/.mise/tasks/stencil/post/_default
+++ b/.mise/tasks/stencil/post/_default
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Discover and run tasks meant to be run after Stencil completes."
-#MISE tools={"ubi:getoutreach/stencil" = "latest"}
+#MISE tools={"gojq" = "latest"}
 
 set -euo pipefail
 

--- a/.mise/tasks/stencil/post/_default
+++ b/.mise/tasks/stencil/post/_default
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Discover and run tasks meant to be run after Stencil completes."
+#MISE tools={"ubi:getoutreach/stencil" = "latest"}
+
+set -euo pipefail
+
+# Why: word splitting is not an issue with task names.
+# shellcheck disable=SC2046
+exec mise run $(mise tasks ls --json | gojq --raw-output '. | map(select(.name | startswith("stencil:post:")).name) | join(" ::: ")')

--- a/.mise/tasks/stencil/post/catalog-sync
+++ b/.mise/tasks/stencil/post/catalog-sync
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 #MISE description="Sync service catalog values if it is not managed by a Stencil module."
 #MISE tools={"gojq" = "latest"}
+#
+# Syncs the service catalog manifest for the given repository with
+# the metadata present in the repository.
 
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DEVBASE_LIB_DIR="$DIR/../../../../shell/lib"
+
 # shellcheck source=../../../../shell/lib/bootstrap.sh
 source "$DEVBASE_LIB_DIR/bootstrap.sh"
 # shellcheck source=../../../../shell/lib/logging.sh

--- a/.mise/tasks/stencil/post/catalog-sync
+++ b/.mise/tasks/stencil/post/catalog-sync
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#MISE description="Sync service catalog values if it is not managed by a Stencil module."
+#MISE tools={"gojq" = "latest"}
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEVBASE_LIB_DIR="$DIR/../../../../shell/lib"
+# shellcheck source=../../../../shell/lib/bootstrap.sh
+source "$DEVBASE_LIB_DIR/bootstrap.sh"
+# shellcheck source=../../../../shell/lib/logging.sh
+source "$DEVBASE_LIB_DIR/logging.sh"
+# shellcheck source=../../../../shell/lib/sed.sh
+source "$DEVBASE_LIB_DIR/sed.sh"
+
+sync_cortex() {
+  info "Syncing cortex.yaml"
+  local golang_version lintroller reporting_team
+
+  lintroller="$(stencil_arg lintroller)"
+  if [[ -z $lintroller ]]; then
+    fatal "lintroller field is missing in service.yaml"
+  fi
+  sed_replace '\(lintroller:\) .\+' "\1 $lintroller" cortex.yaml
+
+  reporting_team="$(stencil_arg reportingTeam)"
+  if [[ -z $reporting_team ]]; then
+    fatal "reportingTeam field is missing in service.yaml"
+  fi
+  sed_replace '\(reporting_team:\) .\+' "\1 $reporting_team" cortex.yaml
+
+  golang_version="$(grep -w ^golang .tool-versions | awk '{print $2}')"
+  if [[ -n $golang_version ]]; then
+    sed_replace '\(golang_version:\) .\+' "\1 $golang_version" cortex.yaml
+  fi
+
+  sed_replace '\(stencil_version:\) .\+' "\1 $(stencil_version)" cortex.yaml
+}
+
+if ! managed_by_stencil cortex.yaml; then
+  sync_cortex
+fi

--- a/.mise/tasks/stencil/post/catalog-sync
+++ b/.mise/tasks/stencil/post/catalog-sync
@@ -13,6 +13,9 @@ source "$DEVBASE_LIB_DIR/logging.sh"
 # shellcheck source=../../../../shell/lib/sed.sh
 source "$DEVBASE_LIB_DIR/sed.sh"
 
+# Syncs cortex.yaml with the values from service.yaml.
+# This uses sed instead of gojq because the latter does not support
+# roundtripping comments or maintaining the order of fields.
 sync_cortex() {
   info "Syncing cortex.yaml"
   local golang_version lintroller reporting_team

--- a/.mise/tasks/stencil/post/circleci-orb-sync
+++ b/.mise/tasks/stencil/post/circleci-orb-sync
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#MISE description="Sync CircleCI orb versions if files aren't managed by a Stencil module."
+#MISE tools={"gojq" = "latest"}
+#
+# Syncs the CircleCI orb definition with the version of devbase in the
+# stencil.lock file.  By default, it only updates .circleci/config.yml
+# (the default config file), but this is only necessary for repositories
+# which do not use stencil-circleci to manage the CircleCI config.
+# The default config file is validated, others are not (as they may not
+# be config files per se, such as orb definitions).
+#
+# Additional confi files can be passed into this script via the
+# CIRCLECI_ORB_SYNC_FILES environment variable, which is usually expected
+# to be set in the repository's `mise.toml` file.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEVBASE_LIB_DIR="$DIR/../../../../shell/lib"
+
+# shellcheck source=../../../../shell/lib/bootstrap.sh
+source "$DEVBASE_LIB_DIR"/bootstrap.sh
+# shellcheck source=../../../../shell/lib/box.sh
+source "$DEVBASE_LIB_DIR"/box.sh
+# shellcheck source=../../../../shell/lib/github.sh
+source "$DEVBASE_LIB_DIR"/github.sh
+# shellcheck source=../../../../shell/lib/logging.sh
+source "$DEVBASE_LIB_DIR"/logging.sh
+# shellcheck source=../../../../shell/lib/sed.sh
+source "$DEVBASE_LIB_DIR"/sed.sh
+# shellcheck source=../../../../shell/lib/shell.sh
+source "$DEVBASE_LIB_DIR"/shell.sh
+
+ensure_bash_5_or_greater
+
+repoCircleCIConfig=".circleci/config.yml"
+org="$(get_box_field org)"
+
+if [[ "$(get_app_name)" == "devbase" ]]; then
+  isDevbaseItself=true
+else
+  isDevbaseItself=false
+fi
+
+if [[ $# == 0 ]] && managed_by_stencil "$repoCircleCIConfig" && [[ $isDevbaseItself == "false" ]]; then
+  info "CircleCI config is managed by Stencil, skipping manual CircleCI orb sync" >&2
+  exit 0
+fi
+
+if [[ $isDevbaseItself == "true" ]]; then
+  # devbase itself will always use a local version of devbase, so have
+  # the CircleCI orb use the latest (pre-)release version.
+  devbaseVersion="$(latest_github_release_version "$org/devbase" true)"
+else
+  devbaseVersion="$(stencil_module_version "github.com/$org/devbase")"
+fi
+
+if [[ $devbaseVersion =~ -rc ]]; then
+  replaceVersion="dev:${devbaseVersion:1}"
+elif [[ $devbaseVersion == local ]]; then
+  replaceVersion="dev:first"
+else
+  replaceVersion="${devbaseVersion:1}"
+fi
+
+info "Replacing CircleCI shared orb version with $replaceVersion"
+
+configFiles=("$repoCircleCIConfig")
+if [[ -n ${CIRCLECI_ORB_SYNC_FILES:-} ]]; then
+  readarray -t -d ' ' extraFiles < <(echo "$CIRCLECI_ORB_SYNC_FILES")
+  configFiles+=("${extraFiles[@]}")
+fi
+
+for config in "${configFiles[@]}"; do
+  info_sub "Updating $config"
+  sed_replace "$org/shared@.\+" "$org/shared@$replaceVersion" "$config"
+  if [[ $config == "$repoCircleCIConfig" ]]; then
+    circleci config validate --org-slug="github/$org" "$config"
+  fi
+done

--- a/.mise/tasks/stencil/post/circleci-orb-sync
+++ b/.mise/tasks/stencil/post/circleci-orb-sync
@@ -57,7 +57,7 @@ fi
 
 if [[ $devbaseVersion =~ -rc ]]; then
   replaceVersion="dev:${devbaseVersion:1}"
-elif [[ $devbaseVersion == local ]]; then
+elif [[ $devbaseVersion == local || ! $devbaseVersion =~ ^v[0-9]+ ]]; then
   replaceVersion="dev:first"
 else
   replaceVersion="${devbaseVersion:1}"

--- a/.mise/tasks/stencil/post/circleci-orb-sync
+++ b/.mise/tasks/stencil/post/circleci-orb-sync
@@ -9,7 +9,7 @@
 # The default config file is validated, others are not (as they may not
 # be config files per se, such as orb definitions).
 #
-# Additional confi files can be passed into this script via the
+# Additional config files can be passed into this script via the
 # CIRCLECI_ORB_SYNC_FILES environment variable, which is usually expected
 # to be set in the repository's `mise.toml` file.
 

--- a/.mise/tasks/stencil/upgrade
+++ b/.mise/tasks/stencil/upgrade
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run Stencil on the current repo and update any module versions if available."
+#MISE tools={"ubi:getoutreach/stencil" = "latest"}
+#MISE depends_post=["stencil:post"]
+
+exec stencil --skip-update

--- a/root/Makefile
+++ b/root/Makefile
@@ -228,21 +228,21 @@ docs:: pre-docs
 docs-publish:: pre-docs-publish
 	@./.bootstrap/shell/docs-publish.sh
 
-## stencil:         run stencil
+## stencil:         [DEPRECATED] run stencil
 .PHONY: stencil
 stencil:: pre-stencil run-stencil post-stencil
 
 .PHONY: run-stencil
 run-stencil:
-	stencil --skip-update
+	@./scripts/shell-wrapper.sh deprecated-task.sh stencil stencil:upgrade
 
-## restencil:       run stencil without updating module versions
+## restencil:       [DEPRECATED] run stencil without updating module versions
 .PHONY: restencil
 restencil:: pre-stencil run-restencil post-stencil
 
 .PHONY: run-restencil
 run-restencil:
-	stencil --skip-update --frozen-lockfile
+	@./scripts/shell-wrapper.sh deprecated-task.sh restencil stencil
 
 ## benchmarker-gen:	generate a benchmarker input file using your locally running gRPC server
 .PHONY: benchmarker-gen

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -13,5 +13,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "$DIR/lib/logging.sh"
 
 warn "This script is deprecated and will be removed in the future. Please use 'mise run stencil:post:catalog-sync' instead."
+echo
+warn "Starting in 5 seconds..."
+echo
+
+sleep 5
 
 exec mise run stencil:post:catalog-sync "$@"

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -6,37 +6,10 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-# shellcheck source=./lib/bootstrap.sh
-source "$DIR/lib/bootstrap.sh"
+
 # shellcheck source=./lib/logging.sh
 source "$DIR/lib/logging.sh"
-# shellcheck source=./lib/sed.sh
-source "$DIR/lib/sed.sh"
 
-sync_cortex() {
-  info "Syncing cortex.yaml"
-  local golang_version lintroller reporting_team
+warn "This script is deprecated and will be removed in the future. Please use 'mise run stencil:post:catalog-sync' instead."
 
-  lintroller="$(stencil_arg lintroller)"
-  if [[ -z $lintroller ]]; then
-    fatal "lintroller field is missing in service.yaml"
-  fi
-  sed_replace '\(lintroller:\) .\+' "\1 $lintroller" cortex.yaml
-
-  reporting_team="$(stencil_arg reportingTeam)"
-  if [[ -z $reporting_team ]]; then
-    fatal "reportingTeam field is missing in service.yaml"
-  fi
-  sed_replace '\(reporting_team:\) .\+' "\1 $reporting_team" cortex.yaml
-
-  golang_version="$(grep -w ^golang .tool-versions | awk '{print $2}')"
-  if [[ -n $golang_version ]]; then
-    sed_replace '\(golang_version:\) .\+' "\1 $golang_version" cortex.yaml
-  fi
-
-  sed_replace '\(stencil_version:\) .\+' "\1 $(stencil_version)" cortex.yaml
-}
-
-if ! managed_by_stencil cortex.yaml; then
-  sync_cortex
-fi
+exec mise run stencil:post:catalog-sync "$@"

--- a/shell/catalog-sync.sh
+++ b/shell/catalog-sync.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 #
+# DEPRECATED: Use `mise run stencil:post:catalog-sync` instead.
+#
 # Syncs the service catalog manifest for the given repository with
 # the metadata present in the repository.
 

--- a/shell/circleci-orb-sync.sh
+++ b/shell/circleci-orb-sync.sh
@@ -10,56 +10,10 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEVBASE_LIB_DIR="$DIR/lib"
 
-# shellcheck source=lib/bootstrap.sh
-source "$DEVBASE_LIB_DIR"/bootstrap.sh
+# shellcheck source=./lib/logging.sh
+source "$DIR/lib/logging.sh"
 
-# shellcheck source=lib/box.sh
-source "$DEVBASE_LIB_DIR"/box.sh
+warn "This script is deprecated and will be removed in the future. Please use 'mise run stencil:post:circleci-orb-sync' instead."
 
-# shellcheck source=lib/logging.sh
-source "$DEVBASE_LIB_DIR"/logging.sh
-
-# shellcheck source=lib/sed.sh
-source "$DEVBASE_LIB_DIR"/sed.sh
-
-repoCircleCIConfig=".circleci/config.yml"
-
-if [[ "$(get_app_name)" == "devbase" ]]; then
-  isDevbaseItself=true
-else
-  isDevbaseItself=false
-fi
-
-if [[ $# == 0 ]] && managed_by_stencil "$repoCircleCIConfig" && [[ $isDevbaseItself == "false" ]]; then
-  info "CircleCI config is managed by Stencil, skipping manual CircleCI orb sync" >&2
-  exit 0
-fi
-
-if [[ $isDevbaseItself == "true" ]]; then
-  # devbase itself will always use a local version of devbase, so have
-  # the CircleCI orb use the latest (pre-)release version.
-  devbaseVersion="$(get_app_version)"
-else
-  devbaseVersion="$(stencil_module_version github.com/getoutreach/devbase)"
-fi
-
-if [[ $devbaseVersion =~ -rc ]]; then
-  replaceVersion="dev:${devbaseVersion:1}"
-elif [[ $devbaseVersion == local ]]; then
-  replaceVersion="dev:first"
-else
-  replaceVersion="${devbaseVersion:1}"
-fi
-
-info "Replacing CircleCI shared orb version with $replaceVersion"
-
-org="$(get_box_field org)"
-for config in "$repoCircleCIConfig" "$@"; do
-  info_sub "Updating $config"
-  sed_replace "$org/shared@.\+" "$org/shared@$replaceVersion" "$config"
-  if [[ $config == "$repoCircleCIConfig" ]]; then
-    circleci config validate --org-slug="github/$org" "$config"
-  fi
-done
+exec mise run stencil:post:circleci-orb-sync "$@"

--- a/shell/circleci-orb-sync.sh
+++ b/shell/circleci-orb-sync.sh
@@ -17,5 +17,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "$DIR/lib/logging.sh"
 
 warn "This script is deprecated and will be removed in the future. Please use 'mise run stencil:post:circleci-orb-sync' instead."
+echo
+warn "Starting in 5 seconds..."
+echo
+
+sleep 5
 
 exec mise run stencil:post:circleci-orb-sync "$@"

--- a/shell/circleci-orb-sync.sh
+++ b/shell/circleci-orb-sync.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 #
+# DEPRECATED: Use `mise run stencil:post:circleci-orb-sync` instead.
+#
 # Syncs the CircleCI orb definition with the version of devbase in the
 # stencil.lock file.  By default, it only updates .circleci/config.yml
 # (the default config file), but this is only necessary for repositories

--- a/shell/deprecated-task.sh
+++ b/shell/deprecated-task.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <make_task> <mise_task> [args...]" >&2
+  exit 1
+fi
+
+make_task="$1"
+mise_task="$2"
+shift
+shift
+
+deprecated_msg() {
+  echo >&2
+  # Bold, blinking, red text
+  echo -e "\e[1m\e[5m\e[31m**DEPRECATION MESSAGE**\e[0m"
+  echo "'make $make_task' is deprecated. Use 'mise run $mise_task' instead" >&2
+  echo >&2
+}
+
+deprecated_msg
+
+trap deprecated_msg EXIT
+
+echo "Starting in 5 seconds..." >&2
+echo >&2
+sleep 5
+
+mise run "$mise_task" "$@"


### PR DESCRIPTION
## What this PR does / why we need it

* Moves the `stencil` and `post-stencil` tasks from `make` to `mise`, with a deprecation warning / delay for the old tasks
* Moves the catalog sync and CircleCI orb sync scripts to become `mise` tasks, with a deprecation warning / delay for the old script locations

## Jira ID

[DT-4791]

[DT-4791]: https://outreach-io.atlassian.net/browse/DT-4791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ