### PR TITLE
feat(orb): upgrade machine image to Ubuntu 24.04

### DIFF
--- a/orbs/shared/executors/testbed-machine.yml
+++ b/orbs/shared/executors/testbed-machine.yml
@@ -1,6 +1,6 @@
 description: Standard executor for machine runtimes
 machine:
-  image: ubuntu-2204:2023.10.1
+  image: ubuntu-2404:2024.11.1
   docker_layer_caching: true
 environment:
   TEST_RESULTS: /tmp/test-results


### PR DESCRIPTION
## What this PR does / why we need it

This affects, among other jobs, container builders and E2E tests. As of the creation of this PR, [`mise@2025.9.13` requires Ubuntu 24.04](https://github.com/jdx/mise/discussions/6343).

It is unclear how supported this CircleCI machine image is given that Ubuntu 24.04 is not listed [here](https://web.archive.org/web/20250916050120/https://circleci.com/docs/reference/configuration-reference/#available-linux-machine-images-cloud), and the image hasn't been updated in almost a year.

<!--

## Jira ID

[XX-XX]

-->