### PR TITLE
test(github): normalize semver tags in `latest_github_release_version`

### DIFF
--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -85,6 +85,13 @@ install_latest_github_release() {
 
   info "Using $slug:${binary_name} version: ($tag)"
 
+  # Strip a leading `v` (before a digit) so mise receives a normalized version.
+  # mise 2026.6.14+ drops the `v` when installing a pre-release tag but re-adds
+  # it during `mise which`/`mise where`, so the tool resolves as not installed.
+  if [[ $tag =~ ^v[0-9] ]]; then
+    tag="${tag#v}"
+  fi
+
   # Need to export GITHUB_TOKEN so that future calls to `mise`
   # continue to use it for the configured private repos.
   if [[ -z ${GITHUB_TOKEN:-} ]]; then

--- a/shell/lib/github_test.bats
+++ b/shell/lib/github_test.bats
@@ -52,6 +52,7 @@ teardown() {
   assert mise which stencil
 
   run "$(mise which stencil)" --version
+  assert_success
 }
 
 @test "install_latest_github_release should be able to download and install the latest pre-release of a repo" {
@@ -64,5 +65,6 @@ teardown() {
   assert mise which stencil
 
   run "$(mise which stencil)" --version
+  assert_success
   assert_output --regexp "(rc|unstable)"
 }

--- a/shell/lib/github_test.bats
+++ b/shell/lib/github_test.bats
@@ -18,8 +18,11 @@ setup() {
   export MISE_GLOBAL_CONFIG_ROOT="$MISE_CONFIG_DIR"
   export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/global.toml"
   export MISE_OVERRIDE_CONFIG_FILENAMES="global.toml"
-  echo '[tools]' >>"$MISE_GLOBAL_CONFIG_FILE"
-  echo 'github-cli = "latest"' >>"$MISE_GLOBAL_CONFIG_FILE"
+  {
+    echo '[tools]'
+    echo 'github-cli = "latest"'
+    echo 'wait-for-gh-rate-limit = "1.1.1"'
+  } >>"$MISE_GLOBAL_CONFIG_FILE"
 }
 
 teardown() {


### PR DESCRIPTION
## What this PR does / why we need it

`test-macos` fails deterministically when `install_latest_github_release` installs a pre-release tag (stencil). The cause is an upstream mise bug: on mise `2026.6.14+`, installing a GitHub tool with a `v`-prefixed pre-release tag such as `v1.44.0-rc.3` records the install under the `v`-stripped version but leaves a stale `v`-prefixed entry, so `mise which`/`mise where` resolve the requested `v`-form and report the freshly-installed tool as not installed. It affects any `v`-prefixed pre-release GitHub tool resolved through `mise_exec_tool`; stable
`v`-prefixed tags are unaffected.

`latest_github_release_version` now strips a leading `v` (only before a digit) so callers receive a normalized version. `circleci-orb-sync`, its only other consumer, previously relied on the leading `v`; it now normalizes the stencil.lock-sourced version the same way and classifies on the `v`-less form, preserving its existing orb-version output.