### PR TITLE
fix(ci): cache mise tool installs to reduce GitHub API rate limit usage

### DIFF
--- a/orbs/shared/commands/setup_environment.yml
+++ b/orbs/shared/commands/setup_environment.yml
@@ -37,7 +37,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - v1-daily-cache-{{ arch }}-
+              - v2-daily-cache-{{ arch }}-
   # Adds a github org scoped SSH key to the project added by Wheatley
   - add_ssh_keys
   - when:

--- a/orbs/shared/jobs/save_cache.yaml
+++ b/orbs/shared/jobs/save_cache.yaml
@@ -60,7 +60,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - v1-toggle-daily-cache-{{ arch }}-{{ .Revision }}
+              - v2-toggle-daily-cache-{{ arch }}-{{ .Revision }}
         - run:
             name: Check cache flag
             command: |
@@ -78,13 +78,14 @@ steps:
             name: Run tests
             command: make test
         - save_cache:
-            key: v1-daily-cache-{{ arch }}-{{ epoch }}
+            key: v2-daily-cache-{{ arch }}-{{ epoch }}
             paths:
               - "~/.cache"
               - "~/.asdf"
               - "~/.outreach/.cache"
+              - "~/.local/share/mise"
         - save_cache:
-            key: v1-toggle-daily-cache-{{ arch }}-{{ .Revision }}
+            key: v2-toggle-daily-cache-{{ arch }}-{{ .Revision }}
             paths:
               - "~/cache-toggle"
 


### PR DESCRIPTION
## Summary

- **Add `~/.local/share/mise` to CircleCI `save_cache` paths** so installed mise tool binaries and shims are persisted across builds
- **Bump cache key prefix from `v1` to `v2`** on all daily-cache and toggle-cache keys to force a fresh cache write that includes the new path

## Problem

Every CI run re-installs mise tool binaries because `~/.local/share/mise/` (where installed binaries live) is **not** in the cached paths. Only `~/.cache` (downloaded archives) was cached. Each `mise install` hits `api.github.com/repos/.../releases` for every `github:` backend tool, consuming shared GitHub API rate limits (~18 API URLs per build). With concurrent CI builds across all repos sharing the same 15,000 req/hour token pool, this is the primary driver of rate limit exhaustion causing CI failures and devenv provisioning failures org-wide.

## Fix

| File | Change |
|---|---|
| `orbs/shared/jobs/save_cache.yaml` | Add `~/.local/share/mise` to `save_cache` paths; bump `v1` → `v2` on daily-cache save key (line 81), toggle-cache restore key (line 63), and toggle-cache save key (line 87) |
| `orbs/shared/commands/setup_environment.yml` | Bump `v1` → `v2` on daily-cache restore key (line 40) |

With mise installs cached, subsequent CI runs find tool binaries already installed. `mise install` becomes a no-op for already-installed tools, skipping GitHub API calls entirely.

## Risk Assessment

- **Low risk** — additive change only (one new path in cache list + key prefix bump)
- **No behavioral change** — if cache is empty, mise installs normally as before
- **Rollback** — bump to `v3` to invalidate if needed
- **Cache size** — `~/.local/share/mise` adds ~500MB-1GB; CircleCI supports up to 3GB per cache key

## Rollout

Once merged and released, all repos pick this up automatically when they restencil (devbase version bumps via `stencil.lock` → `.bootstrap/` syncs new orb version).

## Notes

- The `{{ epoch }}` key pattern (existing, not introduced here) means every build writes a new cache entry. CircleCI auto-evicts after 15 days. A future optimization could key off `checksum("mise.toml")-checksum("mise.lock")` instead of epoch to deduplicate cache entries.
- The `v1-node-client-cache-*` keys are unrelated and intentionally left unchanged.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Something went wrong while reviewing this pull request.
[Troubleshoot code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

