### PR TITLE
fix: use mise for mage execution

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -16,7 +16,7 @@ APP                 ?= unset
 ORG                 ?= getoutreach
 
 # Transition
-MAGE_CMD            := ASDF_MAGE_VERSION=$(shell cat "$(BOOTSTRAP_DIR)/.tool-versions" | grep mage | awk '{ print $$2 }') MAGEFILE_HASHFAST=true mage -d "$(CURDIR)/$(shell if [[ "$(APP)" != "devbase" ]]; then echo ".bootstrap/"; fi)root" -w "$(CURDIR)"
+MAGE_CMD            := MAGEFILE_HASHFAST=true mise exec mage@$(shell cat "$(BOOTSTRAP_DIR)/.tool-versions" | grep mage | awk '{ print $$2 }') -- mage -d "$(CURDIR)/$(shell if [[ "$(APP)" != "devbase" ]]; then echo ".bootstrap/"; fi)root" -w "$(CURDIR)"
 APP_VERSION         := $(shell mise run --quiet version)
 
 # go options


### PR DESCRIPTION
## What this PR does / why we need it

Updates the existing asdf version logic to instead use mise exec.

This might cause issues if `mise` isn't available on everyone's
machines already, or if `mise` isn't being used to install
versions. I can make this switch based on `command -v asdf`
instead, just didn't want to do that hacky stuff upfront...

Context: Couldn't get `localizer` to build without this :'(

## Jira ID

🙈