### PR TITLE
test: update bats infrastructure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "scripts/bats/bats"]
-	path = scripts/bats/bats
-	url = https://github.com/bats-core/bats-core.git
 [submodule "scripts/bats/test_helper/bats-support"]
 	path = scripts/bats/test_helper/bats-support
 	url = https://github.com/bats-core/bats-support.git

--- a/mise.lock
+++ b/mise.lock
@@ -1,0 +1,16 @@
+[tools.bats]
+version = "1.12.0"
+backend = "aqua:bats-core/bats-core"
+
+[tools.bats.platforms.linux-x64]
+checksum = "blake3:836a0963444ede10131984991c0f92219c84418b57c242b4ff5bc80d83daa9a3"
+size = 175914
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
+
+[tools.circleci]
+version = "0.1.32638"
+backend = "aqua:CircleCI-Public/circleci-cli"
+
+[tools."npm:prettier"]
+version = "2.8.8"
+backend = "npm:prettier"

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ CIRCLECI_ORB_NAME = "getoutreach/shared"
 circleci = "latest"
 
 ## <<Stencil::Block(customMiseTools)>>
-
+bats = "latest"
 ## <</Stencil::Block>>
 
 ## <<Stencil::Block(extraMise)>>

--- a/scripts/bash-test-runner.sh
+++ b/scripts/bash-test-runner.sh
@@ -35,7 +35,7 @@ if [[ -n $CI ]]; then
   extraArgs+=("--report-formatter" "junit" "--output" "$junitOutputPath")
 fi
 
-BATS_LIB_PATH="$DIR/bats/test_helper" "$DIR/bats/bats/bin/bats" "${extraArgs[@]}" "${test_files[@]}"
+BATS_LIB_PATH="$DIR/bats/test_helper" bats "${extraArgs[@]}" "${test_files[@]}"
 exitCode=$?
 
 # If we're running in CI, move the test-results to the path that gets

--- a/scripts/bash-test-runner.sh
+++ b/scripts/bash-test-runner.sh
@@ -8,19 +8,18 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # CI determines if we're running in CI or not. Defaults to false.
 CI=${CI:-false}
 
-# Check if bats is installed and usable.
-if [[ ! -e "$DIR/bats/bats" ]]; then
-  echo "Initializing bats submodule(s) ..."
-  git submodule update --init --recursive
-fi
-
-# shellcheck source=../shell/lib/shell.sh
-source "$DIR/../shell/lib/shell.sh"
 # shellcheck source=../shell/lib/bootstrap.sh
 source "$DIR/../shell/lib/bootstrap.sh"
+# shellcheck source=../shell/lib/logging.sh
+source "$DIR/../shell/lib/logging.sh"
+# shellcheck source=../shell/lib/shell.sh
+source "$DIR/../shell/lib/shell.sh"
 
-# Make sure that the bats-related submodules exist before running the bats tests.
-git submodule update --init
+# Check if bats is installed and usable.
+if [[ ! -e "$DIR/bats/test_helper/bats-assert" ]]; then
+  info "Initializing bats submodule(s) ..."
+  git submodule update --init --recursive
+fi
 
 # Find all files with _test.sh at the end of the filename
 # and run them

--- a/scripts/bash-test-runner.sh
+++ b/scripts/bash-test-runner.sh
@@ -4,19 +4,20 @@ set -euo pipefail
 
 # DIR is the directory of this script.
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEVBASE_LIB_DIR="$DIR/../shell/lib"
 
 # CI determines if we're running in CI or not. Defaults to false.
 CI=${CI:-false}
 
 # shellcheck source=../shell/lib/bootstrap.sh
-source "$DIR/../shell/lib/bootstrap.sh"
+source "$DEVBASE_LIB_DIR/bootstrap.sh"
 # shellcheck source=../shell/lib/logging.sh
-source "$DIR/../shell/lib/logging.sh"
+source "$DEVBASE_LIB_DIR/logging.sh"
 # shellcheck source=../shell/lib/shell.sh
-source "$DIR/../shell/lib/shell.sh"
+source "$DEVBASE_LIB_DIR/shell.sh"
 
-# Check if bats is installed and usable.
-if [[ ! -e "$DIR/bats/test_helper/bats-assert" ]]; then
+# Check if the bats test helpers are installed and usable.
+if [[ ! -d "$DIR/bats/test_helper/bats-assert" ]]; then
   info "Initializing bats submodule(s) ..."
   git submodule update --init --recursive
 fi

--- a/scripts/bash-test-runner.sh
+++ b/scripts/bash-test-runner.sh
@@ -27,7 +27,7 @@ fi
 mapfile -t test_files < <(find_files_with_extensions "bats")
 
 extraArgs=()
-if [[ -n $CI ]]; then
+if in_ci_environment; then
   # If we're running in CI, we want to output junit test results.
   junitOutputPath="$(get_repo_directory)/bin/junit-test-results"
   mkdir -p "$junitOutputPath"
@@ -40,7 +40,7 @@ exitCode=$?
 
 # If we're running in CI, move the test-results to the path that gets
 # uploaded. See shell/test.sh.
-if [[ -n $CI ]]; then
+if in_ci_environment; then
   mkdir -p /tmp/test-results
   mv "$junitOutputPath/"*.xml /tmp/test-results
 fi

--- a/shell/ci/release/dryrun.sh
+++ b/shell/ci/release/dryrun.sh
@@ -14,13 +14,16 @@ source "${LIB_DIR}/github.sh"
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
 
+# shellcheck source=../../lib/shell.sh
+source "${LIB_DIR}/shell.sh"
+
 if circleci_pr_is_fork; then
   warn "Skipping pre-release (dry run) check, does not run in CircleCI for PR forks"
   exit 0
 fi
 
 # Setup git user name / email only in CI
-if [[ -n $CI ]]; then
+if in_ci_environment; then
   git config --global user.name "Devbase CI"
   git config --global user.email "devbase@outreach.io"
 fi

--- a/shell/ci/release/pre-release-dryrun-gha.sh
+++ b/shell/ci/release/pre-release-dryrun-gha.sh
@@ -12,9 +12,11 @@ LIB_DIR="${DIR}/../../lib"
 source "$DIR/../../lib/bootstrap.sh"
 # shellcheck source=../../lib/logging.sh
 source "${LIB_DIR}/logging.sh"
+# shellcheck source=../../lib/shell.sh
+source "${LIB_DIR}/shell.sh"
 
 # Setup git user name / email only in CI
-if [[ -n $CI ]]; then
+if in_ci_environment; then
   git config --global user.name "Devbase CI"
   git config --global user.email "devbase@outreach.io"
   mise use --global gojq

--- a/shell/ci/testing/setup-devenv.sh
+++ b/shell/ci/testing/setup-devenv.sh
@@ -27,7 +27,7 @@ fi
 
 # CI sets up dependencies in CI and other small adjustments.
 # These are not required on local machines.
-if [[ -n $CI ]]; then
+if in_ci_environment; then
   if [[ -z $VAULT_ROLE_ID ]]; then
     echo "Hint: Outreach CircleCI must be configured to have"
     echo "  vault-dev be added to the list of contexts for this"
@@ -62,11 +62,9 @@ if [[ $PROVISION == "true" ]]; then
     exit 0
   fi
 
-  if [[ -n $CI ]]; then
-    if [[ -z $VAULT_ADDR ]]; then
-      VAULT_ADDR="$(get_box_field devenv.vault.address)"
-      export VAULT_ADDR
-    fi
+  if [[ -z $VAULT_ADDR ]]; then
+    VAULT_ADDR="$(get_box_field devenv.vault.address)"
+    export VAULT_ADDR
   fi
 
   info "Provisioning developer environment"

--- a/shell/devconfig.sh
+++ b/shell/devconfig.sh
@@ -9,17 +9,20 @@ YQ="$DIR/yq.sh"
 # shellcheck source=./lib/bootstrap.sh
 source "$DIR/lib/bootstrap.sh"
 
+# shellcheck source=./lib/box.sh
+source "$DIR/lib/box.sh"
+
+# shellcheck source=./lib/logging.sh
+source "$DIR/lib/logging.sh"
+
+# shellcheck source=./lib/shell.sh
+source "$DIR/lib/shell.sh"
+
 APPNAME="$(get_app_name)"
 
 overridePath="$(get_repo_directory)/scripts/devconfig.override.sh"
 configDir="$HOME/.outreach/$APPNAME"
 volumeDir="${TMPDIR:-/tmp}/$APPNAME"
-
-# shellcheck source=./lib/logging.sh
-source "$DIR/lib/logging.sh"
-
-# shellcheck source=./lib/box.sh
-source "$DIR/lib/box.sh"
 
 mkdir -p "$configDir"
 
@@ -74,7 +77,7 @@ get_vault_secrets() {
   return 0
 }
 
-if [[ -z $CI ]]; then
+if ! in_ci_environment; then
   ensure_logged_into_vault
 fi
 

--- a/shell/docs-build.sh
+++ b/shell/docs-build.sh
@@ -9,6 +9,8 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "$SCRIPTS_DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/logging.sh
 source "$SCRIPTS_DIR/lib/logging.sh"
+# shellcheck source=./lib/shell.sh
+source "$SCRIPTS_DIR/lib/shell.sh"
 
 ROOT_DIR="$(get_repo_directory)"
 API_DIR="$ROOT_DIR/api"
@@ -22,7 +24,7 @@ info_sub "Protobuf"
 
 mkdir -p "$PROTO_DOCS_DIR"
 
-if [[ -n $CI ]]; then
+if in_ci_environment; then
   pushd "$API_DIR" >/dev/null || fatal "Could not change directory to api"
   protoc --doc_out="$PROTO_DOCS_DIR" --doc_opt=html,index.html ./*.proto
   popd >/dev/null || fatal "Could not pop directory out of api"

--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -9,10 +9,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "$DIR/lib/bootstrap.sh"
 # shellcheck source=./lib/asdf.sh
 source "$DIR/lib/asdf.sh"
-
-in_ci_environment() {
-  [[ -n ${CI:-} ]]
-}
+# shellcheck source=./lib/shell.sh
+source "$DIR/lib/shell.sh"
 
 if [[ -z $workspaceFolder ]]; then
   workspaceFolder="$(get_repo_directory)"

--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -78,7 +78,7 @@ install_mise() {
     set +e
     if ! retry 5 5 sh "$install_script"; then
       local distro
-      if [[ -z $CI ]]; then
+      if ! in_ci_environment; then
         fatal "Could not install mise"
       fi
       set -e

--- a/shell/lib/shell.sh
+++ b/shell/lib/shell.sh
@@ -93,7 +93,7 @@ get_time_ms() {
 # is_terminal returns true if the current process is a terminal, with
 # a special case of always being false if CI is true
 is_terminal() {
-  [[ -t 0 ]] && [[ $CI != "true" ]]
+  [[ -t 0 ]] && ! in_ci_environment
 }
 
 # get_cursor_pos returns the current cursor position
@@ -213,4 +213,10 @@ find_files_with_shebang() {
       echo "$file"
     fi
   done | sort | uniq
+}
+
+# in_ci_environment determines whether the script is run in the context
+# of a CI job/workflow.
+in_ci_environment() {
+  [[ -n ${CI:-} ]]
 }

--- a/shell/linters/go.sh
+++ b/shell/linters/go.sh
@@ -18,7 +18,7 @@ go_mod_tidy() {
   #
   # Skip when go.sum doesn't exist, because this causes errors. This can
   # happen when go.mod has no dependencies
-  if [[ -n $CI ]] && [[ -e "go.sum" ]]; then
+  if in_ci_environment && [[ -e "go.sum" ]]; then
     git diff --exit-code go.{mod,sum} || fatal "go.{mod,sum} are out of date, please run 'go mod tidy' and commit the result"
   fi
 }


### PR DESCRIPTION
## What this PR does / why we need it

* Use `mise` to run `bats` instead of embedding a git submodule.
* Update `bats-support` and `bats-assert` libraries. Among other things, this adds the `assert_stderr` command.
* Move `in_ci_environment` into `lib/shell.sh` and replace all `$CI` checks.
* Add `mise.lock` to specify what version of `bats` is currently being used.