### PR TITLE
fix(golangci-lint): add path-prefix flag

### DIFF
--- a/shell/golangci-lint.sh
+++ b/shell/golangci-lint.sh
@@ -89,6 +89,7 @@ if [[ -n $needRunFlags || -n $needConfigFlag ]]; then
     fatal "$errMsg"
   fi
   args+=("--config=${configPath}")
+  args+=("--path-prefix=$(basename "$workspaceFolder")")
 fi
 
 # If GOGC or GOMEMLIMIT aren't set, we attempt to set them to better


### PR DESCRIPTION

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


With this change, linter errors have paths from workspace root rather
than scripts subdir.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->


On 4fda58f2291d0dd22caca57e518596c8e3f3df20

```
part-chunk-index  feature/part-chunk-index ❯ make lint
GOPROXY= GOPRIVATE=github.com/getoutreach/* OUTREACH_ACCOUNTS_BASE_URL=https://accounts.outreach-dev.com SKIP_VALIDATE= SKIP_LINTERS= OSS=false TEST_TAGS=or_test ./scripts/shell-wrapper.sh mise.sh exec -- ./scripts/shell-wrapper.sh linters
.sh
 :: Running linters
    -> shellcheck (.sh,.bash,.bats)
    -> shellcheck (.sh,.bash,.bats) (0.818s)t is mise-managed
    -> shellfmt (.sh,.bash,.bats)
    -> shellfmt (.sh,.bash,.bats) (0.548s)s mise-managed
    -> go mod tidy (.go) (0.576s)
    -> golangci-lint (.go)
internal/blobs/blobs.go:377:21: SA5009: Printf format %s has arg #3 of wrong type github.com/getoutreach/polaroid/internal/polaroids3.Key (staticcheck)
                        URL: fmt.Sprintf("s3-%s://%s/%s",
                                         ^
1 issues:
* staticcheck: 1
    -> golangci-lint (.go) (10.392s)
Error: linter failed to run. Please check the logs, 'make fmt' may help in some cases.
make: *** [lint] Error 1
```

On curent main:

```
part-chunk-index  feature/part-chunk-index ❯ make lint
GOPROXY= GOPRIVATE=github.com/getoutreach/* OUTREACH_ACCOUNTS_BASE_URL=https://accounts.outreach-dev.com SKIP_VALIDATE= SKIP_LINTERS= OSS=false TEST_TAGS=or_test ./scripts/shell-wrapper.sh mise.sh exec -- ./scripts/shell-wrapper.sh linters.sh
 :: Running linters
    -> shellcheck (.sh,.bash,.bats)
    -> shellcheck (.sh,.bash,.bats) (1.113s)t is mise-managed
    -> shellfmt (.sh,.bash,.bats)
    -> shellfmt (.sh,.bash,.bats) (0.893s)s mise-managed
    -> go mod tidy (.go) (0.595s)
    -> golangci-lint (.go)
../internal/blobs/blobs.go:377:21: SA5009: Printf format %s has arg #3 of wrong type github.com/getoutreach/polaroid/internal/polaroids3.Key (staticcheck)
                        URL: fmt.Sprintf("s3-%s://%s/%s",
                                         ^
1 issues:
* staticcheck: 1
    -> golangci-lint (.go) (4.277s)
Error: linter failed to run. Please check the logs, 'make fmt' may help in some cases.
make: *** [lint] Error 1
```

<!-- <</Stencil::Block>> -->




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

