### PR TITLE
fix(stencil): exit early from stencil:post:go-sync if no Go version in .tool-versions

### DIFF
--- a/.mise/tasks/stencil/post/go-sync
+++ b/.mise/tasks/stencil/post/go-sync
@@ -22,6 +22,11 @@ source "$DEVBASE_LIB_DIR"/sed.sh
 
 appDir="$(get_repo_directory)"
 
+if ! grep -q '^golang ' "$appDir/.tool-versions"; then
+  info "No Go version found in $appDir/.tool-versions, skipping"
+  exit 0
+fi
+
 goVersion="$(grep "^golang " "$appDir"/.tool-versions | awk '{print $2}')"
 gomodGoVersion=""
 if [[ -f "$appDir/go.mod" ]]; then


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.