### PR TITLE
fix: buf version to 1.57.2

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -12,7 +12,7 @@ gh: 2.62.0
 gojq: v0.12.17
 
 # protobuf formatters/plugins/tools/etc
-buf: 1.8.0 # formatter
+buf: 1.57.2 # formatter
 protoc-gen-validate: 0.6.7
 protoc-gen-go: 1.5.2
 protoc-gen-doc: 1.5.1


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

I'd like to test out buf in a new service (tombstone), but the existing version of buf is so old it doesn't support the version2 configuration files.

This PR upgrades the buf version.

I am still testing this out, but I think it should be safe since buf still supports v1 yaml schemas.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
