### PR TITLE
fix: replace `mage version` task with a mise task

### DIFF
--- a/.mise/tasks/version
+++ b/.mise/tasks/version
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+#MISE description="Prints the current application version."
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEVBASE_LIB_DIR="$DIR/../../shell/lib"
+
+# shellcheck source=../../shell/lib/bootstrap.sh
+source "$DEVBASE_LIB_DIR"/bootstrap.sh
+
+get_app_version

--- a/root/Magefile.go
+++ b/root/Magefile.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -24,11 +23,6 @@ func Dep() error {
 	}
 
 	return runGoCommand(log, "mod", "tidy")
-}
-
-// Version prints the current application version
-func Version() {
-	fmt.Println(getAppVersion())
 }
 
 // E2ETestBuild builds binaries of e2e tests

--- a/root/Makefile
+++ b/root/Makefile
@@ -17,7 +17,7 @@ ORG                 ?= getoutreach
 
 # Transition
 MAGE_CMD            := ASDF_MAGE_VERSION=$(shell cat "$(BOOTSTRAP_DIR)/.tool-versions" | grep mage | awk '{ print $$2 }') MAGEFILE_HASHFAST=true mage -d "$(CURDIR)/$(shell if [[ "$(APP)" != "devbase" ]]; then echo ".bootstrap/"; fi)root" -w "$(CURDIR)"
-APP_VERSION         := $(shell $(MAGE_CMD) version)
+APP_VERSION         := $(shell mise run --quiet version)
 
 # go options
 GO                  ?= go
@@ -105,6 +105,10 @@ help: Makefile
 	@printf "\n"
 	@echo "Mage (make <target>) targets"
 	@$(MAGE_CMD) -l
+
+.PHONY: version
+version::
+	@./scripts/shell-wrapper.sh deprecated-task.sh version version
 
 ## pre-commit:      run housekeeping utilities before creating a commit
 .PHONY: pre-commit

--- a/shell/deprecated-task.sh
+++ b/shell/deprecated-task.sh
@@ -15,7 +15,7 @@ shift
 deprecated_msg() {
   echo >&2
   # Bold, blinking, red text
-  echo -e "\e[1m\e[5m\e[31m**DEPRECATION MESSAGE**\e[0m"
+  echo -e "\e[1m\e[5m\e[31m**DEPRECATION MESSAGE**\e[0m" >&2
   echo "'make $make_task' is deprecated. Use 'mise run $mise_task' instead" >&2
   echo >&2
 }
@@ -28,4 +28,4 @@ echo "Starting in 5 seconds..." >&2
 echo >&2
 sleep 5
 
-mise run "$mise_task" "$@"
+mise run --quiet "$mise_task" "$@"


### PR DESCRIPTION
## What this PR does / why we need it

Another `mage` task replaced with `mise`.

## Jira ID

[DT-4636]

## Notes for your reviewers

`getAppVersion()` as Go code still exists because `mage gobuild` still uses it. Once that's removed, that function can go as well.
