### PR TITLE
chore: make pre-release dry run job for forked PRs more obvious

### DIFF
--- a/.github/workflows/release-dryrun.yaml
+++ b/.github/workflows/release-dryrun.yaml
@@ -1,10 +1,10 @@
-name: Release (dry run)
+name: Release (dry run) for forked PRs
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  release-dryrun:
+  release-dryrun-fork:
     runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
     steps:


### PR DESCRIPTION
## What this PR does / why we need it

Reduce the confusion of contributors by clarifying that the GHA workflow is for forked PRs only.