### PR TITLE
feat(circleci): make Docker layer caching configurable

### DIFF
--- a/orbs/shared/commands/setup_docker_auth.yml
+++ b/orbs/shared/commands/setup_docker_auth.yml
@@ -8,6 +8,10 @@ parameters:
     type: string
     description: Space-separated list of container registries to push to.
     default: ""
+  docker_layer_caching:
+    type: boolean
+    description: Whether to enable Docker layer caching for the remote Docker environment.
+    default: true
 steps:
   - add_ssh_keys
   - checkout
@@ -16,7 +20,8 @@ steps:
       command: |
         git submodule sync
         git submodule update --init --recursive
-  - use_docker
+  - use_docker:
+      docker_layer_caching: << parameters.docker_layer_caching >>
   - run:
       name: Authenticate to Docker registries
       command: ./scripts/shell-wrapper.sh ci/release/docker-authn.sh

--- a/orbs/shared/commands/use_docker.yml
+++ b/orbs/shared/commands/use_docker.yml
@@ -1,5 +1,10 @@
 description: Sets up a remote docker image with a standard version being used
+parameters:
+  docker_layer_caching:
+    type: boolean
+    description: Whether to enable Docker layer caching for the remote Docker environment.
+    default: true
 steps:
   - setup_remote_docker:
-      docker_layer_caching: true
+      docker_layer_caching: << parameters.docker_layer_caching >>
       version: docker28

--- a/orbs/shared/executors/testbed-machine.yml
+++ b/orbs/shared/executors/testbed-machine.yml
@@ -1,7 +1,12 @@
 description: Standard executor for machine runtimes
+parameters:
+  docker_layer_caching:
+    type: boolean
+    description: Whether to enable Docker layer caching for the machine executor.
+    default: true
 machine:
   image: ubuntu-2404:current
-  docker_layer_caching: true
+  docker_layer_caching: << parameters.docker_layer_caching >>
 environment:
   TEST_RESULTS: /tmp/test-results
   GOPRIVATE: github.com/getoutreach/*

--- a/orbs/shared/jobs/docker_stitch.yaml
+++ b/orbs/shared/jobs/docker_stitch.yaml
@@ -26,6 +26,7 @@ parameters:
 steps:
   - setup_docker_auth:
       push_registries: << parameters.push_registries >>
+      docker_layer_caching: false
   - stitch_docker_image:
       push_registries: << parameters.push_registries >>
       versioning_scheme: << parameters.versioning_scheme >>

--- a/orbs/shared/jobs/save_e2e_cache.yaml
+++ b/orbs/shared/jobs/save_e2e_cache.yaml
@@ -42,6 +42,7 @@ parameters:
 resource_class: << parameters.resource_class >>
 executor:
   name: testbed-machine
+  docker_layer_caching: false
 
 environment:
   PRE_SETUP_SCRIPT: << parameters.pre_setup_script >>


### PR DESCRIPTION
## Description

# [FG-149]

> **Status:** Draft for Dev Tooling evaluation. This Docker/DLC work is intentionally excluded from the fast-track E2E rollout.

**What:** Makes Docker layer caching configurable in the shared orb and disables it for `docker_stitch` and `save_e2e_cache`, where no reusable Docker image layers are built.

**Why:** The 30-day CircleCI usage export attributed approximately 6.37M credits to DLC. `docker_stitch` and `save_e2e_cache` accounted for approximately 1.97M credits/month combined despite only stitching persisted archives or populating mise and Go caches.

**How:**

- Add a backward-compatible `docker_layer_caching` parameter to `use_docker` and `setup_docker_auth`, defaulting to `true`.
- Parameterize the existing `testbed-machine` executor instead of introducing a duplicate executor.
- Explicitly disable DLC for `docker_stitch` and `save_e2e_cache`.
- Leave rollout, ownership, and any related Docker workflow-policy changes to Dev Tooling review.

---

<details>
<summary>Initial Prompt and Follow ups</summary>

#### Initial Request

Investigate why backend CircleCI services cost substantially more than the client monorepo and identify shared changes capable of drastically reducing organization-wide credit usage.

#### Follow-up Decisions

1. Dev Tooling requested release-producing `feat` semantics.
2. Docker changes should not be part of the first E2E savings release.
3. This PR remains Draft so Dev Tooling can evaluate Docker behavior, ownership, and rollout implications.

</details>

---

<details>
<summary>Architectural Decisions</summary>

**Decision:** Keep DLC enabled by default and expose explicit per-use opt-outs.

**Rationale:** Existing consumers retain current behavior while known non-build jobs can avoid unnecessary DLC charges.

**Impact:** Future shared jobs can make an explicit cost/performance choice without duplicating commands or executors.

**Decision:** Parameterize `testbed-machine` rather than adding a second executor.

**Rationale:** This keeps image and environment configuration centralized and prevents executor drift.

</details>

---

<details>
<summary>Plan</summary>

1. Dev Tooling evaluates Docker and DLC implications.
2. Adjust or split the implementation under DT ownership if needed.
3. Canary an approved RC on representative Docker workloads.
4. Promote and roll out only after DT approval.

</details>

---

## Demo

<!-- To be filled after Dev Tooling evaluation -->

[FG-149]: https://outreach-io.atlassian.net/browse/FG-149
