### PR TITLE
fix(tasks): remove sources for orb:build

### DIFF
--- a/.mise/tasks/orb/build
+++ b/.mise/tasks/orb/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Build the CircleCI orb."
-#MISE sources=["{{ get_env(name="CIRCLECI_ORB_PATH")}}/**/*"]
+#MISE sources=["{{ get_env(name='CIRCLECI_ORB_PATH') }}/**/*"]
 #MISE outputs=["orb.yml"]
 
 set -euo pipefail

--- a/.mise/tasks/orb/build
+++ b/.mise/tasks/orb/build
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #MISE description="Build the CircleCI orb."
-#MISE sources=["{{ get_env(name='CIRCLECI_ORB_PATH') }}/**/*"]
 #MISE outputs=["orb.yml"]
 
 set -euo pipefail

--- a/scripts/test.include.sh
+++ b/scripts/test.include.sh
@@ -11,4 +11,4 @@ if ! command -v circleci &>/dev/null; then
   echo "Hint: brew install circleci" >&2
   exit 1
 fi
-MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none mise run orb:validate || exit 1
+MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none mise --verbose run orb:validate || exit 1


### PR DESCRIPTION
## What this PR does / why we need it

First it was a nested quotes problem. Not sure why this didn't show up earlier. Then it appears to be a chicken-and-egg problem with the declared env. The amount of effort isn't worth declaring `sources` for the task.