### PR TITLE
fix(orb): add resource_class for save_e2e_cache

### DIFF
--- a/orbs/shared/jobs/save_e2e_cache.yaml
+++ b/orbs/shared/jobs/save_e2e_cache.yaml
@@ -18,6 +18,10 @@ parameters:
     description: Unused, needed so that it can be run with *rebuild-cache workflows
     type: string
     default: ""
+  resource_class:
+    description: The resource class to use for the release
+    type: string
+    default: "large"
   docker_image:
     description: Unused, needed so that it can be run with *rebuild-cache workflows
     type: string
@@ -31,6 +35,7 @@ parameters:
     type: string
     default: ""
 
+resource_class: << parameters.resource_class >>
 executor:
   name: testbed-machine
 

--- a/orbs/shared/jobs/save_e2e_cache.yaml
+++ b/orbs/shared/jobs/save_e2e_cache.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
     default: ""
   resource_class:
-    description: The resource class to use for the release
+    description: Unused, needed so that it can be run with *rebuild-cache workflows
     type: string
     default: "large"
   docker_image:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

- added `resource_class` to fix compatibility with save_cache

Error: https://app.circleci.com/pipelines/gh/getoutreach/gearbox/12718
```
Error calling workflow: 'rebuild-cache'
Error calling job: 'shared/save_e2e_cache'
Unexpected argument(s): resource_class
```

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

Discussed at 
https://outreach-hq.slack.com/archives/CN9MU7GLW/p1777580330430999


<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

