### PR TITLE
fix: add stencil upgrade to stencil:upgrade

### DIFF
--- a/.mise/tasks/stencil/upgrade
+++ b/.mise/tasks/stencil/upgrade
@@ -4,4 +4,5 @@
 #MISE depends=["devbase:sync"]
 #MISE depends_post=["stencil:post"]
 
+mise upgrade github:getoutreach/stencil@latest
 exec stencil --skip-update


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

When restenciling, I noticed that the binary installed `stencil` and mise-managed `stencil` have different versions due to `stencil:upgrade` does not include upgrade of `stencil`. This PR should fix it.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
