### PR TITLE
fix(mise): define aws/vault/wait-for-gh-rate-limit in devbase config

### DIFF
--- a/mise.devbase.lock
+++ b/mise.devbase.lock
@@ -32,6 +32,29 @@ url = "https://github.com/fullstorydev/grpcui/releases/download/v1.3.1/grpcui_1.
 checksum = "sha256:ff666b684f51d146599cc3ff26509284bf1af0206fc6dca1cfe908a0da4819cc"
 url = "https://github.com/fullstorydev/grpcui/releases/download/v1.3.1/grpcui_1.3.1_windows_x86_64.zip"
 
+[[tools.aws-cli]]
+version = "2.34.31"
+backend = "aqua:aws/aws-cli"
+
+[tools.aws-cli."platforms.linux-arm64"]
+url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.34.31.zip"
+
+[tools.aws-cli."platforms.linux-arm64-musl"]
+url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.34.31.zip"
+
+[tools.aws-cli."platforms.linux-x64"]
+checksum = "blake3:72db413f347e7f601d8ff2de1aac0421ad9ede4c74b483ebed93587a42960a9b"
+url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.31.zip"
+
+[tools.aws-cli."platforms.linux-x64-musl"]
+url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.31.zip"
+
+[tools.aws-cli."platforms.macos-arm64"]
+url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.31.pkg"
+
+[tools.aws-cli."platforms.macos-x64"]
+url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.31.pkg"
+
 [[tools.buf]]
 version = "1.60.0"
 backend = "aqua:bufbuild/buf"
@@ -644,3 +667,69 @@ url = "https://github.com/tombi-toml/tombi/releases/download/v0.7.27/tombi-cli-0
 [tools.tombi."platforms.windows-x64"]
 checksum = "sha256:ef9c2ff17a5153cb0ebd9bdce72c979f5e0630c36c2f86fc928fc5010443b65e"
 url = "https://github.com/tombi-toml/tombi/releases/download/v0.7.27/tombi-cli-0.7.27-x86_64-pc-windows-msvc.zip"
+
+[[tools.vault]]
+version = "2.0.0"
+backend = "aqua:hashicorp/vault"
+
+[tools.vault."platforms.linux-arm64"]
+checksum = "sha256:5f04207fd0fbabbb8c6cca494fdee96f81bb0a82e1176670649e1aeeaadf0281"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_linux_arm64.zip"
+
+[tools.vault."platforms.linux-arm64-musl"]
+checksum = "sha256:5f04207fd0fbabbb8c6cca494fdee96f81bb0a82e1176670649e1aeeaadf0281"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_linux_arm64.zip"
+
+[tools.vault."platforms.linux-x64"]
+checksum = "sha256:0367bdd46dd1fff1ff19fc44e60df48866515bb519c80527236b3808ea879ac2"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_linux_amd64.zip"
+
+[tools.vault."platforms.linux-x64-musl"]
+checksum = "sha256:0367bdd46dd1fff1ff19fc44e60df48866515bb519c80527236b3808ea879ac2"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_linux_amd64.zip"
+
+[tools.vault."platforms.macos-arm64"]
+checksum = "sha256:3b8ad2cc6de8b6cc13e030465e83729aec1070ef91327a55be0a28af81a530bf"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_darwin_arm64.zip"
+
+[tools.vault."platforms.macos-x64"]
+checksum = "sha256:4fe88b981fcf14917a5f1b1c1ffaf4f9231c3f646ab778ba44e71dfb80e5b234"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_darwin_amd64.zip"
+
+[tools.vault."platforms.windows-x64"]
+checksum = "sha256:6ba79a7937360f96502dcbca84395b96d4299e770497e342805a3c4dcadb6de2"
+url = "https://releases.hashicorp.com/vault/2.0.0/vault_2.0.0_windows_amd64.zip"
+
+[[tools.wait-for-gh-rate-limit]]
+version = "1.1.1"
+backend = "github:jdx/wait-for-gh-rate-limit"
+
+[tools.wait-for-gh-rate-limit."platforms.linux-arm64"]
+checksum = "sha256:156016c123e3a979c1e648b9c482338ba7cc0552028ba241eda1bcf9cf7e69e8"
+url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588000"
+
+[tools.wait-for-gh-rate-limit."platforms.linux-arm64-musl"]
+checksum = "sha256:156016c123e3a979c1e648b9c482338ba7cc0552028ba241eda1bcf9cf7e69e8"
+url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588000"
+
+[tools.wait-for-gh-rate-limit."platforms.linux-x64"]
+checksum = "sha256:90668d96b9f0485050c281d72797aa1c09e3d75196aca330a1b9fd4426778641"
+url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337587818"
+
+[tools.wait-for-gh-rate-limit."platforms.linux-x64-musl"]
+checksum = "sha256:90668d96b9f0485050c281d72797aa1c09e3d75196aca330a1b9fd4426778641"
+url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337587818"
+
+[tools.wait-for-gh-rate-limit."platforms.macos-arm64"]
+checksum = "sha256:266bb0edf065994b5a4b75c91adbae3e94c042ded1de03c00a1673c68409b77e"
+url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588442"
+
+[tools.wait-for-gh-rate-limit."platforms.windows-x64"]
+checksum = "sha256:1e52ba1857d3918b54c336de32028abf5f03b8e16745413e573e4153ab9a92e2"
+url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588993"

--- a/mise.devbase.toml
+++ b/mise.devbase.toml
@@ -1,4 +1,5 @@
 [tools]
+aws-cli = "2.34.31"
 "aqua:fullstorydev/grpcui" = "1.3.1"
 # For provenance verification
 cosign = "3.0.5"
@@ -11,6 +12,9 @@ goreleaser = "1.20.0"
 gotestsum = "1.13.0"
 mage = "1.14.0"
 "github:getoutreach/ci" = "1.6.14"
+vault = "2.0.0"
+# Work around GitHub token rate limits
+wait-for-gh-rate-limit = "1.1.1"
 # Delibird telemetry
 "github:getoutreach/orc" = "1.124.1"
 # linters

--- a/shell/ci/auth/vault.sh
+++ b/shell/ci/auth/vault.sh
@@ -8,10 +8,16 @@ DEVBASE_LIB_DIR="$DIR/../../lib"
 # shellcheck source=../../lib/box.sh
 source "$DEVBASE_LIB_DIR/box.sh"
 
+# shellcheck source=../../lib/mise.sh
+source "$DEVBASE_LIB_DIR/mise.sh"
+
+# shellcheck source=../../lib/shell.sh
+source "$DEVBASE_LIB_DIR/shell.sh"
+
 if [[ -n $VAULT_ROLE_ID ]] && [[ -n $VAULT_SECRET_ID ]]; then
-  VAULT_ADDR="$(get_box_field devenv.vault.addressCI)" vault write auth/approle/login \
+  VAULT_ADDR="$(get_box_field devenv.vault.addressCI)" "$(find_tool vault)" write auth/approle/login \
     role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID" -format=json |
-    jq .auth.client_token -r >"$HOME/.vault-token"
+    "$(find_tool gojq)" --raw-output .auth.client_token >"$HOME/.vault-token"
 else
   echo "Skipped: VAULT_ROLE_ID or VAULT_SECRET_ID is not set."
 fi

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -64,6 +64,6 @@ install_tool_with_mise uv
 mise config set settings.pipx.uvx true
 install_tool_with_mise pipx:yq
 
-if [[ ! -e /opt/vault ]]; then
+if [[ -e /opt/vault ]]; then
   sudo rm -rf /opt/vault
 fi

--- a/shell/circleci/machine.sh
+++ b/shell/circleci/machine.sh
@@ -64,16 +64,6 @@ install_tool_with_mise uv
 mise config set settings.pipx.uvx true
 install_tool_with_mise pipx:yq
 
-if ! command -v vault >/dev/null 2>&1; then
-  install_tool_with_mise vault
+if [[ ! -e /opt/vault ]]; then
   sudo rm -rf /opt/vault
 fi
-
-# install AWS CLI
-
-if ! command -v aws >/dev/null; then
-  install_tool_with_mise aws-cli
-fi
-
-# Tiny app to work around GitHub token rate limits
-install_tool_with_mise wait-for-gh-rate-limit


### PR DESCRIPTION
## What this PR does / why we need it

This should resolve the issues in the latest CI image where the `mise` shim can't find the tool for some reason even though it was installed globally.

## Jira ID

[DT-5283]

[DT-5283]: https://outreach-io.atlassian.net/browse/DT-5283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

