### PR TITLE
fix(orb): upgrade remote docker to v28

### DIFF
--- a/orbs/shared/commands/use_docker.yml
+++ b/orbs/shared/commands/use_docker.yml
@@ -2,4 +2,4 @@ description: Sets up a remote docker image with a standard version being used
 steps:
   - setup_remote_docker:
       docker_layer_caching: true
-      version: docker24
+      version: docker28


### PR DESCRIPTION
## What this PR does / why we need it

This change is for two reasons:

1. This is the [current default for CircleCI](https://discuss.circleci.com/t/upcoming-change-docker-default-switching-to-docker-28-this-monday/54498).
2. With the latest `docker` CLI, it currently fails with the following error:

```
Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.43
```

## Jira ID

[DT-5299]


[DT-5299]: https://outreach-io.atlassian.net/browse/DT-5299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

