### PR TITLE
fix(ci): print mise version after installing

### DIFF
--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -23,11 +23,15 @@ ensure_mise_installed() {
       export MISE_INSTALL_PATH=/usr/local/bin/mise
     fi
 
-    info "Installing mise to ${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"
+    local mise_bin="${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"
+
+    info "Installing mise to $mise_bin"
 
     install_mise
 
     unset MISE_INSTALL_PATH
+
+    "$mise_bin" --version
 
     local mise_manages_tool_versions="${ALLOW_MISE_TO_MANAGE_TOOL_VERSIONS:-}"
 


### PR DESCRIPTION
## What this PR does / why we need it

This is largely for debugging in the event that there's an issue with using `mise`.

## Jira ID

[DT-4850]

## Notes for reviewers

We're only printing versions if `mise` needs to be installed, because if it doesn't need to be installed, it's usually in a Docker container that can be queried. If we want to change that in the future, that's fine.

[DT-4850]: https://outreach-io.atlassian.net/browse/DT-4850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ