### PR TITLE
fix(mise): don't set environment variable if managing .tool-versions

### DIFF
--- a/shell/lib/mise.sh
+++ b/shell/lib/mise.sh
@@ -244,18 +244,17 @@ mise_manages_tool_versions() {
 run_mise() {
   local mise_path
   mise_path="$(find_mise)"
+
   if in_ci_environment && [[ -n ${MISE_GITHUB_TOKEN:-} || -n ${GITHUB_TOKEN:-} ]]; then
     local ghToken="${MISE_GITHUB_TOKEN:-$GITHUB_TOKEN}"
     GITHUB_TOKEN="$ghToken" wait_for_gh_rate_limit
   fi
 
-  local tool_versions_override=""
-  if ! mise_manages_tool_versions; then
-    tool_versions_override="none"
-  fi
-
-  MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES="$tool_versions_override" \
+  if mise_manages_tool_versions; then
     "$mise_path" "$@"
+  else
+    MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES=none "$mise_path" "$@"
+  fi
 }
 
 # If `wait-for-gh-rate-limit` is installed, runs it to wait for


### PR DESCRIPTION
## What this PR does / why we need it

Setting it to an empty variable causes unexpected behavior in CI. In particular, it thinks that "" (empty string) is the filename and thus looks for it until it panics.

## Jira ID

[DT-5283]




[DT-5283]: https://outreach-io.atlassian.net/browse/DT-5283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

