### PR TITLE
feat: support forked PRs for OSS repositories

### DIFF
--- a/orbs/shared/executors/oss-docker.yml
+++ b/orbs/shared/executors/oss-docker.yml
@@ -1,0 +1,17 @@
+description: Standard executor for Docker based runtimes
+parameters:
+  docker_tag:
+    type: string
+    default: stable
+  docker_image:
+    type: string
+    default: $DOCKER_PULL_REGISTRY_URL/bootstrap/ci-slim
+docker:
+  - image: << parameters.docker_image >>:<< parameters.docker_tag >>
+    auth:
+      username: _json_key
+      password: $GCLOUD_SERVICE_ACCOUNT
+environment:
+  TEST_RESULTS: /tmp/test-results
+  GOPRIVATE: github.com/getoutreach/*
+  GOPROXY: https://proxy.golang.org

--- a/orbs/shared/executors/oss-docker.yml
+++ b/orbs/shared/executors/oss-docker.yml
@@ -1,16 +1,13 @@
-description: Standard executor for Docker based runtimes
+description: Executor for Docker based runtimes in OSS repositories
 parameters:
   docker_tag:
     type: string
     default: stable
   docker_image:
     type: string
-    default: $DOCKER_PULL_REGISTRY_URL/bootstrap/ci-slim
+    default: ghcr.io/getoutreach/bootstrap/ci-oss
 docker:
   - image: << parameters.docker_image >>:<< parameters.docker_tag >>
-    auth:
-      username: _json_key
-      password: $GCLOUD_SERVICE_ACCOUNT
 environment:
   TEST_RESULTS: /tmp/test-results
   GOPRIVATE: github.com/getoutreach/*

--- a/orbs/shared/jobs/pre-release.yaml
+++ b/orbs/shared/jobs/pre-release.yaml
@@ -23,7 +23,7 @@ parameters:
   executor_name:
     description: The executor to use for the job
     type: enum
-    enum: [testbed-docker, testbed-docker-aws]
+    enum: [oss-docker, testbed-docker, testbed-docker-aws]
     default: "testbed-docker-aws"
   docker_image:
     description: The docker image to use for running the test

--- a/orbs/shared/jobs/test.yaml
+++ b/orbs/shared/jobs/test.yaml
@@ -34,7 +34,7 @@ parameters:
   executor_name:
     description: The executor to use for the job
     type: enum
-    enum: [testbed-docker, testbed-docker-aws]
+    enum: [oss-docker, testbed-docker, testbed-docker-aws]
     default: "testbed-docker-aws"
   aws_region:
     description: AWS_REGION environment variable to set

--- a/shell/ci/release/dryrun.sh
+++ b/shell/ci/release/dryrun.sh
@@ -8,6 +8,9 @@ LIB_DIR="${DIR}/../../lib"
 # shellcheck source=../../lib/github.sh
 source "${LIB_DIR}/github.sh"
 
+# shellcheck source=../../lib/logging.sh
+source "${LIB_DIR}/logging.sh"
+
 # Setup git user name / email only in CI
 if [[ -n $CI ]]; then
   git config --global user.name "Devbase CI"
@@ -43,9 +46,15 @@ git checkout "$CIRCLE_BRANCH"
 if ! git diff --quiet "$OLD_CIRCLE_BRANCH"; then
   git merge --squash "$OLD_CIRCLE_BRANCH"
   git commit -m "$COMMIT_MESSAGE"
-  GH_TOKEN="$(github_token)"
-  if [[ -z $GH_TOKEN ]]; then
-    echo "Failed to read Github personal access token" >&2
+
+  if [[ -n $CIRCLE_PR_REPONAME ]]; then
+    # We are in a fork, there is no GitHub token
+    warn "No GitHub token found, this is a fork PR"
+  else
+    GH_TOKEN="$(github_token)"
+    if [[ -z $GH_TOKEN ]]; then
+      warn "Failed to read Github personal access token" >&2
+    fi
   fi
 
   GH_TOKEN="$GH_TOKEN" yarn --frozen-lockfile semantic-release --dry-run


### PR DESCRIPTION
## What this PR does / why we need it

* Disables service authentication when a forked PR is detected, since no secrets are available with forked PRs
* Adds an OSS Docker executor, defaulting to a public GHCR image
* Allow the `test` and `pre-release` orb jobs to use the new executor

## Jira ID

[DT-4869]

## Notes for reviewers

A follow-up PR will be needed to enable it for this repo, once the associated `stencil-circleci` PR is merged and in a release candidate.

[DT-4869]: https://outreach-io.atlassian.net/browse/DT-4869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ