### PR TITLE
fix(devspace): trust mise config for the repo and its devbase instance

### DIFF
--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -6,6 +6,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/box.sh
 source "$DIR/lib/box.sh"
 
+mise trust
+
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 
 # SSH -> HTTPS, since we're not using SSH keys

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -6,8 +6,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/box.sh
 source "$DIR/lib/box.sh"
 
-set -x
-
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 
 # SSH -> HTTPS, since we're not using SSH keys

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -6,8 +6,9 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=./lib/box.sh
 source "$DIR/lib/box.sh"
 
+set -x
+
 mise trust
-mise trust --cd .bootstrap
 
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -8,8 +8,6 @@ source "$DIR/lib/box.sh"
 
 set -x
 
-mise trust
-
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 
 # SSH -> HTTPS, since we're not using SSH keys
@@ -48,7 +46,7 @@ fi
 # We actually don't want it to expand, we want it to be a literal string written to the file
 # shellcheck disable=SC2016
 # shellcheck disable=SC2086
-if ! grep -q '. "$HOME/.asdf/asdf.sh"' "$HOME/.bashrc"; then
+if [[ ! -f "$HOME/.bashrc" ]] || ! grep -q '. "$HOME/.asdf/asdf.sh"' "$HOME/.bashrc"; then
   # We actually don't want it to expand, we want it to be a literal string written to the file
   # shellcheck disable=SC2016
   # shellcheck disable=SC2086
@@ -57,6 +55,7 @@ fi
 
 echo "$(tput bold)Ensuring asdf plugins are installed$(tput sgr0)"
 pushd /home/dev/app >/dev/null || exit 1
+mise trust --cd .bootstrap
 ./.bootstrap/root/ensure_asdf.sh
 popd >/dev/null || exit 1
 

--- a/shell/devspace_start.sh
+++ b/shell/devspace_start.sh
@@ -7,6 +7,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "$DIR/lib/box.sh"
 
 mise trust
+mise trust --cd .bootstrap
 
 GH_NO_UPDATE_NOTIFIER=true gh auth setup-git
 


### PR DESCRIPTION
## What this PR does / why we need it

Otherwise, `devspace start` hangs trying to ask the user whether the repo's `mise` config is trusted (and the TTY will not allow any interaction).

Also, fixes an uncaught error if `~/.bashrc` doesn't exist.

## Jira ID

[DT-4899]

[DT-4899]: https://outreach-io.atlassian.net/browse/DT-4899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ