### PR TITLE
fix(github): resolve latest release via REST API to avoid flaky GraphQL 401

### DIFF
--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -46,16 +46,24 @@ github_token() {
 }
 
 # Determines the latest release version of a GitHub repository.
+#
+# This uses the REST API rather than `gh release list` because the
+# latter relies on GitHub's GraphQL API, which intermittently returns
+# 401 Unauthorized for some organization repositories.
 latest_github_release_version() {
   local slug="$1"
   local use_pre_releases="$2"
 
-  local gh_args=(--limit 1 --json tagName --jq '.[].tagName' --exclude-drafts)
+  # Filter out drafts, and pre-releases unless they're requested, then
+  # print the tag name of the most recent matching release. Releases are
+  # returned newest-first by the API.
+  local jq_filter='[.[] | select(.draft == false)'
   if [[ $use_pre_releases != "true" ]]; then
-    gh_args+=(--exclude-pre-releases)
+    jq_filter+=' | select(.prerelease == false)'
   fi
+  jq_filter+='] | first | .tag_name // empty'
 
-  run_gh release --repo "$slug" list "${gh_args[@]}"
+  run_gh api "repos/$slug/releases" --jq "$jq_filter"
 }
 
 # install_latest_github_release downloads the latest version of a tool


### PR DESCRIPTION
## What this PR does / why we need it

`latest_github_release_version` used `gh release list`, which calls GitHub's
GraphQL API. That endpoint intermittently returns `401 Unauthorized` for some
organization repositories (~45% failure rate observed locally for
`getoutreach/stencil` over 20 runs), causing `github_test.bats` to fail flakily
in CI when resolving the latest release tag.

This switches the function to the equivalent REST endpoint, which passed all of
the same runs. Draft and pre-release filtering keep the same semantics as
before.

Unblocks #1155 (blocked on a green CI run).

## Jira ID

N/A

## Notes for your reviewers

- Coverage comes from the existing `github_test.bats` integration tests, which
  exercise `latest_github_release_version` end-to-end via
  `install_latest_github_release` against the real GitHub API. They went from
  flaky (401) to consistently passing with this change.
- Other `gh release list` / `gh release create|delete` usages (e.g.
  `shell/protoc.sh`, `shell/ci/release/pre-release.sh`) are intentionally out of
  scope for this CI fix.## What this PR does / why we need it

`latest_github_release_version` used `gh release list`, which calls GitHub's
GraphQL API. That endpoint intermittently returns `401 Unauthorized` for some
organization repositories (~45% failure rate observed locally for
`getoutreach/stencil` over 20 runs), causing `github_test.bats` to fail flakily
in CI when resolving the latest release tag.

This switches the function to the equivalent REST endpoint, which passed all of
the same runs. Draft and pre-release filtering keep the same semantics as
before.

Unblocks #1155 (blocked on a green CI run).

## Notes for your reviewers

- Coverage comes from the existing `github_test.bats` integration tests, which
  exercise `latest_github_release_version` end-to-end via
  `install_latest_github_release` against the real GitHub API. They went from
  flaky (401) to consistently passing with this change.
- Other `gh release list` / `gh release create|delete` usages (e.g.
  `shell/protoc.sh`, `shell/ci/release/pre-release.sh`) are intentionally out of
  scope for this CI fix.

----
:robot: _PR generated by AI_