### PR TITLE
fix: pass BASE_TEST_ENV to the coverage target

### DIFF
--- a/root/Makefile
+++ b/root/Makefile
@@ -130,8 +130,8 @@ test-e2e:: pre-test
 ## coverage:        generate code coverage
 .PHONY: coverage
 coverage:: pre-coverage
-	 WITH_COVERAGE=true GOPROXY=$(GOPROXY) GOPRIVATE=$(GOPRIVATE) ./scripts/shell-wrapper.sh test.sh
-	 go tool cover --html=/tmp/coverage.out
+	$(BASE_TEST_ENV) WITH_COVERAGE=true ./scripts/shell-wrapper.sh test.sh
+	go tool cover --html=/tmp/coverage.out
 
 .PHONY: e2e
 e2e:: pre-e2e


### PR DESCRIPTION
- `coverage` hand-rolled its environment with only `GOPROXY`/`GOPRIVATE`, so `TEST_TAGS` never reached `test.sh`, which defaults it to empty.
- `make coverage` therefore ran untagged while `test` and `test-e2e` did not, dropping any package whose tests reach an `or_test`-gated dependency out of the coverage run.
- `docs/makefile.md` already documents the default as `or_test`.

Why: `searchproxy/internal/searchproxy/server_test.go` excludes itself from coverage builds and cites this gap by name.
