### PR TITLE
fix(orb): add stub setup_remote_docker param to save_e2e_cache for compat purposes

### DIFF
--- a/orbs/shared/jobs/save_e2e_cache.yaml
+++ b/orbs/shared/jobs/save_e2e_cache.yaml
@@ -34,6 +34,10 @@ parameters:
     description: Unused, needed so that it can be run with *rebuild-cache workflows
     type: string
     default: ""
+  setup_remote_docker:
+    description: Unused, needed so that it can be run with *rebuild-cache workflows
+    type: boolean
+    default: false
 
 resource_class: << parameters.resource_class >>
 executor:


### PR DESCRIPTION
## What this PR does / why we need it

This fixes an issue with repos which add `setup_remote_docker` to the `test` shared params.