### PR TITLE
docs: clarify the "use a custom build" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ modules:
 ...
 ```
 
-CI will now use that branch, to use it locally re-run any `make` command. **Note**: This will not automatically update locally when the remote branch is changed, in order to do that you will need to `rm -rf .bootstrap` and re-run a `make` command. If you are testing changes to `make e2e`, you must also run
+CI will now use that branch, to use it locally re-run any `make` command.
+
+> [!NOTE]
+> This will not automatically update locally when the remote branch is changed, in order to do that you will need to `rm -rf .bootstrap` and re-run a `make` command. If you are testing changes to `make e2e`, you must also run
 `rm -rf ~/.outreach/.cache/gobin/binaries/$(go version | awk '{ print $3 }' | tr -d 'go')/github.com/getoutreach/devbase` before re-running a make command, in addition to `rm -rf .bootstrap`.
+
+> [!WARNING]
+> If you run `stencil` while using the custom build, your manual changes to `stencil.lock` will be erased and replaced with the `devbase` version specified by `service.yaml`. You will need to restore the branch name manually after `stencil` completes.
 
 ## Building Docker Images
 


### PR DESCRIPTION
## What this PR does / why we need it

* Use GitHub-Flavored Markdown admonitions
* Add a note about running `stencil`