### PR TITLE
feat: ability of skipping e2e pipeline

### DIFF
--- a/orbs/shared/jobs/e2e.yaml
+++ b/orbs/shared/jobs/e2e.yaml
@@ -40,6 +40,10 @@ parameters:
     description: Flags to pass to the e2e test runner
     type: string
     default: ""
+  skip:
+    description: If this is set to true all E2E steps in this job will be skipped
+    type: boolean
+    default: false
 executor:
   name: testbed-machine
 environment:
@@ -53,13 +57,21 @@ environment:
   TEST_FLAGS: << parameters.test_flags >>
 resource_class: << parameters.resource_class >>
 steps:
-  - setup_environment:
-      machine: true
-  - run:
-      name: Run E2E Tests
-      command: KUBECONFIG="$HOME/.outreach/kubeconfig.yaml" make e2e
-      no_output_timeout: << parameters.no_output_timeout >>
-  - run:
-      name: Upload Code Coverage
-      command: ./scripts/shell-wrapper.sh ci/testing/coverage.sh /tmp/coverage.out e2e
-  - upload_test_results # Uploads to CircleCI
+  - when:
+      condition:
+        not: << parameters.skip >>
+      steps:
+        - setup_environment:
+            machine: true
+        - run:
+            name: Run E2E Tests
+            command: KUBECONFIG="$HOME/.outreach/kubeconfig.yaml" make e2e
+            no_output_timeout: << parameters.no_output_timeout >>
+        - run:
+            name: Upload Code Coverage
+            command: ./scripts/shell-wrapper.sh ci/testing/coverage.sh /tmp/coverage.out e2e
+        - upload_test_results # Uploads to CircleCI
+  - when:
+      condition: << parameters.skip >>
+      steps:
+        - run: echo "skip parameter in CI config was set to true, skipping"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Got inspired [here](https://github.com/getoutreach/devbase/blob/main/orbs/shared/jobs/test.yaml#L43), I'd propose ability to skip e2e pipeline if someone wants.

When there are no tests in the project, the env is spin up and the machine time is then wasted (which can be >1 minute).

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
