### PR TITLE
feat(e2e): add scripts/devenv/pre-e2e-deploy.sh hook

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -413,6 +413,19 @@ func main() { //nolint:funlen,gocyclo // Why: there are no reusable parts to ext
 		}(&wg)
 	}
 
+	// If the pre-deploy script for e2e exists, run it. This runs after provision
+	// and devconfig but before the main `devenv apps deploy --with-deps .` so the
+	// service has a hook to set up any prerequisite cluster state (e.g. CRDs that
+	// must be applied + Ready before the app pods can start) that isn't expressible
+	// via the devenv.yaml `dependencies.required` list.
+	if _, err := os.Stat("scripts/devenv/pre-e2e-deploy.sh"); err == nil {
+		log.Info().Msg("Running scripts/devenv/pre-e2e-deploy.sh")
+
+		if err := osStdInOutErr(exec.CommandContext(ctx, "scripts/devenv/pre-e2e-deploy.sh")).Run(); err != nil {
+			log.Fatal().Err(err).Msg("Failed to run scripts/devenv/pre-e2e-deploy.sh")
+		}
+	}
+
 	if dc.Service {
 		log.Info().Msg("Deploying current application into cluster")
 		if err := runDevenvPassthrough(ctx, "apps", "deploy", "--with-deps", "."); err != nil {


### PR DESCRIPTION
Two related additive changes to support a `provision_target: base` e2e flow for services that need DPO-provisioned databases (motivating case: getoutreach/kaiafrontdoor — see PoC PR).

## 1. `scripts/devenv/pre-e2e-deploy.sh` hook (`e2e/e2e.go`, +13 lines)

Symmetric counterpart to the existing `post-e2e-deploy.sh` hook. Runs after provision + devconfig but **before** the main `devenv apps deploy --with-deps .` call.

```diff
@@ e2e/e2e.go @@
+	if _, err := os.Stat("scripts/devenv/pre-e2e-deploy.sh"); err == nil {
+		log.Info().Msg("Running scripts/devenv/pre-e2e-deploy.sh")
+
+		if err := osStdInOutErr(exec.CommandContext(ctx, "scripts/devenv/pre-e2e-deploy.sh")).Run(); err != nil {
+			log.Fatal().Err(err).Msg("Failed to run scripts/devenv/pre-e2e-deploy.sh")
+		}
+	}
+
 	if dc.Service {
 		log.Info().Msg("Deploying current application into cluster")
 		if err := runDevenvPassthrough(ctx, "apps", "deploy", "--with-deps", "."); err != nil {
```

No flag, no opt-in — file presence is the trigger. Services that don't need it pay nothing.

**Motivation:** services using `provision_target: base` (cheap snapshot) need a place to set up prerequisite state — e.g. apply a Database CRD and wait for `database-provisioning-operator` to provision it — before the main deploy starts its destructive pod-readiness watcher. The existing `post-e2e-deploy.sh` runs too late.

**Expected impact at kaiafrontdoor:** snapshot restore drops from ~13m30s (flagship) to ~5-6m (base). PoC measured the restore delta in CI; full green-run timing pending.

## 2. `SKIP_TOOLS` opt-out for asdf installs (`shell/lib/asdf.sh` + `orbs/shared/jobs/e2e.yaml`)

`ensure_asdf.sh` installs every entry in `.tool-versions` unconditionally, including release-only tools like `ruby` (used only by `.releaserc.yaml`'s semantic-release gem-publish step; nothing in normal build/test/e2e/lint paths consumes it).

The setup_environment cache (`~/.asdf`) is restored from a `v1-daily-cache-{{ arch }}-` key written by the daily save_cache job that runs on the `testbed-docker-aws` executor — but the e2e job's `testbed-machine` executor has a different `{{ arch }}` value, so the cache **never** hits for e2e. Result: asdf compiles ruby from source on every e2e run, costing 60-120s.

This adds:
- `SKIP_TOOLS` env var (comma-separated tool names) in `asdf_devbase_ensure` — listed tools are skipped during the install loop
- `skip_tools` parameter on the e2e orb job, defaulting to `"ruby"`

Services that genuinely need ruby in e2e can override the parameter to `""`.

```diff
+  skip_tools:
+    description: Comma-separated list of asdf tools to skip installing.
+    type: string
+    default: "ruby"
 ...
+  SKIP_TOOLS: << parameters.skip_tools >>
```

## Validation

PoC pinned via `stencil.lock` in kaiafrontdoor's e2e branch (`feat/pre-e2e-deploy-hook` is `--branch`-cloned by `scripts/devbase.sh`). Snapshot-restore delta confirmed (5m37s vs 13m30s baseline). Full timing comparison + green run posted once the next iteration completes.

## Risk

Both changes are additive and gated:
- Pre-deploy hook only runs if the file exists.
- SKIP_TOOLS only skips installs if the env var is set; the e2e job default is "ruby" but that can be overridden per-service via the existing CircleCI `<<Stencil::Block(circleE2EExtra)>>` block.

No release-path changes — the release/save_cache job paths still install ruby as today.