### PR TITLE
fix(authn): modular support for GHCR auth

### DIFF
--- a/shell/ci/auth/github_packages.sh
+++ b/shell/ci/auth/github_packages.sh
@@ -9,6 +9,9 @@ source "${LIB_DIR}/bootstrap.sh"
 # shellcheck source=../../lib/github.sh
 source "${LIB_DIR}/github.sh"
 
+# shellcheck source=../../lib/docker/authn/ghcr.sh
+source "${LIB_DIR}/docker/authn/ghcr.sh"
+
 bootstrap_github_token --env-prefix GHACCESSTOKEN_PAT
 
 # Allow setting for using static auth
@@ -56,4 +59,4 @@ if command -v npm >/dev/null 2>&1; then
 EOF
 fi
 
-echo "$GITHUB_TOKEN" | docker login ghcr.io --username="$ORG" --password-stdin
+ghcr_auth "$ORG"

--- a/shell/ci/release/docker-authn.sh
+++ b/shell/ci/release/docker-authn.sh
@@ -55,11 +55,17 @@ download_box
 # shellcheck source=../../lib/docker.sh
 source "${LIB_DIR}/docker.sh"
 
+# shellcheck source=../../lib/github.sh
+source "${LIB_DIR}/github.sh"
+
 # shellcheck source=../../lib/docker/authn/aws-ecr.sh
 source "${DOCKER_AUTH_DIR}/aws-ecr.sh"
 
 # shellcheck source=../../lib/docker/authn/gcr.sh
 source "${DOCKER_AUTH_DIR}/gcr.sh"
+
+# shellcheck source=../../lib/docker/authn/ghcr.sh
+source "${DOCKER_AUTH_DIR}/ghcr.sh"
 
 pullRegistry="${DOCKER_PULL_REGISTRY:-$(get_docker_pull_registry)}"
 pushRegistries="${DOCKER_PUSH_REGISTRIES:-$(get_docker_push_registries)}"
@@ -76,6 +82,13 @@ for crURL in $registries; do
     ;;
   *.amazonaws.com | *.amazonaws.com/*)
     ecr_auth "$crURL"
+    ;;
+  ghcr.io/*)
+    info_sub "🔓 GHCR ($crURL)"
+    # shellcheck disable=SC2119
+    # Why: no extra args needed to pass to ghaccesstoken in this case.
+    bootstrap_github_token
+    ghcr_auth "$(get_box_field org)"
     ;;
   *)
     warn "No authentication script found for registry: $crURL"

--- a/shell/lib/docker/authn/ghcr.sh
+++ b/shell/lib/docker/authn/ghcr.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# GHCR (GitHub Container Registry) authentication.
+
+set -eo pipefail
+
+# ghcr_auth(org)
+# Assumes that GITHUB_TOKEN has been set already.
+ghcr_auth() {
+  local org="$1"
+
+  echo "$GITHUB_TOKEN" |
+    docker login ghcr.io --username="$org" --password-stdin
+}

--- a/shell/lib/docker/authn/ghcr.sh
+++ b/shell/lib/docker/authn/ghcr.sh
@@ -5,7 +5,8 @@
 set -eo pipefail
 
 # ghcr_auth(org)
-# Assumes that GITHUB_TOKEN has been set already.
+# Assumes that GITHUB_TOKEN has been set already, usually via
+# bootstrap_github_token from `shell/lib/github.sh`.
 ghcr_auth() {
   local org="$1"
 


### PR DESCRIPTION
## What this PR does / why we need it

Needed for publishing containers to GHCR. Previously we only had support for GHCR authn if the full authn flow was followed, there are cases where we want to call Docker authentication separately (the same use case for AWS ECR and GCR).

## Jira ID

[DT-4870]

[DT-4870]: https://outreach-io.atlassian.net/browse/DT-4870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ