### PR TITLE
fix: save cache mozart pipe - wait for password from AWS ECR

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -18,6 +18,7 @@ url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
 url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
 
 [tools.bats."platforms.macos-arm64"]
+checksum = "blake3:d34af9fd0f9101d5309b2de31f3d1699e56a574d7d4b5e6380580a9e758a9744"
 url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
 
 [tools.bats."platforms.macos-x64"]

--- a/shell/lib/docker/authn/aws-ecr.sh
+++ b/shell/lib/docker/authn/aws-ecr.sh
@@ -16,7 +16,7 @@ ecr_auth() {
   # See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token
   # Capture the password first to avoid pipe stdin issues in non-TTY CI environments.
   ecr_password="$(aws ecr get-login-password --region "$region")"
-  docker login --username AWS --password-stdin "$registry" <<< "$ecr_password"
+  docker login --username AWS --password-stdin "$registry" <<<"$ecr_password"
 }
 
 # ensure_ecr_repository ensures that an ECR repository exists.

--- a/shell/lib/docker/authn/aws-ecr.sh
+++ b/shell/lib/docker/authn/aws-ecr.sh
@@ -14,7 +14,9 @@ ecr_auth() {
   region="$(echo "$registry" | cut -d. -f4)"
   info_sub "Authenticating with AWS ECR in $registry"
   # See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token
-  aws ecr get-login-password --region "$region" | docker login --username AWS --password-stdin "$registry"
+  # Capture the password first to avoid pipe stdin issues in non-TTY CI environments.
+  ecr_password="$(aws ecr get-login-password --region "$region")"
+  docker login --username AWS --password-stdin "$registry" <<< "$ecr_password"
 }
 
 # ensure_ecr_repository ensures that an ECR repository exists.


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Multiple CircleCI pipelines' runs for mozart's `rebuild-cache` job have failed due to an authentication problem. AI identified the problem as being caused by `docker login ...` command waiting too long for password from pipe.

[AI generated]

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-5300](https://outreach-io.atlassian.net/browse/DT-5300)

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-5300]: https://outreach-io.atlassian.net/browse/DT-5300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

