### PR TITLE
test(github): stop the pre-release install test failing after a stable release

### DIFF
--- a/shell/lib/github.sh
+++ b/shell/lib/github.sh
@@ -46,6 +46,11 @@ github_token() {
 }
 
 # Determines the latest release version of a GitHub repository.
+#
+# $1: The slug of the repo to query, e.g. "getoutreach/stencil".
+# $2: Whether to include pre-releases. `gh release list` returns
+#     releases newest-first, so "true" selects the newest release of any
+#     kind, which can be a stable one.
 latest_github_release_version() {
   local slug="$1"
   local use_pre_releases="$2"
@@ -63,10 +68,11 @@ latest_github_release_version() {
 #
 # $1: The slug of the repo to download from. This is the same as the
 #     repo name, e.g. "github/hub".
-# $2: Whether or not to use pre-releases. If "true", will download the
-#     latest pre-release. If "false", or empty, will download the
-#     latest stable release. "Pre-release", for Outreach releasing, is
-#     any release that is not marked stable (e.g., unstable or rc).
+# $2: Whether or not to include pre-releases. If "true", will download
+#     the newest release of any kind, stable or not; see
+#     latest_github_release_version. If "false", or empty, will download
+#     the latest stable release. "Pre-release", for Outreach releasing,
+#     is any release that is not marked stable (e.g., unstable or rc).
 # $3: The name of the binary to extract from the downloaded archive. If
 #     empty, will use the basename of the slug.
 install_latest_github_release() {

--- a/shell/lib/github_test.bats
+++ b/shell/lib/github_test.bats
@@ -23,6 +23,8 @@ setup() {
     echo 'github-cli = "latest"'
     echo 'wait-for-gh-rate-limit = "1.1.1"'
   } >>"$MISE_GLOBAL_CONFIG_FILE"
+
+  setup_command_stubs
 }
 
 teardown() {
@@ -35,11 +37,46 @@ teardown() {
   unset MISE_GLOBAL_CONFIG_ROOT
   unset MISE_GLOBAL_CONFIG_FILE
   unset MISE_OVERRIDE_CONFIG_FILENAMES
+
+  teardown_command_stubs
 }
 
 @test "separate mise install" {
   run mise doctor
   assert_output --partial "config: $MISE_CONFIG_DIR"
+}
+
+@test "latest_github_release_version asks gh to exclude pre-releases when they are not wanted" {
+  stub_command gh "v1.45.0"
+
+  run latest_github_release_version getoutreach/stencil false
+  assert_success
+  assert_output "v1.45.0"
+
+  run stub_argv gh
+  assert_line "getoutreach/stencil"
+  assert_line "--exclude-drafts"
+  assert_line "--exclude-pre-releases"
+}
+
+@test "latest_github_release_version takes the newest release of any kind when pre-releases are wanted" {
+  stub_command gh "v1.45.0"
+
+  run latest_github_release_version getoutreach/stencil true
+  assert_success
+  assert_output "v1.45.0"
+
+  run stub_argv gh
+  assert_line "--exclude-drafts"
+  refute_line "--exclude-pre-releases"
+}
+
+@test "install_latest_github_release fails when there is no release to install" {
+  stub_command gh ""
+
+  run install_latest_github_release getoutreach/stencil false stencil
+  assert_failure
+  assert_output --partial "Failed to determine version for getoutreach/stencil"
 }
 
 @test "install_latest_github_release should be able to download and install the latest release of a repo" {
@@ -59,6 +96,15 @@ teardown() {
   if circleci_pr_is_fork; then
     skip "Skipping test in fork PR, no GitHub token available to utilize gh."
   fi
+
+  # The newest release is the stable one between a release and the next
+  # commit to the repo, so a pre-release is not always available.
+  local tag
+  tag="$(latest_github_release_version getoutreach/stencil true)"
+  if [[ ! $tag =~ (rc|unstable) ]]; then
+    skip "Newest getoutreach/stencil release ($tag) is stable, not a pre-release."
+  fi
+
   install_latest_github_release getoutreach/stencil true stencil
 
   # We expect the stencil binary to be installed in the install dir.

--- a/shell/lib/metrics_test.bats
+++ b/shell/lib/metrics_test.bats
@@ -6,55 +6,19 @@ bats_load_library "bats-assert/load.bash"
 load logging.sh
 load shell.sh
 load metrics.sh
+load test_helper.sh
 
 setup() {
-  STUB_DIR="$(mktemp -d -t metrics-stubs-XXXXXX)"
-  STUB_CALLS_FILE="$STUB_DIR/calls"
-  STUB_OUTPUTS_DIR="$STUB_DIR/outputs"
-  STUB_ARGS_DIR="$STUB_DIR/args"
-  mkdir -p "$STUB_OUTPUTS_DIR" "$STUB_ARGS_DIR"
-  : >"$STUB_CALLS_FILE"
-  export STUB_CALLS_FILE STUB_OUTPUTS_DIR STUB_ARGS_DIR
-  export PATH="$STUB_DIR:$PATH"
+  setup_command_stubs
 }
 
 teardown() {
-  rm -rf "$STUB_DIR"
-  unset STUB_CALLS_FILE STUB_OUTPUTS_DIR STUB_ARGS_DIR
-}
-
-# stub_command NAME OUTPUT [EXIT_CODE]
-#
-# Install an executable stub on PATH that records its invocation to
-# $STUB_CALLS_FILE (one line: "NAME ARGS..."), records its full argv to
-# $STUB_ARGS_DIR/NAME.argv (one arg per line, latest invocation only),
-# prints OUTPUT to stdout, and exits with EXIT_CODE (default 0).
-stub_command() {
-  local name="$1" output="$2" exitCode="${3:-0}"
-  printf '%s' "$output" >"$STUB_OUTPUTS_DIR/$name"
-  printf '%s' "$exitCode" >"$STUB_OUTPUTS_DIR/$name.exit"
-  cat >"$STUB_DIR/$name" <<'EOF'
-#!/usr/bin/env bash
-name="$(basename "$0")"
-echo "$name $*" >>"$STUB_CALLS_FILE"
-printf '%s\n' "$@" >"$STUB_ARGS_DIR/$name.argv"
-cat "$STUB_OUTPUTS_DIR/$name"
-exit "$(cat "$STUB_OUTPUTS_DIR/$name.exit")"
-EOF
-  chmod +x "$STUB_DIR/$name"
-}
-
-assert_stub_not_called() {
-  local name="$1"
-  # `run` swallows grep's non-zero exit when the count is 0, so we can
-  # assert the count directly without an explicit failure-path check.
-  run grep -c "^$name " "$STUB_CALLS_FILE"
-  assert_output "0"
+  teardown_command_stubs
 }
 
 # Extract the argument passed to curl's `--data` flag (the JSON payload).
 curl_payload() {
-  awk '/^--data$/ { getline; print; exit }' "$STUB_ARGS_DIR/curl.argv"
+  stub_argv curl | awk '/^--data$/ { getline; print; exit }'
 }
 
 @test "report_gh_rate_limit_to_datadog fails when tokenType is empty" {
@@ -125,7 +89,7 @@ curl_payload() {
   assert_output "1"
 
   # Verify endpoint and headers.
-  run cat "$STUB_ARGS_DIR/curl.argv"
+  run stub_argv curl
   assert_output --partial "https://api.datadoghq.com/api/v2/series"
   assert_output --partial "DD-API-KEY: fake-key"
   assert_output --partial "Content-Type: application/json"

--- a/shell/lib/test_helper.sh
+++ b/shell/lib/test_helper.sh
@@ -10,3 +10,61 @@ mktempdir() {
   local dir="$tmpdir/$suffix"
   mktemp -d "$dir"
 }
+
+# setup_command_stubs creates the directories that stub_command writes
+# to, and puts the stub directory first on PATH so that stubs shadow the
+# real tools. Call it from `setup()` and teardown_command_stubs from
+# `teardown()`.
+setup_command_stubs() {
+  STUB_DIR="$(mktempdir devbase-stubs-XXXXXX)"
+  STUB_CALLS_FILE="$STUB_DIR/calls"
+  STUB_OUTPUTS_DIR="$STUB_DIR/outputs"
+  STUB_ARGS_DIR="$STUB_DIR/args"
+  mkdir -p "$STUB_OUTPUTS_DIR" "$STUB_ARGS_DIR"
+  : >"$STUB_CALLS_FILE"
+  export STUB_DIR STUB_CALLS_FILE STUB_OUTPUTS_DIR STUB_ARGS_DIR
+  export PATH="$STUB_DIR:$PATH"
+}
+
+# teardown_command_stubs removes the directory that setup_command_stubs
+# created, and unsets the variables that point into it.
+teardown_command_stubs() {
+  rm -rf "$STUB_DIR"
+  unset STUB_DIR STUB_CALLS_FILE STUB_OUTPUTS_DIR STUB_ARGS_DIR
+}
+
+# stub_command NAME OUTPUT [EXIT_CODE]
+#
+# Install an executable stub on PATH that records its invocation to
+# $STUB_CALLS_FILE (one line: "NAME ARGS..."), records its full argv to
+# $STUB_ARGS_DIR/NAME.argv (one arg per line, latest invocation only),
+# prints OUTPUT to stdout, and exits with EXIT_CODE (default 0).
+stub_command() {
+  local name="$1" output="$2" exitCode="${3:-0}"
+  printf '%s' "$output" >"$STUB_OUTPUTS_DIR/$name"
+  printf '%s' "$exitCode" >"$STUB_OUTPUTS_DIR/$name.exit"
+  cat >"$STUB_DIR/$name" <<'EOF'
+#!/usr/bin/env bash
+name="$(basename "$0")"
+echo "$name $*" >>"$STUB_CALLS_FILE"
+printf '%s\n' "$@" >"$STUB_ARGS_DIR/$name.argv"
+cat "$STUB_OUTPUTS_DIR/$name"
+exit "$(cat "$STUB_OUTPUTS_DIR/$name.exit")"
+EOF
+  chmod +x "$STUB_DIR/$name"
+}
+
+# stub_argv NAME prints the arguments of the latest invocation of the
+# named stub, one per line.
+stub_argv() {
+  cat "$STUB_ARGS_DIR/$1.argv"
+}
+
+# assert_stub_not_called NAME asserts that the named stub never ran.
+assert_stub_not_called() {
+  local name="$1"
+  # `run` swallows grep's non-zero exit when the count is 0, so we can
+  # assert the count directly without an explicit failure-path check.
+  run grep -c "^$name " "$STUB_CALLS_FILE"
+  assert_output "0"
+}


### PR DESCRIPTION
## What this PR does / why we need it

`latest_github_release_version` only drops `--exclude-pre-releases` when pre-releases are requested, so it returns the newest release of any kind. Between a stable stencil release and the next commit that re-creates that repo's `unstable` release, the newest release is a stable one, and the test's assertion that the installed version matches `(rc|unstable)` failed.

Cover the flags the function builds with a stubbed `gh`, so that coverage no longer depends on another repo's release state or on the GitHub API rate limit. Skip the live install test while the newest release is stable. Correct the doc comments, which described the stricter behavior the test assumed.

## Notes for your reviewers

The first commit is almost all relocation. `stub_command` and `assert_stub_not_called` move from `metrics_test.bats` to `test_helper.sh` byte-identical, and only `stub_argv` is new.

The skip guard spends one extra `gh release list` call. Reading the tag from the install log would avoid it, but `(rc|unstable)` also matches CI paths such as `/home/circleci/...`.

---
:robot: _Generated by [Claude Code](https://claude.ai/code/session_01NWz3v5hdZRcyB6RLPzDgGZ)_